### PR TITLE
add browser metadata to resource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+        "@opentelemetry/opentelemetry-browser-detector": "^0.57.0",
         "@opentelemetry/otlp-exporter-base": "^0.57.0",
         "@opentelemetry/sdk-trace-web": "^1.30.0",
         "@opentelemetry/web-common": "^0.57.0",
@@ -303,6 +304,21 @@
         "@opentelemetry/otlp-transformer": "0.57.0",
         "@opentelemetry/resources": "1.30.0",
         "@opentelemetry/sdk-trace-base": "1.30.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/opentelemetry-browser-detector": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/opentelemetry-browser-detector/-/opentelemetry-browser-detector-0.57.0.tgz",
+      "integrity": "sha512-rz7UPVzNrnLYx0tTYNFJLUD4hTt9B/nQWvpwvwDfiSqbIwpiQBfkRg++DxB7+XXSn1DEmqJ3SmC+sdSqHZ1KLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/resources": "1.30.0"
       },
       "engines": {
         "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+    "@opentelemetry/opentelemetry-browser-detector": "^0.57.0",
     "@opentelemetry/otlp-exporter-base": "^0.57.0",
     "@opentelemetry/sdk-trace-web": "^1.30.0",
     "@opentelemetry/web-common": "^0.57.0",

--- a/src/resources/webSdkResource.ts
+++ b/src/resources/webSdkResource.ts
@@ -1,8 +1,9 @@
-import {Resource} from '@opentelemetry/resources';
+import {Resource, detectResourcesSync} from '@opentelemetry/resources';
 import {ATTR_SERVICE_NAME} from '@opentelemetry/semantic-conventions';
+import {browserDetector} from '@opentelemetry/opentelemetry-browser-detector';
 
 const getWebSDKResource = () => {
-  return new Resource({
+  let resource = new Resource({
     [ATTR_SERVICE_NAME]: 'embrace-web-sdk',
     app_version: '0.0.1',
     app_framework: 2,
@@ -14,6 +15,9 @@ const getWebSDKResource = () => {
     os_version: '10.15.7',
     os_name: 'android',
   });
+  const detectedResources = detectResourcesSync({detectors: [browserDetector]});
+  resource = resource.merge(detectedResources);
+  return resource;
 };
 
 export {getWebSDKResource};


### PR DESCRIPTION
as an initial iteration, We are adding the experimental metadata detected by the otel browser detector adding [these](https://github.com/scheler/opentelemetry-specification/blob/browser-events/specification/resource/semantic_conventions/browser.md) attributes using [this](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts) detector. That detector is quite rudimentary and just reads from https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgentData. We may want to improve it in the future by including something fancier like https://www.npmjs.com/package/ua-parser-js.

this generates a resource payload like this one (running the demo app from my MacBook)

```
{
    "attributes": {
        "service.name": "embrace-web-sdk",
        "telemetry.sdk.language": "webjs",
        "telemetry.sdk.name": "opentelemetry",
        "telemetry.sdk.version": "1.30.0",
        "app_version": "0.0.1",
        "app_framework": 2,
        "bundle_id": "test.bundle.js",
        "environment": "development",
        "sdk_version": "0.0.1",
        "sdk_simple_version": 1,
        "os_type": "android",
        "os_version": "10.15.7",
        "os_name": "android",
        "browser.platform": "macOS",
        "browser.brands": [
            "Google Chrome 131",
            "Chromium 131",
            "Not_A Brand 24"
        ],
        "browser.mobile": false,
        "browser.language": "en-US"
    }
}
```