### PR TITLE
fix-missing-tracer-for-sessions-provider

### DIFF
--- a/src/instrumentations/session/SpanSessionProvider.ts
+++ b/src/instrumentations/session/SpanSessionProvider.ts
@@ -1,10 +1,8 @@
 import {SessionProvider} from '@opentelemetry/web-common';
 import {Span, trace} from '@opentelemetry/api';
 import generateUUID from '../../utils/generateUUID';
-import {KEY_EMB_TYPE, EMB_TYPES} from '../../constants/attributes';
+import {EMB_TYPES, KEY_EMB_TYPE} from '../../constants/attributes';
 import {ATTR_SESSION_ID} from '@opentelemetry/semantic-conventions/incubating';
-
-const tracer = trace.getTracer('embrace-web-sdk-sessions');
 
 class SpanSessionProvider implements SessionProvider {
   private readonly _activeSessionId: string;
@@ -23,6 +21,7 @@ class SpanSessionProvider implements SessionProvider {
   }
 
   startSessionSpan() {
+    const tracer = trace.getTracer('embrace-web-sdk-sessions');
     tracer.startSpan('emb-session');
 
     this._sessionSpan = tracer.startSpan('emb-session');


### PR DESCRIPTION
This was working fine with `vite dev` because the import order of esbuild is not the same es the one for the minified final bundle after `vite build`. The module level line

`src/instrumentations/session/SpanSessionProvider.ts`
```
const tracer = trace.getTracer('embrace-web-sdk-sessions'); 
```

was being executed before 
`demo/embrace-web-sdk-react-demo/src/otel.ts`
```
  logs.setGlobalLoggerProvider(loggerProvider);
```

