### PR TITLE
Migrate exceptions to be error logs

### DIFF
--- a/demo/embrace-web-sdk-react-demo/src/App.tsx
+++ b/demo/embrace-web-sdk-react-demo/src/App.tsx
@@ -3,7 +3,7 @@ import styles from './App.module.css';
 import {Counter, metrics, Span, trace} from '@opentelemetry/api';
 import {logs, SeverityNumber} from '@opentelemetry/api-logs';
 import {useCallback, useState} from 'react';
-import {session} from '@embraceio/embrace-web-sdk';
+import {session} from '@embraceio/embrace-web-sdk'; // some free and open source random API for testing purposes
 // some free and open source random API for testing purposes
 const POKEMON_URL = 'https://pokeapi.co/api/v2/pokemon/1/';
 const tracer = trace.getTracer('embrace-web-sdk-demo-tracer');
@@ -65,13 +65,14 @@ const App = () => {
   }, [counter]);
 
   const handleRecordException = () => {
-    const errorSpan = tracer.startSpan('error-span');
-    errorSpan.recordException({
-      name: 'Error',
-      message: 'This is an error',
-      stack: 'Error: This is an error',
-    });
-    errorSpan.end();
+    const sessionSpan = sessionProvider.getSessionSpan();
+    if (sessionSpan) {
+      sessionSpan.recordException({
+        name: 'Error',
+        message: 'This is an error',
+        stack: 'Error: This is an error',
+      });
+    }
   };
 
   const handleSendLog = () => {
@@ -81,6 +82,17 @@ const App = () => {
       body: 'This is a log',
       attributes: {
         key: 'some value',
+      },
+    });
+  };
+
+  const handleSendErrorLog = () => {
+    logger.emit({
+      severityNumber: SeverityNumber.ERROR,
+      severityText: 'ERROR',
+      body: 'This is a error log',
+      attributes: {
+        key: 'some value for an error log',
       },
     });
   };
@@ -127,6 +139,11 @@ const App = () => {
           onClick={handleSendLog}
           disabled={sessionProvider.getSessionSpan() === null}>
           Send Log
+        </button>
+        <button
+          onClick={handleSendErrorLog}
+          disabled={sessionProvider.getSessionSpan() === null}>
+          Send Error Log
         </button>
         <button
           onClick={handleRecordException}

--- a/src/constants/attributes.ts
+++ b/src/constants/attributes.ts
@@ -1,20 +1,18 @@
-const KEY_EMB_TYPE = 'emb.type';
-const KEY_EMB_STATE = 'emb.state';
+export const KEY_EMB_TYPE = 'emb.type';
+export const KEY_EMB_STATE = 'emb.state';
 // TODO: update once we have the right type
-const KEY_JS_EXCEPTION = 'emb.android.react_native_crash.js_exception';
+export const KEY_JS_EXCEPTION_STACKTRACE = 'emb.stacktrace.rn';
 
-enum EMB_TYPES {
+export enum EMB_TYPES {
   Session = 'ux.session',
   Network = 'perf.network_request',
   // TODO: update once we have the right type
-  Exception = 'sys.android.react_native_crash',
+  SystemLog = 'sys.log',
   // todo update once we support a new type specific to web RUM
   WebViewInfo = 'sys.webview_info',
 }
 
-enum EMB_STATES {
+export enum EMB_STATES {
   Foreground = 'foreground',
   Background = 'background',
 }
-
-export {KEY_EMB_TYPE, KEY_EMB_STATE, EMB_TYPES, EMB_STATES, KEY_JS_EXCEPTION};

--- a/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -11,6 +11,7 @@ import {
   WEB_VITALS_ID_TO_LISTENER,
 } from './constants';
 import {TrackingLevel, WebVitalsInstrumentationArgs} from './types';
+import {withErrorFallback} from '../../../utils/withErrorFallback';
 
 export class WebVitalsInstrumentation extends InstrumentationBase {
   //map of web vitals to gauges to emit to
@@ -81,7 +82,12 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
         };
         Object.entries(metric.attribution).forEach(([key, value]) => {
           highCardinalityAtts[`attribution.${key}`] =
-            typeof value === 'number' ? value : JSON.stringify(value);
+            typeof value === 'number'
+              ? value
+              : withErrorFallback(
+                  JSON.stringify,
+                  'Error: unable to serialize the value as JSON. Likely a js circular structure ',
+                )(value);
         });
         const currentSessionSpan = this._spanSessionProvider.getSessionSpan();
         if (!currentSessionSpan) {

--- a/src/processors/EmbraceSpanEventExceptionToLogProcessor/types.ts
+++ b/src/processors/EmbraceSpanEventExceptionToLogProcessor/types.ts
@@ -1,0 +1,42 @@
+import {TimedEvent} from '@opentelemetry/sdk-trace-web';
+import {Attributes} from '@opentelemetry/api/build/src/common/Attributes';
+import {
+  ATTR_EXCEPTION_MESSAGE,
+  ATTR_EXCEPTION_STACKTRACE,
+  ATTR_EXCEPTION_TYPE,
+} from '@opentelemetry/semantic-conventions';
+import {LogAttributes, LogRecord} from '@opentelemetry/api-logs';
+
+export interface ExceptionEvent extends TimedEvent {
+  attributes: Attributes &
+    (
+      | {
+          // available when the captured exception has a `code` or a `name` property
+          [ATTR_EXCEPTION_TYPE]: string;
+        }
+      | {
+          // available when the captured exception is just a string, or an object including a `message` property
+          [ATTR_EXCEPTION_MESSAGE]: string;
+        }
+      | {
+          // available when the captured exception is an object with a `stack` property
+          [ATTR_EXCEPTION_STACKTRACE]: string;
+        }
+    );
+}
+
+export const isExceptionEvent = (
+  spanEvent: ExceptionEvent | TimedEvent,
+): spanEvent is ExceptionEvent => {
+  return !!(
+    spanEvent.attributes &&
+    (spanEvent.attributes[ATTR_EXCEPTION_TYPE] ||
+      spanEvent.attributes[ATTR_EXCEPTION_MESSAGE] ||
+      spanEvent.attributes[ATTR_EXCEPTION_STACKTRACE])
+  );
+};
+
+export interface EmbraceLogRecord extends LogRecord {
+  time_unix_nano: number;
+  attributes: LogAttributes;
+}

--- a/src/processors/EmbraceSpanEventWebVitalsSpanProcessor/types.ts
+++ b/src/processors/EmbraceSpanEventWebVitalsSpanProcessor/types.ts
@@ -6,7 +6,7 @@ export interface EmbraceSpanEventWebViewInfo extends TimedEvent {
   time_unix_nano: number; // nanoseconds since epoc time
   attributes: Attributes & {
     name: WEB_VITALS_IDS;
-  }; // attributes will always be defined for this type
+  };
 }
 
 export const isWebViewSpanEvent = (

--- a/src/utils/withErrorFallback.ts
+++ b/src/utils/withErrorFallback.ts
@@ -1,0 +1,19 @@
+/**
+ * Wraps a callback in a try-catch and returns a default value upon failure
+ */
+export const withErrorFallback =
+  <Args extends U[], R, U>(
+    fn: (...args: Args) => R,
+    defaultValue: R,
+    silent = true,
+  ) =>
+  (...args: Args) => {
+    try {
+      return fn(...args);
+    } catch (e) {
+      if (!silent) {
+        console.error(e);
+      }
+      return defaultValue;
+    }
+  };


### PR DESCRIPTION
The previous implementation logged exceptions as the old concept of exceptions, which closes the session and doesn't allow us to show any more events after that in a timeline. In web, exceptions are just error logs, so migrating to that to get continuos sessions in the timeline 

![image](https://github.com/user-attachments/assets/5451d460-5703-4698-9c81-19fd3d86b103)
