### PR TITLE
remove source maps from published code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embraceio/embrace-web-sdk",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Embrace Web SDK",
   "type": "module",
   "main": "build/src/index.js",
@@ -19,13 +19,10 @@
   },
   "files": [
     "build/esm/**/*.js",
-    "build/esm/**/*.js.map",
     "build/esm/**/*.d.ts",
     "build/esnext/**/*.js",
-    "build/esnext/**/*.js.map",
     "build/esnext/**/*.d.ts",
     "build/src/**/*.js",
-    "build/src/**/*.js.map",
     "build/src/**/*.d.ts",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
our published code was including source maps files by mistake. Now the published versions exclude that.

Before: https://origin-repo.embrace.io/#browse/browse:web-testing:%40embraceio%2Fembrace-web-sdk%2Fembrace-web-sdk-0.0.7.tgz 

After: https://origin-repo.embrace.io/#browse/browse:web-testing:%40embraceio%2Fembrace-web-sdk%2Fembrace-web-sdk-0.0.8.tgz 

The size of the package was reduced to almost half