### PR TITLE
remove dependency for users of the cli to import json files

### DIFF
--- a/cli/src/constants.ts
+++ b/cli/src/constants.ts
@@ -1,20 +1,6 @@
-import packageInfo from '../package.json';
-
-export const CLI_VERSION = packageInfo.version;
-if (!CLI_VERSION) {
-  throw new Error('unable to determine the current CLI version');
-}
-
-export const CLI_NAME = packageInfo.name;
-if (!CLI_NAME) {
-  throw new Error('unable to determine the CLI name');
-}
-
-export const CLI_DESCRIPTION = packageInfo.description;
-if (!CLI_DESCRIPTION) {
-  throw new Error('unable to determine the CLI description');
-}
-
+export const CLI_VERSION = '0.0.3';
+export const CLI_NAME = '@embraceio/sourcemaps-uploader';
+export const CLI_DESCRIPTION = 'Embrace Web SDK Source Uploader';
 export const DEFAULT_FILE_ENCODING = 'utf8';
 export const SOURCE_MAP_UPLOAD_HOST = 'https://dsym-store.emb-api.com';
 export const SOURCE_MAP_UPLOAD_PATH = '/v2/store/';

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -6,7 +6,6 @@
     "moduleResolution": "node16",
     "declaration": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
     "strict": true


### PR DESCRIPTION
I realized that importing fields directly from our package.json has a major disadvantage: it means importing from a json file into javascript. While this doesn't represent a problem for us, it will definitely represent an issue for any user of our CLI tool, as it will condition our users to support json imports in their current setup. 

Some examples: 
 * If a client is using typescript to compile, we force them to use `"resolveJsonModule": true,` 
 * if a client is using any node base environment (like VITE) to compile the app, we force them to run node with `--experimental-json-modules` or to transpile our cli tool to import the json file like `import packageInfo from '../package.json' assert { type: "json" }` or `import packageInfo from '../package.json' with { type: "json" };` depending on the node version, or typescript target version.

I don't think this complex limitation is worth the value it adds. If any added complexity will be added, then it should be on our side, and not on our users. For now, I am just inlining the constants we were importing, but I am sure this will mean we will eventually forget to keep them up to date. An alternative (adding complexity for us but keeping it simple for our users) would be going back to the post processing of env variables to replace this inline AFTER typescript compilation has been completed (see https://github.com/embrace-io/embrace-web-sdk/pull/29#discussion_r1953364408 and https://github.com/embrace-io/embrace-web-sdk/pull/29/commits/2e8bec3403dfdf355f9f6acc89687124e7a8809e) cc @jpmunz I would like to hear your opinion here. Is it worth bringing the inline:env:variables back? or you think is it better to just keep the hardcoded values for now? Everything I am hardcoding is just informative, so even if it gets out of date, it won't break any functionality.

Note: I found this because our demo under demo/frontend is facing this, and already not working 😅 