### PR TITLE
update cli tool to use negated flags and add better logging

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -42,21 +42,19 @@ program
   .addOption(
     new Option(
       '-d, --dry-run',
-      'Make a dry run without uploading or saving the replacements. This is the same as using --upload=false and --replaceBundleID=false'
+      'Make a dry run without uploading or saving the replacements. This is the same as using --no-upload and --no-replaceBundleID'
     ).env('EMB_DRY_RUN')
   )
   .addOption(
-    new Option('-u, --upload', 'Turn on uploading source maps to Embrace')
-      .env('EMB_UPLOAD')
-      .default(true)
+    new Option('--no-upload', 'Turn off uploading source maps to Embrace').env(
+      'EMB_NO_UPLOAD'
+    )
   )
   .addOption(
     new Option(
-      '-r, --replaceBundleID',
-      'Turn on editing the original source bundle and map files to include the bundle ID'
-    )
-      .env('EMB_REPLACE_BUNDLE_ID')
-      .default(true)
+      '--no-replaceBundleID',
+      'Turn off editing the original source bundle and map files to include the bundle ID'
+    ).env('EMB_NO_REPLACE_BUNDLE_ID')
   )
   .addOption(
     new Option(
@@ -134,7 +132,7 @@ program
       cliVersion,
       dryRun,
       upload,
-      replaceBundleId,
+      replaceBundleID,
       encoding,
     } = options; // Destructure the options
     await processSourceFiles({
@@ -150,7 +148,7 @@ program
       fileEncoding: encoding,
       dryRun,
       upload,
-      replaceBundleID: replaceBundleId, // commander processes it as replaceBundleId instead of replaceBundleID, ergo the rename
+      replaceBundleID,
     });
   });
 

--- a/cli/src/processSourceFiles.ts
+++ b/cli/src/processSourceFiles.ts
@@ -67,6 +67,11 @@ export async function processSourceFiles({
       console.error('Template bundle ID not found in the source code');
       process.exit(1); // Exit with error code
     }
+    console.log(
+      replaceBundleID && !dryRun
+        ? 'Replacing the template bundle ID with the generated bundle ID'
+        : 'Dry run mode, not replacing the template bundle ID'
+    );
     // write the updated source code back to the file
     if (!dryRun && replaceBundleID) {
       fs.writeFileSync(jsFilePath, newJsContent, fileEncoding);

--- a/cli/src/uploadToApi.ts
+++ b/cli/src/uploadToApi.ts
@@ -42,6 +42,9 @@ export async function uploadToApi({
   formData.append('app', appID);
   formData.append('token', token);
   formData.append('file', body);
+  console.log(
+    upload && !dryRun ? 'Uploading to Embrace API' : 'Dry run, skipping upload'
+  );
   if (dryRun || !upload) {
     return;
   }

--- a/demo/frontend/scripts/runDemo.sh
+++ b/demo/frontend/scripts/runDemo.sh
@@ -24,8 +24,8 @@ npm run demo:frontend:compile
 bundle_path=$(find ./dist/assets -name "index*.js")
 source_map_path=$(find ./dist/assets -name "index*.js.map")
 # process the bundle to replace the bundle id. NOTE: we don't upload source maps on each run, to avoid spamming s3, so symbolication won't work
-# If you need to upload source maps for testing, remove the "-u=false" flag
-npm run demo:frontend:upload:sourcemaps -- -b "$bundle_path" -m "$source_map_path" -u=false
+# If you need to upload source maps for testing, remove the "--no-upload" flag
+npm run demo:frontend:upload:sourcemaps -- -b "$bundle_path" -m "$source_map_path" --no-upload
 npm run demo:frontend:preview
 
 


### PR DESCRIPTION
This is the recommended way to provide boolean flasg that are defaulted to "true" value based on `Commander.js` docs. The previous one may have invalid cases when they default to undefined instead of true