### PR TITLE
rename our cli to web-cli

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "@embraceio/sourcemaps-uploader",
+  "name": "@embraceio/web-cli",
   "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@embraceio/sourcemaps-uploader",
+      "name": "@embraceio/web-cli",
       "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0"
       },
       "bin": {
-        "sourcemaps-uploader": "build/index.js"
+        "web-cli": "build/index.js"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@embraceio/sourcemaps-uploader",
+  "name": "@embraceio/web-cli",
   "bin": "./build/index.js",
   "version": "0.0.3",
-  "description": "Embrace Web SDK Source Uploader",
+  "description": "Embrace Web CLI to help setup the Embrace SDK in your web app",
   "type": "module",
   "module": "build/index.js",
   "esnext": "build/index.js",

--- a/cli/src/constants.ts
+++ b/cli/src/constants.ts
@@ -1,6 +1,7 @@
 export const CLI_VERSION = '0.0.3';
-export const CLI_NAME = '@embraceio/sourcemaps-uploader';
-export const CLI_DESCRIPTION = 'Embrace Web SDK Source Uploader';
+export const CLI_NAME = '@embraceio/web-cli';
+export const CLI_DESCRIPTION =
+  'Embrace Web CLI to help setup the Embrace SDK in your web app';
 export const DEFAULT_FILE_ENCODING = 'utf8';
 export const SOURCE_MAP_UPLOAD_HOST = 'https://dsym-store.emb-api.com';
 export const SOURCE_MAP_UPLOAD_PATH = '/v2/store/';

--- a/demo/frontend/README.md
+++ b/demo/frontend/README.md
@@ -1,4 +1,4 @@
-This is a simple (extremely simple) demo app that shows how to use the embrace-web-sdk and the sourcemaps-uploader in a
+This is a simple (extremely simple) demo app that shows how to use the embrace-web-sdk and the web-cli in a
 React app.
 
 ## TLDR
@@ -45,14 +45,14 @@ With all of these, here are the steps to run the demo app referencing the latest
 10. Run `npm run demo:frontend:preview` in the `demo/frontend` directory. This will serve the demo app in production
     mode. Open your browser and go to ` http://localhost:4173/`. You should see the demo app running.
 
-## Testing the sourcemaps-uploader
+## Testing the web cli
 
 The dependency between the demo app and the cli is managed through `demo/frontend/package.json`. Specifically, the line
-`"@embraceio/sourcemaps-uploader": "file:../../cli",`. This tell npm to use the local version of the cli instead of
+`"@embraceio/web-cli": "file:../../cli",`. This tell npm to use the local version of the cli instead of
 downloading
 a remote one from npm registry. When you run `npm install` in the `demo/frontend` directory, npm will install the cli
 from the local directory `../../cli`.
-If you check the `node_modules/@embraceio/sourcemaps-uploader` directory, you will see that it is a symlink to `./cli`.
+If you check the `node_modules/@embraceio/web-cli` directory, you will see that it is a symlink to `./cli`.
 This will ensure that the demo app uses the latest version of the cli, even before it is published, for testing
 purposes.
 Note: even while the cli is not published, the exported fields from `cli/package.json` are still honored. This means

--- a/demo/frontend/package-lock.json
+++ b/demo/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "embrace-web-sdk-react-demo",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "embrace-web-sdk-react-demo",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@embraceio/embrace-web-sdk": "file:../..",
         "@opentelemetry/api": "1.9.0",
@@ -17,7 +17,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@embraceio/sourcemaps-uploader": "file:../../cli",
+        "@embraceio/web-cli": "file:../../cli",
         "@eslint/js": "^9.17.0",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
@@ -71,7 +71,7 @@
       }
     },
     "../../cli": {
-      "name": "@embraceio/sourcemaps-uploader",
+      "name": "@embraceio/web-cli",
       "version": "0.0.3",
       "dev": true,
       "license": "Apache-2.0",
@@ -79,7 +79,7 @@
         "commander": "^13.1.0"
       },
       "bin": {
-        "sourcemaps-uploader": "build/index.js"
+        "web-cli": "build/index.js"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -416,7 +416,7 @@
       "resolved": "../..",
       "link": true
     },
-    "node_modules/@embraceio/sourcemaps-uploader": {
+    "node_modules/@embraceio/web-cli": {
       "resolved": "../../cli",
       "link": true
     },

--- a/demo/frontend/package.json
+++ b/demo/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "embrace-web-sdk-react-demo",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "demo:frontend:full:preview": "bash ./scripts/runDemo.sh",
@@ -10,8 +10,8 @@
     "demo:frontend:dev": "vite",
     "demo:frontend:compile": "tsc -b && vite build",
     "demo:frontend:lint": "eslint .",
-    "demo:frontend:upload:sourcemaps": "sourcemaps-uploader upload -t 9819ef05be634fb39720d5f7dffb6404 -a pa6hp",
-    "demo:frontend:upload:sourcemaps:dry": "sourcemaps-uploader upload -d -t 9819ef05be634fb39720d5f7dffb6404 -a pa6hp",
+    "demo:frontend:upload:sourcemaps": "web-cli upload -t 9819ef05be634fb39720d5f7dffb6404 -a pa6hp",
+    "demo:frontend:upload:sourcemaps:dry": "web-cli upload -d -t 9819ef05be634fb39720d5f7dffb6404 -a pa6hp",
     "demo:frontend:preview": "vite preview"
   },
   "dependencies": {
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@embraceio/sourcemaps-uploader": "file:../../cli",
+    "@embraceio/web-cli": "file:../../cli",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",


### PR DESCRIPTION
### TL;DR
Renamed the CLI package from `@embraceio/sourcemaps-uploader` to `@embraceio/web-cli` to better reflect its expanded functionality.

### What changed?
- Updated package name from `@embraceio/sourcemaps-uploader` to `@embraceio/web-cli`
- Modified package description to indicate broader CLI functionality
- Updated binary name in package files
- Adjusted CLI references in demo frontend documentation and scripts

Flor Suggested the new name, considering that the embrace org have not just web packages in it