### PR TITLE
allow injecting sdk version using our cli

### DIFF
--- a/cli/src/constants.ts
+++ b/cli/src/constants.ts
@@ -1,5 +1,4 @@
 export const CLI_VERSION = '0.0.3';
-export const SDK_VERSION = '0.0.8';
 export const CLI_NAME = '@embraceio/web-cli';
 export const CLI_DESCRIPTION =
   'Embrace Web CLI to help setup the Embrace SDK in your web app';
@@ -7,4 +6,3 @@ export const DEFAULT_FILE_ENCODING = 'utf8';
 export const SOURCE_MAP_UPLOAD_HOST = 'https://dsym-store.emb-api.com';
 export const SOURCE_MAP_UPLOAD_PATH = '/v2/store/';
 export const TEMPLATE_BUNDLE_ID = 'EmbIOBundleIDfd6996f1007b363f87a';
-export const TEMPLATE_SDK_VERSION = 'EmbIOSDKVersionX.X.X';

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,11 +6,9 @@ import {
   CLI_NAME,
   CLI_VERSION,
   DEFAULT_FILE_ENCODING,
-  SDK_VERSION,
   SOURCE_MAP_UPLOAD_HOST,
   SOURCE_MAP_UPLOAD_PATH,
   TEMPLATE_BUNDLE_ID,
-  TEMPLATE_SDK_VERSION,
 } from './constants.js';
 
 // Use commander to parse command-line options
@@ -45,13 +43,6 @@ program
     new Option('--cli-version [cliVersion]', 'Version of this CLI tool')
       .env('EMB_CLI_VERSION')
       .default(CLI_VERSION)
-      .makeOptionMandatory()
-      .hideHelp()
-  )
-  .addOption(
-    new Option('--sdk-version [sdkVersion]', 'Version of the SDK')
-      .env('EMB_SDK_VERSION')
-      .default(SDK_VERSION)
       .makeOptionMandatory()
       .hideHelp()
   )
@@ -128,16 +119,6 @@ program
       .makeOptionMandatory()
       .hideHelp()
   )
-  .addOption(
-    new Option(
-      '--template-sdk-version [templateSdkVersion]',
-      'Embrace Template SDK Version build into the SDK source code for replacement'
-    )
-      .env('EMB_TEMPLATE_APP_VERSION')
-      .default(TEMPLATE_SDK_VERSION)
-      .makeOptionMandatory()
-      .hideHelp()
-  )
   .action(async options => {
     const {
       bundle,
@@ -148,12 +129,10 @@ program
       pathForUpload,
       storeType,
       templateBundleId,
-      templateSdkVersion,
       cliVersion,
       dryRun,
       upload,
       replaceBundleID,
-      sdkVersion,
       encoding,
     } = options; // Destructure the options
     await processSourceFiles({
@@ -165,11 +144,9 @@ program
       pathForUpload,
       storeType,
       templateBundleID: templateBundleId, // commander processes it as templateBundleId instead of templateBundleID, ergo the rename
-      templateSDKVersion: templateSdkVersion, // commander processes it as templateSdkVersion instead of templateSDKVersion, ergo the rename
       cliVersion,
       fileEncoding: encoding,
       dryRun,
-      sdkVersion,
       upload,
       replaceBundleID,
     });

--- a/cli/src/processSourceFiles.ts
+++ b/cli/src/processSourceFiles.ts
@@ -8,12 +8,10 @@ interface ProcessSourceFilesArgs {
   mapFilePath: string;
   token: string;
   appID: string;
-  sdkVersion: string;
   host: string;
   pathForUpload: string;
   storeType: string;
   cliVersion: string;
-  templateSDKVersion: string;
   templateBundleID: string;
   fileEncoding: BufferEncoding;
   dryRun: boolean;
@@ -31,12 +29,10 @@ export async function processSourceFiles({
   storeType,
   cliVersion,
   templateBundleID,
-  templateSDKVersion,
   dryRun,
   replaceBundleID,
   upload,
   fileEncoding,
-  sdkVersion,
 }: ProcessSourceFilesArgs): Promise<void> {
   const validationError = validateInput({
     jsFilePath,
@@ -47,9 +43,7 @@ export async function processSourceFiles({
     pathForUpload,
     storeType,
     cliVersion,
-    sdkVersion,
     templateBundleID,
-    templateSDKVersion,
   });
   if (validationError) {
     console.error('Input Validation Error: ', validationError);
@@ -61,32 +55,13 @@ export async function processSourceFiles({
     let jsContent = fs.readFileSync(jsFilePath, fileEncoding);
     let mapContent = fs.readFileSync(mapFilePath, fileEncoding);
 
-    // inject the appVersion into the source code
-    // for that, generate a 20 chars long appid by adding leading spaces to the appid
-    // if the appid is less than 20 chars long
-    const sdkVersionLength = sdkVersion.length;
-    if (sdkVersionLength < 20) {
-      sdkVersion = sdkVersion.padStart(20, ' ');
-    }
-    let newJsContent = jsContent.replace(templateSDKVersion, sdkVersion);
-    let newMapContent = mapContent.replace(templateSDKVersion, sdkVersion);
-
-    if (newJsContent === jsContent || newMapContent === mapContent) {
-      console.error('Template SDK version not found in the source code');
-      process.exit(1); // Exit with error code
-    }
-
-    // save the content to the base vars for later processing
-    jsContent = newJsContent;
-    mapContent = newMapContent;
-
     // generate 32 chars long hash from the js content using md5
     const bundleID = crypto.createHash('md5').update(jsContent).digest('hex');
     console.log(`Generated bundleID ${bundleID}`);
 
     // replace the injected template bundle ID with the generated bundle ID in the source code
-    newJsContent = jsContent.replace(templateBundleID, bundleID);
-    newMapContent = mapContent.replace(templateBundleID, bundleID);
+    const newJsContent = jsContent.replace(templateBundleID, bundleID);
+    const newMapContent = mapContent.replace(templateBundleID, bundleID);
 
     if (newJsContent === jsContent || newMapContent === mapContent) {
       console.error('Template bundle ID not found in the source code');

--- a/cli/src/validateInput.ts
+++ b/cli/src/validateInput.ts
@@ -10,10 +10,8 @@ interface ValidateInputArgs {
   host: string;
   pathForUpload: string;
   storeType: string;
-  sdkVersion: string;
   cliVersion: string;
   templateBundleID: string;
-  templateSDKVersion: string;
 }
 
 export function validateInput({
@@ -25,18 +23,10 @@ export function validateInput({
   pathForUpload,
   storeType,
   cliVersion,
-  sdkVersion,
   templateBundleID,
-  templateSDKVersion,
 }: ValidateInputArgs): string | null {
   if (!jsFilePath.trim()) {
     return 'JS file path cannot be empty.';
-  }
-  if (!sdkVersion.trim()) {
-    return 'sdkVersion cannot be empty.';
-  }
-  if (sdkVersion.length > 20) {
-    return 'sdkVersion cannot be longer than 20 characters.';
   }
   if (!mapFilePath.trim()) {
     return 'Map file path cannot be empty.';
@@ -71,13 +61,6 @@ export function validateInput({
   if (templateBundleID.length !== 32) {
     return 'Template bundle ID must be 32 characters long.';
   }
-  if (!templateSDKVersion.trim()) {
-    return 'Template SDK version cannot be empty.';
-  }
-  if (templateSDKVersion.length !== 20) {
-    return 'Template SDK version must be 20 characters long.';
-  }
-
   try {
     const jsStats = fs.statSync(jsFilePath);
     if (!jsStats.isFile() || jsStats.size === 0) {

--- a/src/resources/constants/index.ts
+++ b/src/resources/constants/index.ts
@@ -1,7 +1,7 @@
 // This will be replaced after bundling the app by the Embrace SourceUpload CLI tool.
 // It needs to always remain 32 chars long, so we don't mess with the sourcemaps location after replacing the bundle id with the real 32 chars long bundle ID
 export const TEMPLATE_BUNDLE_ID = 'EmbIOBundleIDfd6996f1007b363f87a';
-export const TEMPLATE_SDK_VERSION = 'EmbIOSDKVersionX.X.X';
+export const SDK_VERSION = '0.0.8';
 export const EMBRACE_SERVICE_NAME = 'embrace-web-sdk';
 // NATIVE_FRAMEWORK is the representation Embrace BE uses to differentiate between
 // sdk . It is an enum, so we just send a number here

--- a/src/resources/webSdkResource.ts
+++ b/src/resources/webSdkResource.ts
@@ -3,26 +3,18 @@ import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { browserDetector } from '@opentelemetry/opentelemetry-browser-detector';
 import {
   EMBRACE_SERVICE_NAME,
-  TEMPLATE_BUNDLE_ID,
-  TEMPLATE_SDK_VERSION,
   NATIVE_FRAMEWORK,
+  SDK_VERSION,
+  TEMPLATE_BUNDLE_ID,
 } from './constants/index.js';
 
 export const getWebSDKResource = () => {
-  /* We need to trim the app to remove any leading/trailing spaces
-  added by our cli tool. This is required to guarantee that the version is always
-  20 characters long in the final bundle, so sourcemaps don't get confused by
-  changing the length of the inlined app version. E.g. versions "0.0.1" and "0.0.115"
-  are both valid, but injecting them without leading whitespaces will result in
-  different lengths, pushing the sourcemaps mapping out of range. Instead
-  "               0.0.1" and "             0.0.115" are both 20 characters long,
-  and we trim them before loading at runtime */
   let resource = new Resource({
     [ATTR_SERVICE_NAME]: EMBRACE_SERVICE_NAME,
     app_version: '0.0.1', // TODO: this should be provided by the user / injected by our cli / both
     app_framework: NATIVE_FRAMEWORK,
     bundle_id: TEMPLATE_BUNDLE_ID,
-    sdk_version: TEMPLATE_SDK_VERSION.trim(),
+    sdk_version: SDK_VERSION,
     sdk_simple_version: 1,
     sdk_platform: 'web',
   });


### PR DESCRIPTION
### TL;DR
Added SDK version injection capability to the CLI tool and source code.

### What changed?
- Added SDK version constants and template placeholders
- Implemented SDK version injection logic in the CLI
- Added validation for SDK version length and format
- Modified the web SDK resource to trim injected SDK versions
- Added new CLI options for SDK version handling
- Updated bundle ID replacement process to handle both SDK version and bundle ID replacements


Note: It is technically possible to do this on our side instead of pushing the processing into our users. For that, we need to add a processor that makes this replacement at the build time of the SDK or to import from package.json directly. Both options have been discussed in previous PRs and discarded, so for now, we are reusing our already existing CLI to process the files