### PR TITLE
EMBR-6618 - Correctly handle log stacktraces

### DIFF
--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -108,9 +108,30 @@ const App = () => {
     req.send();
   };
 
-  const handleThrowError = () => {
+  // handleThrowError Throws an error by going through a set of nested functions to validate stacktraces
+  function handleThrowError() {
+    handleThrowErrorA(true);
+  }
+
+  function handleThrowErrorA(useBranchB: boolean) {
+    if (useBranchB) {
+      handleThrowErrorB();
+    } else {
+      handleThrowErrorD();
+    }
+  }
+
+  function handleThrowErrorB() {
+    handleThrowErrorC();
+  }
+
+  function handleThrowErrorC() {
+    handleThrowErrorA(false);
+  }
+
+  function handleThrowErrorD() {
     throw new Error('This is an error');
-  };
+  }
 
   const handleRejectPromise = () => {
     return new Promise((_, reject) => {

--- a/src/exporters/EmbraceLogExporter/EmbraceLogExporter.ts
+++ b/src/exporters/EmbraceLogExporter/EmbraceLogExporter.ts
@@ -3,9 +3,6 @@ import { getEmbraceHeaders } from '../utils.js';
 import { OTLPFetchLogExporter } from '../OTLPFetchLogExporter.js';
 import { EmbraceLogExporterArgs } from './types.js';
 import { getLogEndpoint } from './utils.js';
-import { ExportResult } from '@opentelemetry/core';
-import type { ReadableLogRecord } from '@opentelemetry/sdk-logs';
-import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
 
 export class EmbraceLogExporter extends OTLPFetchLogExporter {
   constructor({ appID, userID }: EmbraceLogExporterArgs) {
@@ -14,18 +11,5 @@ export class EmbraceLogExporter extends OTLPFetchLogExporter {
       headers: getEmbraceHeaders(appID, userID),
       url: getLogEndpoint(appID),
     });
-  }
-
-  override export(
-    items: ReadableLogRecord[],
-    resultCallback: (result: ExportResult) => void
-  ): void {
-    items.forEach(item => {
-      // SystemLog = 'sys.log', is an log emb type that tells the Embrace BE to process and keep the log.
-      // Our SDK adds it to any log generated through Embrace SDK. We check if this isn't already configure for some
-      // other specific emb.type and if not we set it to SystemLog.
-      item.attributes[KEY_EMB_TYPE] ??= EMB_TYPES.SystemLog;
-    });
-    super.export(items, resultCallback);
   }
 }

--- a/src/processors/EmbraceSpanEventExceptionToLogProcessor/EmbraceSpanEventExceptionToLogProcessor.ts
+++ b/src/processors/EmbraceSpanEventExceptionToLogProcessor/EmbraceSpanEventExceptionToLogProcessor.ts
@@ -4,7 +4,11 @@ import {
   ATTR_EXCEPTION_STACKTRACE,
 } from '@opentelemetry/semantic-conventions';
 import { Logger, SeverityNumber } from '@opentelemetry/api-logs';
-import { KEY_JS_EXCEPTION_STACKTRACE } from '../../constants/index.js';
+import {
+  EMB_TYPES,
+  KEY_EMB_TYPE,
+  KEY_JS_EXCEPTION_STACKTRACE,
+} from '../../constants/index.js';
 import { EmbraceLogRecord, ExceptionEvent, isExceptionEvent } from './types.js';
 
 /**
@@ -40,9 +44,9 @@ export class EmbraceSpanEventExceptionToLogProcessor implements SpanProcessor {
       body: event.attributes[ATTR_EXCEPTION_MESSAGE],
       attributes: {
         ...event.attributes,
-        [KEY_JS_EXCEPTION_STACKTRACE]: JSON.stringify(
-          event.attributes[ATTR_EXCEPTION_STACKTRACE]
-        ),
+        [KEY_EMB_TYPE]: EMB_TYPES.SystemLog,
+        [KEY_JS_EXCEPTION_STACKTRACE]:
+          event.attributes[ATTR_EXCEPTION_STACKTRACE],
       },
     };
     // need to remove the exception stack trace from the attributes since it's already sent as a separate attribute and Embrace interprets the log as android if ATTR_EXCEPTION_STACKTRACE is present


### PR DESCRIPTION
Fixed the reporting of logs with stacktraces.

---

How the stacktrace looks in the terminal:
![image](https://github.com/user-attachments/assets/2309313b-d771-4bad-920f-e4a9bc7fecb0)
```
App.tsx:133 Uncaught Error: This is an error
    at Ee (App.tsx:133:11)
    at q (App.tsx:120:25)
    at fe (App.tsx:129:5)
    at ie (App.tsx:125:23)
    at q (App.tsx:118:25)
    at H (App.tsx:113:5)
    at Object.Ry (react-dom.production.min.js:54:317)
    at xy (react-dom.production.min.js:54:471)
    at Cy (react-dom.production.min.js:55:35)
    at gd (react-dom.production.min.js:105:68)

```

---

How it looks in the dash:

https://dash.stg.emb-eng.com/app/pa6hp/v/top_versions/logging/last_1_hour/raw?log_type=all
![image](https://github.com/user-attachments/assets/9e1c93bb-4cd9-4a53-ab6e-2c314b57514c)
```
at handleThrowErrorD (../../src/App.tsx:133:11)
at handleThrowErrorA (../../src/App.tsx:120:25)
at handleThrowErrorC (../../src/App.tsx:129:5)
at handleThrowErrorB (../../src/App.tsx:125:23)
at handleThrowErrorA (../../src/App.tsx:118:25)
at handleThrowError (../../src/App.tsx:113:5)
at Object.Ry (../../node_modules/react-dom/cjs/react-dom.production.min.js:54:317)
at Tb (../../node_modules/react-dom/cjs/react-dom.production.min.js:54:471)
at Ub (../../node_modules/react-dom/cjs/react-dom.production.min.js:55:35)
at nf (../../node_modules/react-dom/cjs/react-dom.production.min.js:105:68)
```