### PR TITLE
refactor emb system log logic

### DIFF
--- a/src/processors/EmbTypeLogRecordProcessor/EmbTypeLogRecordProcessor.ts
+++ b/src/processors/EmbTypeLogRecordProcessor/EmbTypeLogRecordProcessor.ts
@@ -1,0 +1,20 @@
+import { LogRecord, type LogRecordProcessor } from '@opentelemetry/sdk-logs';
+import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
+
+export class EmbTypeLogRecordProcessor implements LogRecordProcessor {
+  onEmit(logRecord: LogRecord) {
+    if (!logRecord.attributes[KEY_EMB_TYPE]) {
+      logRecord.setAttribute(KEY_EMB_TYPE, EMB_TYPES.SystemLog);
+    }
+  }
+
+  // no-op
+  forceFlush(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+
+  // no-op
+  shutdown(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+}

--- a/src/processors/EmbTypeLogRecordProcessor/index.ts
+++ b/src/processors/EmbTypeLogRecordProcessor/index.ts
@@ -1,0 +1,1 @@
+export { EmbTypeLogRecordProcessor } from './EmbTypeLogRecordProcessor.js';

--- a/src/processors/EmbraceSpanEventExceptionToLogProcessor/EmbraceSpanEventExceptionToLogProcessor.ts
+++ b/src/processors/EmbraceSpanEventExceptionToLogProcessor/EmbraceSpanEventExceptionToLogProcessor.ts
@@ -4,11 +4,7 @@ import {
   ATTR_EXCEPTION_STACKTRACE,
 } from '@opentelemetry/semantic-conventions';
 import { Logger, SeverityNumber } from '@opentelemetry/api-logs';
-import {
-  EMB_TYPES,
-  KEY_EMB_TYPE,
-  KEY_JS_EXCEPTION_STACKTRACE,
-} from '../../constants/index.js';
+import { KEY_JS_EXCEPTION_STACKTRACE } from '../../constants/index.js';
 import { EmbraceLogRecord, ExceptionEvent, isExceptionEvent } from './types.js';
 
 /**
@@ -44,7 +40,6 @@ export class EmbraceSpanEventExceptionToLogProcessor implements SpanProcessor {
       body: event.attributes[ATTR_EXCEPTION_MESSAGE],
       attributes: {
         ...event.attributes,
-        [KEY_EMB_TYPE]: EMB_TYPES.SystemLog,
         [KEY_JS_EXCEPTION_STACKTRACE]:
           event.attributes[ATTR_EXCEPTION_STACKTRACE],
       },

--- a/src/sdk/initSDK.ts
+++ b/src/sdk/initSDK.ts
@@ -52,6 +52,7 @@ import { LocalStorageUserInstrumentation } from '../instrumentations/user/LocalS
 import { EmbraceUserManager } from '../instrumentations/user/index.js';
 import { user, UserManager } from '../api-users/index.js';
 import { KEY_ENDUSER_PSEUDO_ID } from '../api-users/manager/constants/index.js';
+import { EmbTypeLogRecordProcessor } from '../processors/EmbTypeLogRecordProcessor/index.js';
 
 type Exporter = 'otlp' | 'embrace';
 
@@ -301,6 +302,7 @@ const setupLogs = ({
     new IdentifiableSessionLogRecordProcessor({
       spanSessionManager: spanSessionManager,
     }),
+    new EmbTypeLogRecordProcessor(),
   ];
 
   if (exporters.includes('otlp')) {


### PR DESCRIPTION
follow up to https://github.com/embrace-io/embrace-web-sdk/pull/48/files (cc @pablomatiasgomez )

The previous PR avoided editing the Logs in an Exporter, which is not allowed. But the drawback is that we were only adding the Emb.type to logs added by the Exceptions instrumentation. 

I am moving the logic to add the embt type to a Processor now, which is allowed to edit the in flight logs (Same way we do in the IdentifiableSessionLogRecordProcessor. 

Screenshot: the logs are still including the emb type 
<img width="315" alt="image" src="https://github.com/user-attachments/assets/04f3d548-f498-4f23-b2ec-d997e40bac0e" />
