### PR TITLE
add a compile -- watch npm command to make it easy to develop the sdk locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "sdk:test": "echo \"Error: no test specified\" && exit 1",
     "sdk:compile": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "sdk:compile:esm": "tsc --build tsconfig.esm.json",
+    "sdk:compile:esm:watch": "tsc --build tsconfig.esm.json --watch",
     "sdk:compile:esnext": "tsc --build tsconfig.esnext.json",
     "sdk:compile:cjs": "tsc --build tsconfig.json",
     "sdk:lint:fix": "eslint --fix ./src"


### PR DESCRIPTION
Added a new watch mode script for ESM compilation

I am using this new script paired with `demo:frontend:dev` from the demo app to get a live reloading of both the demo and sdk so I can easily debug sdk changes in real time
