### PR TITLE
EMBR-6474 made sure existing sessions are terminated before starting new ones

### DIFF
--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -156,6 +156,11 @@ const App = () => {
             disabled={isSessionSpanStarted}>
             Start Session span
           </button>
+          <button
+            onClick={handleStartSessionSpan}
+            disabled={!isSessionSpanStarted}>
+            Override Session span
+          </button>
           <button onClick={handleEndSessionSpan}>End Session Span</button>
         </div>
         <button

--- a/src/instrumentations/session/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
+++ b/src/instrumentations/session/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
@@ -22,6 +22,10 @@ export class EmbraceSpanSessionManager implements SpanSessionManager {
   }
 
   startSessionSpan() {
+    //if there was a session in progress already, finish it first.
+    if (this._sessionSpan) {
+      this.endSessionSpan();
+    }
     const tracer = trace.getTracer('embrace-web-sdk-sessions');
     this._sessionSpan = tracer.startSpan('emb-session');
     this._activeSessionId = generateUUID();


### PR DESCRIPTION
(AI generated)
### TL;DR
Added ability to override an active session span with a new one in our demo

### What changed?
- Added an "Override Session span" button in the demo app
- Modified `startSessionSpan` to automatically end any existing session before starting a new one
- New button is only enabled when a session span is currently active

### How to test?
1. Start a session span using the "Start Session span" button
2. Click "Override Session span" to force end the current session and start a new one
3. Verify that the original session was ended and a new session was created
4. Confirm the "Override Session span" button is only enabled when a session is active

### Why make this change?
To provide better control over session management by allowing users to forcefully start a new session without manually ending the previous one. This is particularly useful in scenarios where you need to reset or restart a session without explicit cleanup.