### PR TITLE
add session span attributes during span creation, so processors hooking into the onStart hook can see them

### DIFF
--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -13,20 +13,12 @@ const sessionProvider = session.getSpanSessionManager();
 const App = () => {
   const [spans, setSpans] = useState<Span[]>([]);
 
-  const [isSessionSpanStarted, setIsSessionSpanStarted] = useState(
-    sessionProvider.getSessionSpan() !== null
-  );
-
   const handleStartSessionSpan = () => {
     sessionProvider.startSessionSpan();
-    setIsSessionSpanStarted(true);
   };
 
   const handleEndSessionSpan = () => {
-    if (sessionProvider.getSessionSpan()) {
-      sessionProvider.endSessionSpan();
-      setIsSessionSpanStarted(false);
-    }
+    sessionProvider.endSessionSpan();
   };
 
   const handleStartSpan = () => {
@@ -145,6 +137,8 @@ const App = () => {
       reject();
     });
   };
+
+  const isSessionSpanStarted = sessionProvider.getSessionSpan() !== null;
 
   return (
     <>

--- a/src/instrumentations/session/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
+++ b/src/instrumentations/session/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
@@ -27,17 +27,24 @@ export class EmbraceSpanSessionManager implements SpanSessionManager {
       this.endSessionSpan();
     }
     const tracer = trace.getTracer('embrace-web-sdk-sessions');
-    this._sessionSpan = tracer.startSpan('emb-session');
     this._activeSessionId = generateUUID();
-    this._sessionSpan.setAttributes({
-      [KEY_EMB_TYPE]: EMB_TYPES.Session,
-      [KEY_EMB_STATE]: EMB_STATES.Foreground,
-      [ATTR_SESSION_ID]: this._activeSessionId,
+    this._sessionSpan = tracer.startSpan('emb-session', {
+      attributes: {
+        [KEY_EMB_TYPE]: EMB_TYPES.Session,
+        [KEY_EMB_STATE]: EMB_STATES.Foreground,
+        [ATTR_SESSION_ID]: this._activeSessionId,
+      },
     });
   }
 
   endSessionSpan() {
-    this._sessionSpan?.end();
+    if (!this._sessionSpan) {
+      console.log(
+        'trying to end a session, but there is no session in progress. This is a no-op.'
+      );
+      return;
+    }
+    this._sessionSpan.end();
     this._sessionSpan = null;
     this._activeSessionId = null;
   }


### PR DESCRIPTION
(AI generated)
### TL;DR
Improved session span management and handling in the web SDK

### What changed?
- Moved session span state check to be computed directly from the provider instead of maintaining local state in the demo
- Added session span attributes during span creation instead of setting them after. This will allow processor to see them, as a general best practice.
- Added validation and logging when attempting to end non-existent session spans
- Simplified session span start/end handlers in the demo app

### How to test?
1. Start a new session span using the demo app
2. Verify session attributes are correctly set
3. End the session span and confirm it closes properly
4. Try ending a non-existent session and verify the warning message appears
5. Check that the UI correctly reflects the session state

### Why make this change?
To improve the reliability and maintainability of session span management by:
- Preventing potential state synchronization issues
- Making session span attribute handling more efficient
- Adding better error handling for invalid operations
- Reducing complexity in the demo application