### PR TITLE
inform the reason a session ended as a span attribute of the session

### DIFF
--- a/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.ts
+++ b/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.ts
@@ -17,4 +17,6 @@ export class NoOpSpanSessionManager implements SpanSessionManager {
   startSessionSpan(): void {}
 
   endSessionSpan(): void {}
+
+  endSessionSpanInternal(): void {}
 }

--- a/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.ts
+++ b/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.ts
@@ -1,4 +1,4 @@
-import { SpanSessionManager } from '../types.js';
+import { ReasonSessionEnded, SpanSessionManager } from '../types.js';
 import { NoOpSpanSessionManager } from '../NoOpSpanSessionManager/index.js';
 import { HrTime } from '@opentelemetry/api';
 
@@ -33,5 +33,9 @@ export class ProxySpanSessionManager implements SpanSessionManager {
 
   endSessionSpan() {
     this.getDelegate().endSessionSpan();
+  }
+
+  endSessionSpanInternal(reason: ReasonSessionEnded) {
+    this.getDelegate().endSessionSpanInternal(reason);
   }
 }

--- a/src/api-sessions/manager/types.ts
+++ b/src/api-sessions/manager/types.ts
@@ -10,4 +10,16 @@ export interface SpanSessionManager {
   startSessionSpan(): void;
 
   endSessionSpan(): void;
+
+  // todo move this to another class SpanSessionManagerInternal that is only accessible from within our code, but expose the external one without the method to the users.
+  endSessionSpanInternal(reason: ReasonSessionEnded): void;
 }
+
+export type ReasonSessionEnded =
+  | 'unknown'
+  | 'inactivity'
+  | 'max_time_reached'
+  | 'user_ended'
+  | 'max_size_reached'
+  | 'visibility_hidden'
+  | 'new_session_started';

--- a/src/constants/attributes.ts
+++ b/src/constants/attributes.ts
@@ -1,5 +1,6 @@
 export const KEY_EMB_TYPE = 'emb.type';
 export const KEY_EMB_STATE = 'emb.state';
+export const KEY_EMB_SESSION_REASON_ENDED = 'emb.session.reason_ended';
 export const KEY_JS_EXCEPTION_STACKTRACE = 'emb.stacktrace.js';
 
 export enum EMB_TYPES {

--- a/src/instrumentations/session/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
+++ b/src/instrumentations/session/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
@@ -6,8 +6,10 @@ import {
   KEY_EMB_TYPE,
 } from '../../../constants/index.js';
 import { ATTR_SESSION_ID } from '@opentelemetry/semantic-conventions/incubating';
-import { type SpanSessionManager } from '../../../api-sessions/index.js';
 import { generateUUID, getNowHRTime } from '../../../utils/index.js';
+import { KEY_EMB_SESSION_REASON_ENDED } from '../../../constants/attributes.js';
+import { SpanSessionManager } from '../../../api-sessions/index.js';
+import { ReasonSessionEnded } from '../../../api-sessions/manager/types.js';
 
 export class EmbraceSpanSessionManager implements SpanSessionManager {
   private _activeSessionId: string | null = null;
@@ -29,7 +31,7 @@ export class EmbraceSpanSessionManager implements SpanSessionManager {
   startSessionSpan() {
     //if there was a session in progress already, finish it first.
     if (this._sessionSpan) {
-      this.endSessionSpan();
+      this.endSessionSpanInternal('new_session_started');
     }
     const tracer = trace.getTracer('embrace-web-sdk-sessions');
     this._activeSessionId = generateUUID();
@@ -43,16 +45,24 @@ export class EmbraceSpanSessionManager implements SpanSessionManager {
     });
   }
 
-  endSessionSpan() {
+  // endSessionSpanInternal is not part of the public API, but is used internally to end a session span adding a specific reason
+  // the external api doesn't include a reason, and if a users uses it to end a session, the reason will be 'user_ended'
+  endSessionSpanInternal(reason: ReasonSessionEnded) {
     if (!this._sessionSpan) {
       console.log(
         'trying to end a session, but there is no session in progress. This is a no-op.'
       );
       return;
     }
+    this._sessionSpan.setAttribute(KEY_EMB_SESSION_REASON_ENDED, reason);
     this._sessionSpan.end();
     this._sessionSpan = null;
     this._activeSessionStartTime = null;
     this._activeSessionId = null;
+  }
+
+  // note: don't use this internally, this is just for user facing APIs. Use thi.endSessionSpanInternal instead.
+  endSessionSpan() {
+    this.endSessionSpanInternal('user_ended');
   }
 }

--- a/src/instrumentations/session/SpanSessionBrowserActivityInstrumentation/SpanSessionBrowserActivityInstrumentation.ts
+++ b/src/instrumentations/session/SpanSessionBrowserActivityInstrumentation/SpanSessionBrowserActivityInstrumentation.ts
@@ -36,7 +36,7 @@ export class SpanSessionBrowserActivityInstrumentation extends SpanSessionInstru
       clearTimeout(this._activityTimeout);
     }
     this._activityTimeout = null;
-    this.sessionManager.endSessionSpan();
+    this.sessionManager.endSessionSpanInternal('inactivity');
   };
 
   _onActivity = () => {

--- a/src/instrumentations/session/SpanSessionOnLoadInstrumentation/SpanSessionOnLoadInstrumentation.ts
+++ b/src/instrumentations/session/SpanSessionOnLoadInstrumentation/SpanSessionOnLoadInstrumentation.ts
@@ -9,7 +9,7 @@ export class SpanSessionOnLoadInstrumentation extends SpanSessionInstrumentation
   }
 
   disable(): void {
-    this.sessionManager.endSessionSpan();
+    this.sessionManager.endSessionSpanInternal('unknown');
   }
 
   enable(): void {

--- a/src/instrumentations/session/SpanSessionTimeoutInstrumentation/SpanSessionTimeoutInstrumentation.ts
+++ b/src/instrumentations/session/SpanSessionTimeoutInstrumentation/SpanSessionTimeoutInstrumentation.ts
@@ -33,6 +33,7 @@ export class SpanSessionTimeoutInstrumentation extends SpanSessionInstrumentatio
     if (this._sessionTimeout) {
       clearTimeout(this._sessionTimeout);
     }
+    this.sessionManager.endSessionSpanInternal('max_time_reached');
     this.sessionManager.startSessionSpan();
     // set a new check in TIMEOUT_TIME for the session we just started
     this._sessionTimeout = setTimeout(this._checkTimeout, TIMEOUT_TIME);

--- a/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.ts
+++ b/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.ts
@@ -7,7 +7,7 @@ export class SpanSessionVisibilityInstrumentation extends SpanSessionInstrumenta
     super('SpanSessionVisibilityInstrumentation', '1.0.0', {});
     this._onVisibilityChange = () => {
       if (document.visibilityState === 'hidden') {
-        this.sessionManager.endSessionSpan();
+        this.sessionManager.endSessionSpanInternal('visibility_hidden');
       } else {
         this.sessionManager.startSessionSpan();
       }


### PR DESCRIPTION
(AI generated)
### TL;DR
Added session end reason tracking to capture why sessions terminate.

### What changed?
- Added a new attribute `emb.session.reason_ended` to track session termination reasons
- Introduced `endSessionSpanInternal` method to handle different session end scenarios
- Implemented specific end reasons: 'inactivity', 'max_time_reached', 'user_ended', 'visibility_hidden', 'max_size_reached', and 'unknown'
- Updated session instrumentation classes to use appropriate end reasons

### How to test?
1. Trigger different session end scenarios:
   - Let session timeout due to inactivity
   - Switch browser tab to test visibility changes
   - End session manually through the API
   - Wait for max session time to be reached
2. Verify that the `emb.session.reason_ended` attribute contains the correct reason for each scenario

### Why make this change?
This change provides better visibility into why sessions are ending, helping with debugging and analytics. Understanding session termination patterns can help identify potential issues and improve user experience.