### PR TITLE
migrate Date to HRTime

### DIFF
--- a/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
+++ b/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
@@ -16,6 +16,7 @@ import { InstrumentationBase } from '../../InstrumentationBase/index.js';
 import { session, SpanSessionManager } from '../../../api-sessions/index.js';
 
 import { getHTMLElementFriendlyName } from './utils.js';
+import { getNowMilis } from '../../../utils/getNowHRTime/getNowHRTime.js';
 
 export class ClicksInstrumentation extends InstrumentationBase {
   private readonly _spanSessionManager: SpanSessionManager;
@@ -47,7 +48,7 @@ export class ClicksInstrumentation extends InstrumentationBase {
               'view.name': getHTMLElementFriendlyName(element),
               'tap.coords': `${event.x},${event.y}`,
             },
-            Date.now()
+            getNowMilis()
           );
         }
       } catch (e) {

--- a/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -14,6 +14,7 @@ import { TrackingLevel, WebVitalsInstrumentationArgs } from './types.js';
 import { withErrorFallback } from '../../../utils/index.js';
 import { ATTR_URL_FULL } from '@opentelemetry/semantic-conventions';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/index.js';
+import { getNowMilis } from '../../../utils/getNowHRTime/getNowHRTime.js';
 
 export class WebVitalsInstrumentation extends InstrumentationBase {
   //map of web vitals to gauges to emit to
@@ -62,7 +63,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     Object.keys(this._gauges).forEach(name => {
       WEB_VITALS_ID_TO_LISTENER[name as Metric['name']](metric => {
         // first thing record the time when this cb was invoked
-        const now = Date.now();
+        const now = getNowMilis();
         // we split the atts into low cardinality and high cardinality so we only report the low cardinality ones as metrics
         // and keep the high cardinality ones for the span event representation
         const lowCardinalityAtts: Attributes = {

--- a/src/transport/RetryingTransport/RetryingTransport.ts
+++ b/src/transport/RetryingTransport/RetryingTransport.ts
@@ -9,6 +9,7 @@ import {
   MAX_ATTEMPTS,
   MAX_BACKOFF,
 } from './constants.js';
+import { getNowMilis } from '../../utils/getNowHRTime/getNowHRTime.js';
 
 /**
  * Get a pseudo-random jitter that falls in the range of [-JITTER, +JITTER]
@@ -23,7 +24,7 @@ export class RetryingTransport implements IExporterTransport {
   constructor(private _transport: IExporterTransport) {}
 
   async send(data: Uint8Array, timeoutMillis: number): Promise<ExportResponse> {
-    const deadline = Date.now() + timeoutMillis;
+    const deadline = getNowMilis() + timeoutMillis;
     let result = await this._transport.send(data, timeoutMillis);
     let attempts = MAX_ATTEMPTS;
     let nextBackoff = INITIAL_BACKOFF;
@@ -40,7 +41,7 @@ export class RetryingTransport implements IExporterTransport {
       const retryInMillis = result.retryInMillis ?? backoff;
 
       // return when expected retry time is after the export deadline.
-      const remainingTimeoutMillis = deadline - Date.now();
+      const remainingTimeoutMillis = deadline - getNowMilis();
       if (retryInMillis > remainingTimeoutMillis) {
         return result;
       }

--- a/src/utils/getNowHRTime/getNowHRTime.ts
+++ b/src/utils/getNowHRTime/getNowHRTime.ts
@@ -1,4 +1,5 @@
 import { millisToHrTime, otperformance } from '@opentelemetry/core';
 
-export const getNowHRTime = () =>
-  millisToHrTime(otperformance.now() + otperformance.timeOrigin); // otperformance.now() returns milliseconds since timeOrigin, timeOrigin is the time from epoch to the start of the page load
+export const getNowHRTime = () => millisToHrTime(getNowMilis());
+
+export const getNowMilis = () => otperformance.now() + otperformance.timeOrigin; // otperformance.now() returns milliseconds since timeOrigin, timeOrigin is the time from epoch to the start of the page load


### PR DESCRIPTION
(AI generated)
### TL;DR
Replaced `Date.now()` calls with `getNowMilis()` for more accurate time measurements

### What changed?
- Created a new `getNowMilis()` function that uses `performance.now()` + `timeOrigin` for time calculations
- Updated `ClicksInstrumentation`, `WebVitalsInstrumentation`, and `RetryingTransport` to use `getNowMilis()` instead of `Date.now()`
- Refactored `getNowHRTime()` to utilize the new `getNowMilis()` function

### How to test?
1. Verify that all instrumentation timestamps are still being recorded correctly
2. Check that web vitals measurements are accurate
3. Confirm that retry mechanisms in the transport layer work as expected
4. Compare timestamps between old and new implementations to ensure consistency

### Why make this change?
`performance.now()` provides more precise timing measurements than `Date.now()`. It's also monotonic, meaning it's always increasing and not affected by system clock changes. This makes it more reliable for performance measurements and timing-sensitive operations in the instrumentation system.