### PR TITLE
add a EmbraceViewSpanProcessor to map view spans to embrace format

### DIFF
--- a/src/constants/attributes.ts
+++ b/src/constants/attributes.ts
@@ -8,6 +8,7 @@ export enum EMB_TYPES {
   // SystemLog = 'sys.log', is a log emb type that tells the Embrace BE to treat this as an Embrace Log to be shown in the dashboard.
   SystemLog = 'sys.log',
   WebVital = 'ux.web_vital',
+  View = 'ux.view',
 }
 
 export enum EMB_STATES {

--- a/src/instrumentations/session/types.ts
+++ b/src/instrumentations/session/types.ts
@@ -1,11 +1,11 @@
-import { ReadableSpan } from '@opentelemetry/sdk-trace-web';
-import { Attributes } from '@opentelemetry/api';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
+import {
+  EmbraceReadableSpan,
+  EmbraceSpanAttributes,
+} from '../../processors/types.js';
 
-export interface SessionSpanAttributes extends Attributes {
+export interface SessionSpanAttributes extends EmbraceSpanAttributes {
   [KEY_EMB_TYPE]: EMB_TYPES.Session;
 }
 
-export interface SessionSpan extends ReadableSpan {
-  attributes: SessionSpanAttributes;
-}
+export type SessionSpan = EmbraceReadableSpan<SessionSpanAttributes>;

--- a/src/processors/EmbraceNetworkSpanProcessor/types.ts
+++ b/src/processors/EmbraceNetworkSpanProcessor/types.ts
@@ -48,11 +48,3 @@ export const isNetworkSpan = (
 
   return false;
 };
-
-// not used yet, but added for clarity. This is the type for Embrace tagged network spans
-// interface EmbraceNetworkSpanAttributes extends Attributes {
-//   [KEY_EMB_TYPE]: EMB_TYPES.Network;
-// }
-// interface EmbraceNetworkSpan extends NetworkSpan {
-//   attributes: NetworkSpanAttributes & EmbraceNetworkSpanAttributes;
-// }

--- a/src/processors/EmbraceViewSpanProcessor/EmbraceViewSpanProcessor.ts
+++ b/src/processors/EmbraceViewSpanProcessor/EmbraceViewSpanProcessor.ts
@@ -1,0 +1,26 @@
+import { SpanProcessor } from '@opentelemetry/sdk-trace-web';
+import { isViewSpan } from './types.js';
+import { ATTR_URL_PATH } from '@opentelemetry/semantic-conventions';
+import { Span } from '@opentelemetry/sdk-trace-base/build/src/Span';
+import { KEY_VIEW_NAME } from './constants.js';
+
+/**
+ * Embrace's API expects view spans to have it url att as view.path. This maps it to it
+ */
+export class EmbraceViewSpanProcessor implements SpanProcessor {
+  onStart(span: Span): void {
+    if (isViewSpan(span)) {
+      span.attributes[KEY_VIEW_NAME] = span.attributes[ATTR_URL_PATH];
+    }
+  }
+
+  onEnd(): void {}
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+}

--- a/src/processors/EmbraceViewSpanProcessor/constants.ts
+++ b/src/processors/EmbraceViewSpanProcessor/constants.ts
@@ -1,0 +1,3 @@
+// TODO this should be prefixed with "emb." for consistency with other
+//  non-otel standard attributes -> KEY_VIEW_NAME = 'emb.view.name';
+export const KEY_VIEW_NAME = 'view.name';

--- a/src/processors/EmbraceViewSpanProcessor/index.ts
+++ b/src/processors/EmbraceViewSpanProcessor/index.ts
@@ -1,0 +1,1 @@
+export { EmbraceViewSpanProcessor } from './EmbraceViewSpanProcessor.js';

--- a/src/processors/EmbraceViewSpanProcessor/types.ts
+++ b/src/processors/EmbraceViewSpanProcessor/types.ts
@@ -1,0 +1,16 @@
+import { AttributeValue } from '@opentelemetry/api';
+import { ATTR_URL_PATH } from '@opentelemetry/semantic-conventions';
+import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
+import { Span } from '@opentelemetry/sdk-trace-web';
+import { EmbraceReadableSpan, EmbraceSpanAttributes } from '../types.js';
+
+interface ViewSpanAttributes extends EmbraceSpanAttributes {
+  [KEY_EMB_TYPE]: EMB_TYPES.View;
+  [ATTR_URL_PATH]: AttributeValue;
+}
+
+type ViewSpan = EmbraceReadableSpan<ViewSpanAttributes>;
+
+export const isViewSpan = (span: Span | ViewSpan): span is ViewSpan =>
+  span.attributes[KEY_EMB_TYPE] === EMB_TYPES.View &&
+  !!span.attributes[ATTR_URL_PATH];

--- a/src/processors/index.ts
+++ b/src/processors/index.ts
@@ -2,3 +2,4 @@ export { EmbraceSessionBatchedSpanProcessor } from './EmbraceSessionBatchedSpanP
 export { IdentifiableSessionLogRecordProcessor } from './IdentifiableSessionLogRecordProcessor/index.js';
 export { EmbraceSpanEventExceptionToLogProcessor } from './EmbraceSpanEventExceptionToLogProcessor/index.js';
 export { EmbraceNetworkSpanProcessor } from './EmbraceNetworkSpanProcessor/index.js';
+export { EmbraceViewSpanProcessor } from './EmbraceViewSpanProcessor/index.js';

--- a/src/processors/types.ts
+++ b/src/processors/types.ts
@@ -1,0 +1,13 @@
+import { Attributes, AttributeValue } from '@opentelemetry/api';
+import { KEY_EMB_TYPE } from '../constants/index.js';
+import { ReadableSpan } from '@opentelemetry/sdk-trace-web';
+
+export interface EmbraceSpanAttributes extends Attributes {
+  [KEY_EMB_TYPE]: AttributeValue;
+}
+
+export interface EmbraceReadableSpan<
+  Attributes extends EmbraceSpanAttributes = EmbraceSpanAttributes,
+> extends ReadableSpan {
+  attributes: Attributes;
+}

--- a/src/sdk/initSDK.ts
+++ b/src/sdk/initSDK.ts
@@ -1,11 +1,11 @@
 import { Resource } from '@opentelemetry/resources';
 import { getWebSDKResource } from '../resources/index.js';
 import {
+  ClicksInstrumentation,
   EmbraceSpanSessionManager,
   GlobalExceptionInstrumentation,
   SpanSessionInstrumentation,
   WebVitalsInstrumentation,
-  ClicksInstrumentation,
 } from '../instrumentations/index.js';
 import { createSessionSpanProcessor } from '@opentelemetry/web-common';
 import {
@@ -28,6 +28,7 @@ import {
   EmbraceNetworkSpanProcessor,
   EmbraceSessionBatchedSpanProcessor,
   EmbraceSpanEventExceptionToLogProcessor,
+  EmbraceViewSpanProcessor,
   IdentifiableSessionLogRecordProcessor,
 } from '../processors/index.js';
 import { logs } from '@opentelemetry/api-logs';
@@ -261,8 +262,10 @@ const setupTraces = ({
           loggerProvider.getLogger('exceptions')
         );
       const embraceNetworkSpanProcessor = new EmbraceNetworkSpanProcessor();
+      const embraceViewSpanProcessor = new EmbraceViewSpanProcessor();
 
       finalSpanProcessors.push(embraceNetworkSpanProcessor);
+      finalSpanProcessors.push(embraceViewSpanProcessor);
       finalSpanProcessors.push(embraceSessionBatchedProcessor);
       finalSpanProcessors.push(embraceSpanEventExceptionToLogProcessor);
     }


### PR DESCRIPTION
cc @jpmunz I moved the custom attribute mapping to the SDK

Note: I couldn't get rid of the emb.type att, as there are no semantic conventions on how to manage views afaik, so this is not as clean as I would like to. At least I moved the URL path to a standard attribute 🤷 

SDK PR https://github.com/embrace-io/embrace-web-sdk/pull/95
DashJS PR https://github.com/embrace-io/dashjs/pull/5852