### PR TITLE
EMBR-6729 proper timestamp for click events

### DIFF
--- a/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
+++ b/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
@@ -16,7 +16,7 @@ import { InstrumentationBase } from '../../InstrumentationBase/index.js';
 import { session, SpanSessionManager } from '../../../api-sessions/index.js';
 
 import { getHTMLElementFriendlyName } from './utils.js';
-import { getNowMilis } from '../../../utils/getNowHRTime/getNowHRTime.js';
+import { epochMillisFromOriginOffset } from '../../../utils/getNowHRTime/getNowHRTime.js';
 
 export class ClicksInstrumentation extends InstrumentationBase {
   private readonly _spanSessionManager: SpanSessionManager;
@@ -38,6 +38,7 @@ export class ClicksInstrumentation extends InstrumentationBase {
       if (element.hasAttribute('disabled')) {
         return;
       }
+
       try {
         const currentSessionSpan = this._spanSessionManager.getSessionSpan();
         if (currentSessionSpan) {
@@ -48,7 +49,7 @@ export class ClicksInstrumentation extends InstrumentationBase {
               'view.name': getHTMLElementFriendlyName(element),
               'tap.coords': `${event.x},${event.y}`,
             },
-            getNowMilis()
+            epochMillisFromOriginOffset(event.timeStamp)
           );
         }
       } catch (e) {

--- a/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -14,7 +14,7 @@ import { TrackingLevel, WebVitalsInstrumentationArgs } from './types.js';
 import { withErrorFallback } from '../../../utils/index.js';
 import { ATTR_URL_FULL } from '@opentelemetry/semantic-conventions';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/index.js';
-import { getNowMilis } from '../../../utils/getNowHRTime/getNowHRTime.js';
+import { getNowMillis } from '../../../utils/getNowHRTime/getNowHRTime.js';
 
 export class WebVitalsInstrumentation extends InstrumentationBase {
   //map of web vitals to gauges to emit to
@@ -63,7 +63,7 @@ export class WebVitalsInstrumentation extends InstrumentationBase {
     Object.keys(this._gauges).forEach(name => {
       WEB_VITALS_ID_TO_LISTENER[name as Metric['name']](metric => {
         // first thing record the time when this cb was invoked
-        const now = getNowMilis();
+        const now = getNowMillis();
         // we split the atts into low cardinality and high cardinality so we only report the low cardinality ones as metrics
         // and keep the high cardinality ones for the span event representation
         const lowCardinalityAtts: Attributes = {

--- a/src/transport/RetryingTransport/RetryingTransport.ts
+++ b/src/transport/RetryingTransport/RetryingTransport.ts
@@ -9,7 +9,7 @@ import {
   MAX_ATTEMPTS,
   MAX_BACKOFF,
 } from './constants.js';
-import { getNowMilis } from '../../utils/getNowHRTime/getNowHRTime.js';
+import { getNowMillis } from '../../utils/getNowHRTime/getNowHRTime.js';
 
 /**
  * Get a pseudo-random jitter that falls in the range of [-JITTER, +JITTER]
@@ -24,7 +24,7 @@ export class RetryingTransport implements IExporterTransport {
   constructor(private _transport: IExporterTransport) {}
 
   async send(data: Uint8Array, timeoutMillis: number): Promise<ExportResponse> {
-    const deadline = getNowMilis() + timeoutMillis;
+    const deadline = getNowMillis() + timeoutMillis;
     let result = await this._transport.send(data, timeoutMillis);
     let attempts = MAX_ATTEMPTS;
     let nextBackoff = INITIAL_BACKOFF;
@@ -41,7 +41,7 @@ export class RetryingTransport implements IExporterTransport {
       const retryInMillis = result.retryInMillis ?? backoff;
 
       // return when expected retry time is after the export deadline.
-      const remainingTimeoutMillis = deadline - getNowMilis();
+      const remainingTimeoutMillis = deadline - getNowMillis();
       if (retryInMillis > remainingTimeoutMillis) {
         return result;
       }

--- a/src/utils/getNowHRTime/getNowHRTime.ts
+++ b/src/utils/getNowHRTime/getNowHRTime.ts
@@ -1,5 +1,9 @@
 import { millisToHrTime, otperformance } from '@opentelemetry/core';
 
-export const getNowHRTime = () => millisToHrTime(getNowMilis());
+export const getNowHRTime = () => millisToHrTime(getNowMillis());
 
-export const getNowMilis = () => otperformance.now() + otperformance.timeOrigin; // otperformance.now() returns milliseconds since timeOrigin, timeOrigin is the time from epoch to the start of the page load
+export const epochMillisFromOriginOffset = (originOffset: number) =>
+  otperformance.timeOrigin + originOffset;
+
+export const getNowMillis = () =>
+  epochMillisFromOriginOffset(otperformance.now()); // otperformance.now() returns milliseconds since timeOrigin, timeOrigin is the time from epoch to the start of the page load


### PR DESCRIPTION
Was grabbing 'now' in the event listener but this was a few milliseconds later than when the actual click happened, instead use the event timestamp which is relative to the time origin