### PR TITLE
chore: linter - enforce consistent type import and export

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ const compat = new FlatCompat({
 /** @type {import('eslint').Linter.Config[]} */
 export default tseslint.config({
   files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'],
+  ignores: ['**/*.test.ts'],
   extends: [
     pluginJs.configs.recommended,
     tseslint.configs.strictTypeChecked,
@@ -47,6 +48,8 @@ export default tseslint.config({
         allowAsThisParameter: true,
       },
     ],
+    "@typescript-eslint/consistent-type-exports": "error",
+    "@typescript-eslint/consistent-type-imports": "error",
     '@typescript-eslint/naming-convention': [
       'error',
       {

--- a/src/api-sessions/index.ts
+++ b/src/api-sessions/index.ts
@@ -1,6 +1,6 @@
 export { session } from './sessionAPI.js';
+export type { SpanSessionManager } from './manager/index.js';
 export {
-  SpanSessionManager,
   NoOpSpanSessionManager,
   ProxySpanSessionManager,
 } from './manager/index.js';

--- a/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.ts
+++ b/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.ts
@@ -1,5 +1,5 @@
-import { SpanSessionManager } from '../types.js';
-import { HrTime, Span } from '@opentelemetry/api';
+import type { SpanSessionManager } from '../types.js';
+import type { HrTime, Span } from '@opentelemetry/api';
 
 export class NoOpSpanSessionManager implements SpanSessionManager {
   public getSessionId = () => null;

--- a/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.ts
+++ b/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.ts
@@ -1,6 +1,6 @@
-import { ReasonSessionEnded, SpanSessionManager } from '../types.js';
+import type { ReasonSessionEnded, SpanSessionManager } from '../types.js';
 import { NoOpSpanSessionManager } from '../NoOpSpanSessionManager/index.js';
-import { HrTime } from '@opentelemetry/api';
+import type { HrTime } from '@opentelemetry/api';
 
 const NOOP_SPAN_SESSION_MANAGER = new NoOpSpanSessionManager();
 

--- a/src/api-sessions/manager/index.ts
+++ b/src/api-sessions/manager/index.ts
@@ -1,3 +1,3 @@
-export { SpanSessionManager } from './types.js';
+export { type SpanSessionManager } from './types.js';
 export { NoOpSpanSessionManager } from './NoOpSpanSessionManager/index.js';
 export { ProxySpanSessionManager } from './ProxySpanSessionManager/index.js';

--- a/src/api-sessions/manager/types.ts
+++ b/src/api-sessions/manager/types.ts
@@ -1,4 +1,4 @@
-import { HrTime, Span } from '@opentelemetry/api';
+import type { HrTime, Span } from '@opentelemetry/api';
 
 export interface SpanSessionManager {
   getSessionId(): string | null;

--- a/src/api-users/index.ts
+++ b/src/api-users/index.ts
@@ -1,6 +1,3 @@
 export { user } from './userAPI.js';
-export {
-  UserManager,
-  NoOpUserManager,
-  ProxyUserManager,
-} from './manager/index.js';
+export type { UserManager } from './manager/index.js';
+export { NoOpUserManager, ProxyUserManager } from './manager/index.js';

--- a/src/api-users/manager/NoOpUserManager/NoOpUserManager.ts
+++ b/src/api-users/manager/NoOpUserManager/NoOpUserManager.ts
@@ -1,4 +1,4 @@
-import { User, UserManager } from '../types.js';
+import type { User, UserManager } from '../types.js';
 
 export class NoOpUserManager implements UserManager {
   public getUser(): User | null {

--- a/src/api-users/manager/ProxyUserManager/ProxyUserManager.ts
+++ b/src/api-users/manager/ProxyUserManager/ProxyUserManager.ts
@@ -1,4 +1,4 @@
-import { User, UserManager } from '../types.js';
+import type { User, UserManager } from '../types.js';
 import { NoOpUserManager } from '../NoOpUserManager/index.js';
 
 const NOOP_USER_MANAGER = new NoOpUserManager();

--- a/src/api-users/manager/index.ts
+++ b/src/api-users/manager/index.ts
@@ -1,3 +1,3 @@
-export { UserManager } from './types.js';
+export type { UserManager } from './types.js';
 export { NoOpUserManager } from './NoOpUserManager/index.js';
 export { ProxyUserManager } from './ProxyUserManager/index.js';

--- a/src/api-users/manager/types.ts
+++ b/src/api-users/manager/types.ts
@@ -1,4 +1,4 @@
-import { KEY_ENDUSER_PSEUDO_ID } from './constants/index.js';
+import type { KEY_ENDUSER_PSEUDO_ID } from './constants/index.js';
 
 export interface User {
   [KEY_ENDUSER_PSEUDO_ID]: string;

--- a/src/exporters/BaseFetchExporter/BaseFetchExporter.ts
+++ b/src/exporters/BaseFetchExporter/BaseFetchExporter.ts
@@ -1,5 +1,5 @@
-import { IOtlpExportDelegate } from '@opentelemetry/otlp-exporter-base';
-import { ExportResult } from '@opentelemetry/core';
+import type { IOtlpExportDelegate } from '@opentelemetry/otlp-exporter-base';
+import type { ExportResult } from '@opentelemetry/core';
 
 export class BaseFetchExporter<Internal> {
   public constructor(

--- a/src/exporters/EmbraceLogExporter/EmbraceLogExporter.ts
+++ b/src/exporters/EmbraceLogExporter/EmbraceLogExporter.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_EMBRACE_EXPORTER_CONFIG } from '../constants.js';
 import { getEmbraceHeaders } from '../utils.js';
 import { OTLPFetchLogExporter } from '../OTLPFetchLogExporter.js';
-import { EmbraceLogExporterArgs } from './types.js';
+import type { EmbraceLogExporterArgs } from './types.js';
 import { getLogEndpoint } from './utils.js';
 
 export class EmbraceLogExporter extends OTLPFetchLogExporter {

--- a/src/exporters/EmbraceTraceExporter/EmbraceTraceExporter.ts
+++ b/src/exporters/EmbraceTraceExporter/EmbraceTraceExporter.ts
@@ -2,7 +2,7 @@ import { OTLPFetchTraceExporter } from '../OTLPFetchTraceExporter.js';
 import { DEFAULT_EMBRACE_EXPORTER_CONFIG } from '../constants.js';
 import { getEmbraceHeaders } from '../utils.js';
 import { getTraceEndpoint } from './utils.js';
-import { EmbraceTraceExporterArgs } from './types.js';
+import type { EmbraceTraceExporterArgs } from './types.js';
 
 export class EmbraceTraceExporter extends OTLPFetchTraceExporter {
   public constructor({ appID, userID }: EmbraceTraceExporterArgs) {

--- a/src/exporters/OTLPFetchLogExporter.ts
+++ b/src/exporters/OTLPFetchLogExporter.ts
@@ -4,7 +4,7 @@ import type {
 } from '@opentelemetry/sdk-logs';
 import { JsonLogsSerializer } from '@opentelemetry/otlp-transformer';
 import { BaseFetchExporter } from './BaseFetchExporter/index.js';
-import { OtlpFetchExporterConfig } from './types.js';
+import type { OtlpFetchExporterConfig } from './types.js';
 import { createOtlpBrowserFetchExportDelegate } from './otlpBrowserFetchExportDelegate.js';
 
 export class OTLPFetchLogExporter

--- a/src/exporters/OTLPFetchTraceExporter.ts
+++ b/src/exporters/OTLPFetchTraceExporter.ts
@@ -1,7 +1,7 @@
-import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-web';
+import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-web';
 import { JsonTraceSerializer } from '@opentelemetry/otlp-transformer';
 import { BaseFetchExporter } from './BaseFetchExporter/index.js';
-import { OtlpFetchExporterConfig } from './types.js';
+import type { OtlpFetchExporterConfig } from './types.js';
 import { createOtlpBrowserFetchExportDelegate } from './otlpBrowserFetchExportDelegate.js';
 
 export class OTLPFetchTraceExporter

--- a/src/exporters/otlpBrowserFetchExportDelegate.ts
+++ b/src/exporters/otlpBrowserFetchExportDelegate.ts
@@ -1,10 +1,10 @@
 import { createOtlpNetworkExportDelegate } from '@opentelemetry/otlp-exporter-base';
-import { ISerializer } from '@opentelemetry/otlp-transformer';
+import type { ISerializer } from '@opentelemetry/otlp-transformer';
 import {
   createFetchTransport,
   createRetryingTransport,
 } from '../transport/index.js';
-import { OtlpFetchExporterConfig } from './types.js';
+import type { OtlpFetchExporterConfig } from './types.js';
 
 // createOtlpBrowserFetchExportDelegate creates an export delegate that uses
 // the Fetch API to send data to an OTLP receiver.

--- a/src/exporters/types.ts
+++ b/src/exporters/types.ts
@@ -1,4 +1,4 @@
-import { OtlpSharedConfiguration } from '@opentelemetry/otlp-exporter-base';
+import type { OtlpSharedConfiguration } from '@opentelemetry/otlp-exporter-base';
 
 interface OtlpFetchExporterConfig extends OtlpSharedConfiguration {
   url: string;

--- a/src/instrumentations/InstrumentationAbstract/InstrumentationAbstract.ts
+++ b/src/instrumentations/InstrumentationAbstract/InstrumentationAbstract.ts
@@ -1,22 +1,21 @@
-import {
+import type {
   Instrumentation,
   InstrumentationConfig,
   InstrumentationModuleDefinition,
   SpanCustomizationHook,
 } from '@opentelemetry/instrumentation';
-import {
-  diag,
+import type {
   DiagLogger,
   Meter,
   MeterProvider,
-  metrics,
   Span,
-  trace,
   Tracer,
   TracerProvider,
 } from '@opentelemetry/api';
-import { Logger, logs } from '@opentelemetry/api-logs';
-import { LoggerProvider } from '@opentelemetry/sdk-logs';
+import { diag, metrics, trace } from '@opentelemetry/api';
+import type { Logger } from '@opentelemetry/api-logs';
+import { logs } from '@opentelemetry/api-logs';
+import type { LoggerProvider } from '@opentelemetry/sdk-logs';
 import * as shimmer from 'shimmer';
 
 // TODO is there any legal issue with copying this?

--- a/src/instrumentations/InstrumentationBase/InstrumentationBase.ts
+++ b/src/instrumentations/InstrumentationBase/InstrumentationBase.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Instrumentation,
   InstrumentationConfig,
 } from '@opentelemetry/instrumentation';

--- a/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
+++ b/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
@@ -11,9 +11,10 @@
       recording click events for which `stopPropagation` is called.
  */
 
-import { InstrumentationModuleDefinition } from '@opentelemetry/instrumentation';
+import type { InstrumentationModuleDefinition } from '@opentelemetry/instrumentation';
 import { InstrumentationBase } from '../../InstrumentationBase/index.js';
-import { session, SpanSessionManager } from '../../../api-sessions/index.js';
+import type { SpanSessionManager } from '../../../api-sessions/index.js';
+import { session } from '../../../api-sessions/index.js';
 
 import { getHTMLElementFriendlyName } from './utils.js';
 import { epochMillisFromOriginOffset } from '../../../utils/getNowHRTime/getNowHRTime.js';

--- a/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
+++ b/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
@@ -1,4 +1,4 @@
-import { InstrumentationModuleDefinition } from '@opentelemetry/instrumentation';
+import type { InstrumentationModuleDefinition } from '@opentelemetry/instrumentation';
 import { InstrumentationBase } from '../../InstrumentationBase/index.js';
 import { logMessage } from '../../../utils/log.js';
 import { epochMillisFromOriginOffset } from '../../../utils/getNowHRTime/getNowHRTime.js';

--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -1,8 +1,7 @@
+export type { SessionSpanAttributes, SessionSpan } from './session/index.js';
 export {
   EmbraceSpanSessionManager,
   SpanSessionVisibilityInstrumentation,
-  SessionSpanAttributes,
-  SessionSpan,
 } from './session/index.js';
 export { GlobalExceptionInstrumentation } from './exceptions/index.js';
 export { ClicksInstrumentation } from './clicks/index.js';

--- a/src/instrumentations/session/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
+++ b/src/instrumentations/session/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
@@ -1,4 +1,5 @@
-import { diag, DiagLogger, HrTime, Span, trace } from '@opentelemetry/api';
+import type { DiagLogger, HrTime, Span } from '@opentelemetry/api';
+import { diag, trace } from '@opentelemetry/api';
 import {
   EMB_STATES,
   EMB_TYPES,
@@ -8,8 +9,8 @@ import {
 import { ATTR_SESSION_ID } from '@opentelemetry/semantic-conventions/incubating';
 import { generateUUID, getNowHRTime } from '../../../utils/index.js';
 import { KEY_EMB_SESSION_REASON_ENDED } from '../../../constants/attributes.js';
-import { SpanSessionManager } from '../../../api-sessions/index.js';
-import { ReasonSessionEnded } from '../../../api-sessions/manager/types.js';
+import type { SpanSessionManager } from '../../../api-sessions/index.js';
+import type { ReasonSessionEnded } from '../../../api-sessions/manager/types.js';
 
 export class EmbraceSpanSessionManager implements SpanSessionManager {
   private _activeSessionId: string | null = null;

--- a/src/instrumentations/session/SpanSessionBrowserActivityInstrumentation/SpanSessionBrowserActivityInstrumentation.ts
+++ b/src/instrumentations/session/SpanSessionBrowserActivityInstrumentation/SpanSessionBrowserActivityInstrumentation.ts
@@ -4,11 +4,11 @@ import {
   TIMEOUT_TIME,
   WINDOW_USER_EVENTS,
 } from './constants.js';
+import type { TimeoutRef } from '../../../utils/index.js';
 import {
   bulkAddEventListener,
   bulkRemoveEventListener,
   throttle,
-  TimeoutRef,
 } from '../../../utils/index.js';
 
 /**

--- a/src/instrumentations/session/SpanSessionInstrumentation/SpanSessionInstrumentation.ts
+++ b/src/instrumentations/session/SpanSessionInstrumentation/SpanSessionInstrumentation.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   InstrumentationConfig,
   InstrumentationModuleDefinition,
 } from '@opentelemetry/instrumentation';
 import { InstrumentationBase } from '../../InstrumentationBase/index.js';
-import { session, SpanSessionManager } from '../../../api-sessions/index.js';
+import type { SpanSessionManager } from '../../../api-sessions/index.js';
+import { session } from '../../../api-sessions/index.js';
 
 export abstract class SpanSessionInstrumentation<
   ConfigType extends InstrumentationConfig = InstrumentationConfig,

--- a/src/instrumentations/session/SpanSessionTimeoutInstrumentation/SpanSessionTimeoutInstrumentation.ts
+++ b/src/instrumentations/session/SpanSessionTimeoutInstrumentation/SpanSessionTimeoutInstrumentation.ts
@@ -1,5 +1,6 @@
 import { SpanSessionInstrumentation } from '../SpanSessionInstrumentation/index.js';
-import { getNowHRTime, TimeoutRef } from '../../../utils/index.js';
+import type { TimeoutRef } from '../../../utils/index.js';
+import { getNowHRTime } from '../../../utils/index.js';
 import { hrTimeToMilliseconds } from '@opentelemetry/core/build/src/common/time';
 import { TIMEOUT_TIME } from './constants.js';
 

--- a/src/instrumentations/session/index.ts
+++ b/src/instrumentations/session/index.ts
@@ -1,3 +1,3 @@
 export { EmbraceSpanSessionManager } from './EmbraceSpanSessionManager/index.js';
 export { SpanSessionVisibilityInstrumentation } from './SpanSessionVisibilityInstrumentation/index.js';
-export { SessionSpanAttributes, SessionSpan } from './types.js';
+export type { SessionSpanAttributes, SessionSpan } from './types.js';

--- a/src/instrumentations/session/types.ts
+++ b/src/instrumentations/session/types.ts
@@ -1,6 +1,6 @@
-import { ReadableSpan } from '@opentelemetry/sdk-trace-web';
-import { Attributes } from '@opentelemetry/api';
-import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-web';
+import type { Attributes } from '@opentelemetry/api';
+import type { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
 
 export interface SessionSpanAttributes extends Attributes {
   [KEY_EMB_TYPE]: EMB_TYPES.Session;

--- a/src/instrumentations/user/EmbraceUserManager/EmbraceUserManager.ts
+++ b/src/instrumentations/user/EmbraceUserManager/EmbraceUserManager.ts
@@ -1,5 +1,5 @@
-import { UserManager } from '../../../api-users/index.js';
-import { User } from '../../../api-users/manager/types.js';
+import type { UserManager } from '../../../api-users/index.js';
+import type { User } from '../../../api-users/manager/types.js';
 
 export class EmbraceUserManager implements UserManager {
   private _activeUser: User | null = null;

--- a/src/instrumentations/user/LocalStorageUserInstrumentation/LocalStorageUserInstrumentation.ts
+++ b/src/instrumentations/user/LocalStorageUserInstrumentation/LocalStorageUserInstrumentation.ts
@@ -1,9 +1,9 @@
-import { InstrumentationModuleDefinition } from '@opentelemetry/instrumentation';
+import type { InstrumentationModuleDefinition } from '@opentelemetry/instrumentation';
 import { InstrumentationBase } from '../../InstrumentationBase/index.js';
 import { isUser } from './types.js';
 import { generateUUID } from '../../../utils/index.js';
 import { EMBRACE_USER_LOCAL_STORAGE_KEY } from './constants.js';
-import { User, UserManager } from '../../../api-users/manager/types.js';
+import type { User, UserManager } from '../../../api-users/manager/types.js';
 import { KEY_ENDUSER_PSEUDO_ID } from '../../../api-users/manager/constants/index.js';
 import { user } from '../../../api-users/index.js';
 

--- a/src/instrumentations/user/LocalStorageUserInstrumentation/types.ts
+++ b/src/instrumentations/user/LocalStorageUserInstrumentation/types.ts
@@ -1,4 +1,4 @@
-import { User } from '../../../api-users/manager/types.js';
+import type { User } from '../../../api-users/manager/types.js';
 import { KEY_ENDUSER_PSEUDO_ID } from '../../../api-users/manager/constants/index.js';
 
 export const isUser = (user: unknown): user is User =>

--- a/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -1,8 +1,8 @@
-import { InstrumentationModuleDefinition } from '@opentelemetry/instrumentation';
+import type { InstrumentationModuleDefinition } from '@opentelemetry/instrumentation';
 import { InstrumentationBase } from '../../InstrumentationBase/index.js';
-import { Attributes, Gauge, MeterProvider } from '@opentelemetry/api';
+import type { Attributes, Gauge, MeterProvider } from '@opentelemetry/api';
 import { type Metric } from 'web-vitals/attribution';
-import { SpanSessionManager } from '../../../api-sessions/index.js';
+import type { SpanSessionManager } from '../../../api-sessions/index.js';
 import {
   CORE_WEB_VITALS,
   EMB_WEB_VITALS_PREFIX,
@@ -10,7 +10,7 @@ import {
   NOT_CORE_WEB_VITALS,
   WEB_VITALS_ID_TO_LISTENER,
 } from './constants.js';
-import { TrackingLevel, WebVitalsInstrumentationArgs } from './types.js';
+import type { TrackingLevel, WebVitalsInstrumentationArgs } from './types.js';
 import { withErrorFallback } from '../../../utils/index.js';
 import { ATTR_URL_FULL } from '@opentelemetry/semantic-conventions';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/index.js';

--- a/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
+++ b/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
@@ -1,5 +1,5 @@
 import { type SpanSessionManager } from '../../../api-sessions/index.js';
-import { MeterProvider } from '@opentelemetry/api';
+import type { MeterProvider } from '@opentelemetry/api';
 
 export type TrackingLevel = 'core' | 'all';
 

--- a/src/processors/EmbTypeLogRecordProcessor/EmbTypeLogRecordProcessor.ts
+++ b/src/processors/EmbTypeLogRecordProcessor/EmbTypeLogRecordProcessor.ts
@@ -1,4 +1,5 @@
-import { LogRecord, type LogRecordProcessor } from '@opentelemetry/sdk-logs';
+import type { LogRecord } from '@opentelemetry/sdk-logs';
+import { type LogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
 
 export class EmbTypeLogRecordProcessor implements LogRecordProcessor {

--- a/src/processors/EmbraceNetworkSpanProcessor/EmbraceNetworkSpanProcessor.ts
+++ b/src/processors/EmbraceNetworkSpanProcessor/EmbraceNetworkSpanProcessor.ts
@@ -1,4 +1,4 @@
-import { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-web';
+import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-web';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
 import { isNetworkSpan } from './types.js';
 

--- a/src/processors/EmbraceNetworkSpanProcessor/types.ts
+++ b/src/processors/EmbraceNetworkSpanProcessor/types.ts
@@ -1,4 +1,4 @@
-import { Attributes, AttributeValue } from '@opentelemetry/api';
+import type { Attributes, AttributeValue } from '@opentelemetry/api';
 import {
   ATTR_HTTP_REQUEST_METHOD,
   ATTR_HTTP_RESPONSE_STATUS_CODE,
@@ -7,7 +7,7 @@ import {
   SEMATTRS_HTTP_STATUS_CODE,
   SEMATTRS_HTTP_URL,
 } from '@opentelemetry/semantic-conventions';
-import { ReadableSpan } from '@opentelemetry/sdk-trace-web';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-web';
 
 // NetworkSpanAttributesDeprecated and NetworkSpanAttributesNewest are the types for network spans attributes based on the otel conventions.
 // The SEMATTRS_HTTP_METHOD attribute is deprecated in favor of ATTR_HTTP_REQUEST_METHOD,

--- a/src/processors/EmbraceSessionBatchedSpanProcessor/EmbraceSessionBatchedSpanProcessor.ts
+++ b/src/processors/EmbraceSessionBatchedSpanProcessor/EmbraceSessionBatchedSpanProcessor.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ReadableSpan,
   SpanExporter,
   SpanProcessor,
@@ -6,7 +6,7 @@ import {
 // TODO: don't rely on internal API
 import { BindOnceFuture, internal } from '@opentelemetry/core';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
-import { SessionSpan } from '../../instrumentations/index.js';
+import type { SessionSpan } from '../../instrumentations/index.js';
 
 const isSessionSpan = (span: ReadableSpan | SessionSpan): span is SessionSpan =>
   span.attributes[KEY_EMB_TYPE] === EMB_TYPES.Session;

--- a/src/processors/IdentifiableSessionLogRecordProcessor/IdentifiableSessionLogRecordProcessor.ts
+++ b/src/processors/IdentifiableSessionLogRecordProcessor/IdentifiableSessionLogRecordProcessor.ts
@@ -1,11 +1,12 @@
-import { LogRecord, type LogRecordProcessor } from '@opentelemetry/sdk-logs';
+import type { LogRecord } from '@opentelemetry/sdk-logs';
+import { type LogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { generateUUID } from '../../utils/index.js';
 import {
   ATTR_LOG_RECORD_UID,
   ATTR_SESSION_ID,
 } from '@opentelemetry/semantic-conventions/incubating';
-import { SpanSessionManager } from '../../api-sessions/index.js';
-import { IdentifiableSessionLogRecordProcessorArgs } from './types.js';
+import type { SpanSessionManager } from '../../api-sessions/index.js';
+import type { IdentifiableSessionLogRecordProcessorArgs } from './types.js';
 
 export class IdentifiableSessionLogRecordProcessor
   implements LogRecordProcessor

--- a/src/processors/IdentifiableSessionLogRecordProcessor/types.ts
+++ b/src/processors/IdentifiableSessionLogRecordProcessor/types.ts
@@ -1,4 +1,4 @@
-import { SpanSessionManager } from '../../api-sessions/index.js';
+import type { SpanSessionManager } from '../../api-sessions/index.js';
 
 export interface IdentifiableSessionLogRecordProcessorArgs {
   spanSessionManager: SpanSessionManager;

--- a/src/sdk/initSDK.ts
+++ b/src/sdk/initSDK.ts
@@ -8,21 +8,17 @@ import {
   WebVitalsInstrumentation,
 } from '../instrumentations/index.js';
 import { createSessionSpanProcessor } from '@opentelemetry/web-common';
+import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
 import {
   BatchSpanProcessor,
-  SpanProcessor,
   WebTracerProvider,
 } from '@opentelemetry/sdk-trace-web';
-import {
-  ContextManager,
-  metrics,
-  TextMapPropagator,
-  trace,
-} from '@opentelemetry/api';
+import type { ContextManager, TextMapPropagator } from '@opentelemetry/api';
+import { metrics, trace } from '@opentelemetry/api';
+import type { LogRecordProcessor } from '@opentelemetry/sdk-logs';
 import {
   BatchLogRecordProcessor,
   LoggerProvider,
-  LogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
 import {
   EmbraceNetworkSpanProcessor,
@@ -30,10 +26,8 @@ import {
   IdentifiableSessionLogRecordProcessor,
 } from '../processors/index.js';
 import { logs } from '@opentelemetry/api-logs';
-import {
-  Instrumentation,
-  registerInstrumentations,
-} from '@opentelemetry/instrumentation';
+import type { Instrumentation } from '@opentelemetry/instrumentation';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import {
@@ -41,16 +35,18 @@ import {
   EmbraceTraceExporter,
 } from '../exporters/index.js';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
-import { session, SpanSessionManager } from '../api-sessions/index.js';
+import type { SpanSessionManager } from '../api-sessions/index.js';
+import { session } from '../api-sessions/index.js';
+import type { MetricReader } from '@opentelemetry/sdk-metrics';
 import {
   MeterProvider,
-  MetricReader,
   PeriodicExportingMetricReader,
 } from '@opentelemetry/sdk-metrics';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { LocalStorageUserInstrumentation } from '../instrumentations/user/LocalStorageUserInstrumentation/index.js';
 import { EmbraceUserManager } from '../instrumentations/user/index.js';
-import { user, UserManager } from '../api-users/index.js';
+import type { UserManager } from '../api-users/index.js';
+import { user } from '../api-users/index.js';
 import { KEY_ENDUSER_PSEUDO_ID } from '../api-users/manager/constants/index.js';
 import { EmbTypeLogRecordProcessor } from '../processors/EmbTypeLogRecordProcessor/index.js';
 import { isValidAppID } from './utils.js';

--- a/src/transport/FetchTransport/FetchTransport.ts
+++ b/src/transport/FetchTransport/FetchTransport.ts
@@ -1,8 +1,8 @@
-import {
+import type {
   ExportResponse,
   IExporterTransport,
 } from '@opentelemetry/otlp-exporter-base';
-import { FetchRequestParameters } from './types.js';
+import type { FetchRequestParameters } from './types.js';
 
 export class FetchTransport implements IExporterTransport {
   public constructor(private readonly config: FetchRequestParameters) {}

--- a/src/transport/FetchTransport/createFetchTransport.ts
+++ b/src/transport/FetchTransport/createFetchTransport.ts
@@ -1,5 +1,5 @@
-import { FetchRequestParameters } from './types.js';
-import { IExporterTransport } from '@opentelemetry/otlp-exporter-base';
+import type { FetchRequestParameters } from './types.js';
+import type { IExporterTransport } from '@opentelemetry/otlp-exporter-base';
 import { FetchTransport } from './FetchTransport.js';
 
 export const createFetchTransport = (

--- a/src/transport/RetryingTransport/RetryingTransport.ts
+++ b/src/transport/RetryingTransport/RetryingTransport.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ExportResponse,
   IExporterTransport,
 } from '@opentelemetry/otlp-exporter-base';

--- a/src/transport/RetryingTransport/createRetryingTransport.ts
+++ b/src/transport/RetryingTransport/createRetryingTransport.ts
@@ -1,4 +1,4 @@
-import { IExporterTransport } from '@opentelemetry/otlp-exporter-base';
+import type { IExporterTransport } from '@opentelemetry/otlp-exporter-base';
 import { RetryingTransport } from './RetryingTransport.js';
 
 /**

--- a/src/utils/bulkAddEventListener/bulkAddEventListener.ts
+++ b/src/utils/bulkAddEventListener/bulkAddEventListener.ts
@@ -1,4 +1,4 @@
-import { BulkAddEventListenerArgs } from './types.js';
+import type { BulkAddEventListenerArgs } from './types.js';
 
 /**
  * Add multiple event listeners to a target element.

--- a/src/utils/bulkRemoveEventListener/bulkRemoveEventListener.ts
+++ b/src/utils/bulkRemoveEventListener/bulkRemoveEventListener.ts
@@ -1,4 +1,4 @@
-import { BulkRemoveEventListenerArgs } from './types.js';
+import type { BulkRemoveEventListenerArgs } from './types.js';
 
 /**
  * Remove multiple event listeners from a target element.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,6 @@ export { generateUUID } from './generateUUID.js';
 export { withErrorFallback } from './withErrorFallback.js';
 export { bulkAddEventListener } from './bulkAddEventListener/index.js';
 export { bulkRemoveEventListener } from './bulkRemoveEventListener/index.js';
-export { TimeoutRef } from './timeout/index.js';
+export type { TimeoutRef } from './timeout/index.js';
 export { getNowHRTime } from './getNowHRTime/index.js';
 export { throttle } from './throttle.js';

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,11 +1,12 @@
-import { Logger, SeverityNumber } from '@opentelemetry/api-logs';
+import type { Logger } from '@opentelemetry/api-logs';
+import { SeverityNumber } from '@opentelemetry/api-logs';
 import { getNowMillis } from './getNowHRTime/getNowHRTime.js';
 import {
   EMB_TYPES,
   KEY_EMB_TYPE,
   KEY_JS_EXCEPTION_STACKTRACE,
 } from '../constants/index.js';
-import { AttributeValue } from '@opentelemetry/api';
+import type { AttributeValue } from '@opentelemetry/api';
 
 type LogSeverity = 'info' | 'warning' | 'error';
 

--- a/src/utils/timeout/index.ts
+++ b/src/utils/timeout/index.ts
@@ -1,1 +1,1 @@
-export { TimeoutRef } from './types.js';
+export type { TimeoutRef } from './types.js';


### PR DESCRIPTION
### TL;DR

Enforces consistent type imports across the codebase by adding ESLint rules and updating import statements to use the `type` keyword where appropriate.

### What changed?

- Added ESLint rules for consistent type imports:
  - `@typescript-eslint/consistent-type-exports`
  - `@typescript-eslint/consistent-type-imports`
- Updated import statements across files to explicitly use `type` keyword for type-only imports
- Configured ESLint to ignore test files
- Exported types separately from their implementations in public APIs

### How to test?

1. Run ESLint to verify no type import violations exist
2. Verify the codebase builds successfully
3. Run tests to ensure functionality remains unchanged
4. Import types from the library and verify they work as expected

### Why make this change?

Using explicit type imports provides several benefits:
- Clearer distinction between type and value imports
- Better tree-shaking as type imports are removed during compilation
- This is a prerequisite for the testing setup I want to use in my next PR, which will remove ts on the fly instead of processing it for performance
- More maintainable code by enforcing consistent import patterns
- Improved TypeScript performance by reducing the scope of type checking