### PR TITLE
chore: remove unnecessary exports from src/instrumentations

### DIFF
--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -1,16 +1,8 @@
-export type { SessionSpanAttributes, SessionSpan } from './session/index.js';
+export type { SessionSpan } from './session/index.js';
 export {
   EmbraceSpanSessionManager,
   SpanSessionVisibilityInstrumentation
 } from './session/index.js';
 export { GlobalExceptionInstrumentation } from './exceptions/index.js';
 export { ClicksInstrumentation } from './clicks/index.js';
-export {
-  WebVitalsInstrumentation,
-  EMB_WEB_VITALS_PREFIX,
-  METER_NAME,
-  CORE_WEB_VITALS,
-  NOT_CORE_WEB_VITALS,
-  WEB_VITALS,
-  WEB_VITALS_ID_TO_LISTENER
-} from './web-vitals/index.js';
+export { WebVitalsInstrumentation } from './web-vitals/index.js';

--- a/src/instrumentations/session/index.ts
+++ b/src/instrumentations/session/index.ts
@@ -1,3 +1,3 @@
 export { EmbraceSpanSessionManager } from './EmbraceSpanSessionManager/index.js';
 export { SpanSessionVisibilityInstrumentation } from './SpanSessionVisibilityInstrumentation/index.js';
-export type { SessionSpanAttributes, SessionSpan } from './types.js';
+export type { SessionSpan } from './types.js';

--- a/src/instrumentations/session/types.ts
+++ b/src/instrumentations/session/types.ts
@@ -2,7 +2,7 @@ import type { Attributes } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-web';
 import type { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
 
-export interface SessionSpanAttributes extends Attributes {
+interface SessionSpanAttributes extends Attributes {
   [KEY_EMB_TYPE]: EMB_TYPES.Session;
 }
 

--- a/src/instrumentations/web-vitals/index.ts
+++ b/src/instrumentations/web-vitals/index.ts
@@ -1,9 +1,1 @@
-export {
-  WebVitalsInstrumentation,
-  EMB_WEB_VITALS_PREFIX,
-  METER_NAME,
-  CORE_WEB_VITALS,
-  NOT_CORE_WEB_VITALS,
-  WEB_VITALS,
-  WEB_VITALS_ID_TO_LISTENER
-} from './WebVitalsInstrumentation/index.js';
+export { WebVitalsInstrumentation } from './WebVitalsInstrumentation/index.js';


### PR DESCRIPTION
### TL;DR

Reduced API surface by removing unnecessary exports from web-vitals and session instrumentations.