### PR TITLE
chore: shorten all imports from initSDK to max one folder, add intermediate exports

### DIFF
--- a/src/api-users/index.ts
+++ b/src/api-users/index.ts
@@ -1,3 +1,7 @@
 export { user } from './userAPI.js';
 export type { UserManager } from './manager/index.js';
-export { NoOpUserManager, ProxyUserManager } from './manager/index.js';
+export {
+  NoOpUserManager,
+  ProxyUserManager,
+  KEY_ENDUSER_PSEUDO_ID
+} from './manager/index.js';

--- a/src/api-users/manager/index.ts
+++ b/src/api-users/manager/index.ts
@@ -1,3 +1,4 @@
 export type { UserManager } from './types.js';
+export { KEY_ENDUSER_PSEUDO_ID } from './constants/index.js';
 export { NoOpUserManager } from './NoOpUserManager/index.js';
 export { ProxyUserManager } from './ProxyUserManager/index.js';

--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -1,8 +1,15 @@
 export type { SessionSpan } from './session/index.js';
 export {
   EmbraceSpanSessionManager,
-  SpanSessionVisibilityInstrumentation
+  SpanSessionVisibilityInstrumentation,
+  SpanSessionOnLoadInstrumentation,
+  SpanSessionBrowserActivityInstrumentation,
+  SpanSessionTimeoutInstrumentation
 } from './session/index.js';
+export {
+  EmbraceUserManager,
+  LocalStorageUserInstrumentation
+} from './user/index.js';
 export { GlobalExceptionInstrumentation } from './exceptions/index.js';
 export { ClicksInstrumentation } from './clicks/index.js';
 export { WebVitalsInstrumentation } from './web-vitals/index.js';

--- a/src/instrumentations/session/index.ts
+++ b/src/instrumentations/session/index.ts
@@ -1,3 +1,6 @@
 export { EmbraceSpanSessionManager } from './EmbraceSpanSessionManager/index.js';
 export { SpanSessionVisibilityInstrumentation } from './SpanSessionVisibilityInstrumentation/index.js';
+export { SpanSessionBrowserActivityInstrumentation } from './SpanSessionBrowserActivityInstrumentation/index.js';
+export { SpanSessionOnLoadInstrumentation } from './SpanSessionOnLoadInstrumentation/index.js';
+export { SpanSessionTimeoutInstrumentation } from './SpanSessionTimeoutInstrumentation/index.js';
 export type { SessionSpan } from './types.js';

--- a/src/processors/index.ts
+++ b/src/processors/index.ts
@@ -1,3 +1,4 @@
 export { EmbraceSessionBatchedSpanProcessor } from './EmbraceSessionBatchedSpanProcessor/index.js';
 export { IdentifiableSessionLogRecordProcessor } from './IdentifiableSessionLogRecordProcessor/index.js';
 export { EmbraceNetworkSpanProcessor } from './EmbraceNetworkSpanProcessor/index.js';
+export { EmbTypeLogRecordProcessor } from './EmbTypeLogRecordProcessor/index.js';

--- a/src/sdk/initSDK.ts
+++ b/src/sdk/initSDK.ts
@@ -27,8 +27,7 @@ import { createSessionSpanProcessor } from '@opentelemetry/web-common';
 import type { SpanSessionManager } from '../api-sessions/index.js';
 import { session } from '../api-sessions/index.js';
 import type { UserManager } from '../api-users/index.js';
-import { user } from '../api-users/index.js';
-import { KEY_ENDUSER_PSEUDO_ID } from '../api-users/manager/constants/index.js';
+import { KEY_ENDUSER_PSEUDO_ID, user } from '../api-users/index.js';
 import {
   EmbraceLogExporter,
   EmbraceTraceExporter
@@ -36,21 +35,19 @@ import {
 import {
   ClicksInstrumentation,
   EmbraceSpanSessionManager,
+  EmbraceUserManager,
   GlobalExceptionInstrumentation,
+  LocalStorageUserInstrumentation,
+  SpanSessionBrowserActivityInstrumentation,
+  SpanSessionOnLoadInstrumentation,
+  SpanSessionTimeoutInstrumentation,
   SpanSessionVisibilityInstrumentation,
   WebVitalsInstrumentation
 } from '../instrumentations/index.js';
-import { SpanSessionBrowserActivityInstrumentation } from '../instrumentations/session/SpanSessionBrowserActivityInstrumentation/index.js';
-import { SpanSessionOnLoadInstrumentation } from '../instrumentations/session/SpanSessionOnLoadInstrumentation/index.js';
-import { SpanSessionTimeoutInstrumentation } from '../instrumentations/session/SpanSessionTimeoutInstrumentation/index.js';
-import {
-  EmbraceUserManager,
-  LocalStorageUserInstrumentation
-} from '../instrumentations/user/index.js';
-import { EmbTypeLogRecordProcessor } from '../processors/EmbTypeLogRecordProcessor/index.js';
 import {
   EmbraceNetworkSpanProcessor,
   EmbraceSessionBatchedSpanProcessor,
+  EmbTypeLogRecordProcessor,
   IdentifiableSessionLogRecordProcessor
 } from '../processors/index.js';
 import { getWebSDKResource } from '../resources/index.js';


### PR DESCRIPTION
Shortening imports. We had been forgetting to reexport from intermediate packages. No import should ever include more than one folder max