### PR TITLE
fix: multi browser not finishing

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -79,15 +79,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - name: Cache test
-        if: ${{ env.TEST_PREVIOUSLY_PASSED != 'true' }}
-        uses: actions/cache@v4
-        with:
-          path: .test
-          key: ${{ runner.os }}-test-${{ matrix.node-version }}-${{ hashFiles('**/package.lock.json') }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ matrix.node-version }}-${{ hashFiles('**/package.lock.json') }}-branch-
-
       - name: Install npm dependencies
         if: ${{ env.TEST_PREVIOUSLY_PASSED != 'true' }}
         run: |
@@ -105,6 +96,16 @@ jobs:
           fi
           npx playwright install --with-deps
           npm run sdk:test -- $argsCoverage
+
+      - name: Cache successful test results
+        if: ${{ success() }}
+        run: |
+          touch ${{ env.TEST_STATUS_FILE }}
+
+      - name: Do not cache test failures
+        if: ${{ failure() || cancelled() }}
+        run: |
+          rm -f ${{ env.TEST_STATUS_FILE }}
 
       # https://github.com/embrace-io/code-coverage-report-action
       - name: Generate coverage difference report
@@ -160,15 +161,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-
-      - name: Cache test
-        if: ${{ env.TEST_PREVIOUSLY_PASSED != 'true' }}
-        uses: actions/cache@v4
-        with:
-          path: .test
-          key: ${{ runner.os }}-test-${{ matrix.node-version }}-${{ hashFiles('**/package.lock.json') }}-branch-${{ github.head_ref }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ matrix.node-version }}-${{ hashFiles('**/package.lock.json') }}-branch-
 
       - name: Install npm dependencies
         if: ${{ env.TEST_PREVIOUSLY_PASSED != 'true' }}

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -9,6 +9,5 @@ export default {
   files: ['src/**/*.test.ts'],
   plugins: [vitePlugin()],
   browsers: [playwrightLauncher({ product: 'chromium', concurrency: 5 })],
-  concurrentBrowsers: 3,
   filterBrowserLogs: removeViteLogging
 };

--- a/web-test-runner.multi-browser.config.js
+++ b/web-test-runner.multi-browser.config.js
@@ -2,35 +2,35 @@ import { devices, playwrightLauncher } from '@web/test-runner-playwright';
 import baseConfig from './web-test-runner.config.js';
 
 const TEN_MINUTES = 600000;
-
+const SHARED_LAUNCH_OPTIONS = {
+  concurrency: 1,
+  launchOptions: {
+    timeout: TEN_MINUTES
+  }
+};
 export default {
   ...baseConfig,
+  concurrentBrowsers: 1,
   browserStartTimeout: TEN_MINUTES, // 10 minutes. Required as we do not parallelize tests enough to start all browsers at once.
   browsers: [
     /* Test against desktop browsers */
     playwrightLauncher({
       product: 'chromium',
-      launchOptions: {
-        timeout: TEN_MINUTES
-      },
+      ...SHARED_LAUNCH_OPTIONS,
       createBrowserContext({ browser }) {
         return browser.newContext({ ...devices['Desktop Chrome'] });
       }
     }),
     playwrightLauncher({
       product: 'firefox',
-      launchOptions: {
-        timeout: TEN_MINUTES
-      },
+      ...SHARED_LAUNCH_OPTIONS,
       createBrowserContext({ browser }) {
         return browser.newContext({ ...devices['Desktop Firefox'] });
       }
     }),
     playwrightLauncher({
       product: 'webkit',
-      launchOptions: {
-        timeout: TEN_MINUTES
-      },
+      ...SHARED_LAUNCH_OPTIONS,
       createBrowserContext({ browser }) {
         return browser.newContext({ ...devices['Desktop Safari'] });
       }
@@ -38,18 +38,14 @@ export default {
     /* Test against mobile browsers */
     playwrightLauncher({
       product: 'chromium',
-      launchOptions: {
-        timeout: TEN_MINUTES
-      },
+      ...SHARED_LAUNCH_OPTIONS,
       createBrowserContext({ browser }) {
         return browser.newContext({ ...devices['Pixel 5'] });
       }
     }),
     playwrightLauncher({
       product: 'webkit',
-      launchOptions: {
-        timeout: TEN_MINUTES
-      },
+      ...SHARED_LAUNCH_OPTIONS,
       createBrowserContext({ browser }) {
         return browser.newContext({ ...devices['iPhone 12'] });
       }
@@ -57,9 +53,7 @@ export default {
     /* Test against branded browsers. */
     playwrightLauncher({
       product: 'chromium',
-      launchOptions: {
-        timeout: TEN_MINUTES
-      },
+      ...SHARED_LAUNCH_OPTIONS,
       createBrowserContext({ browser }) {
         return browser.newContext({
           ...devices['Desktop Chrome'],
@@ -69,9 +63,7 @@ export default {
     }),
     playwrightLauncher({
       product: 'chromium',
-      launchOptions: {
-        timeout: TEN_MINUTES
-      },
+      ...SHARED_LAUNCH_OPTIONS,
       createBrowserContext({ browser }) {
         return browser.newContext({
           ...devices['Desktop Edge'],


### PR DESCRIPTION
I am not really sure why yet, but for some reason, the dependency optimization from Vite (which we can not disable because we need it to map cjs to esm) fails when we parallelize tests. After a couple of config changes with no luck, I ended up just turning off the concurrency and increasing the timeout so browsers don't die waiting for others to run. Even with this config, it takes about 2 minutes to run our current 50%ish coverage, so I imagine it will take about 4 minutes once we complete the tests.

I added this config to all browser launchers
```
  concurrency: 1,
  launchOptions: {
    timeout: TEN_MINUTES
  }
```


Example failed run: https://github.com/embrace-io/embrace-web-sdk/actions/runs/13995606373/job/39189903139
Example working run https://github.com/embrace-io/embrace-web-sdk/actions/runs/13995728541/job/39190320440