### PR TITLE
chore: cache browser installations during tests

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -84,6 +84,39 @@ jobs:
         run: |
           npm ci --strict-peer-deps
 
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "version=$(npm why --json playwright | jq --raw-output '.[].version' )" >> $GITHUB_OUTPUT
+
+      - name: Restore cached playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: '~/.cache/ms-playwright'
+          key: '${{ runner.os }}-${{ matrix.node-version }}-playwright-${{ steps.playwright-version.outputs.version }}'
+          # As a fallback, if the Playwright version has changed, try use the
+          # most recently cached version. There's a good chance that at least one
+          # of the browser binary versions haven't been updated, so Playwright can
+          # skip installing that in the next step.
+          # Note: When falling back to an old cache, `cache-hit` (used below)
+          # will be `false`. This allows us to restore the potentially out of
+          # date cache, but still let Playwright decide if it needs to download
+          # new binaries or not.
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-playwright-
+
+      # If the Playwright browser binaries weren't restored, we tell
+      # playwright to install everything for us.
+      - name: Install Playwright browsers with dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npm run playwright -- install --with-deps
+
+      # If the Playwright browser binaries were restored, we tell
+      # playwright to install just system deps.
+      - name: Install Playwright's dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npm run playwright -- install-deps
+
       - name: Test with coverage
         if: ${{ env.TEST_PREVIOUSLY_PASSED != 'true' }}
         run: |
@@ -94,7 +127,6 @@ jobs:
             argsCoverage='--config=web-test-runner.coverage.config.js'
             echo 'TEST_COLLECTED_COVERAGE=true' >> $GITHUB_ENV
           fi
-          npx playwright install --with-deps
           npm run sdk:test -- $argsCoverage
 
       - name: Cache successful test results
@@ -129,8 +161,8 @@ jobs:
     needs:
       - configure
       - environment
-    if: ${{ needs.environment.outputs.name == 'staging' }}
     runs-on: ${{ vars.RUNNER_SMALL }}
+    if: ${{ needs.environment.outputs.name == 'staging' }}
     timeout-minutes: 5
     strategy:
       fail-fast: false
@@ -167,10 +199,42 @@ jobs:
         run: |
           npm ci --strict-peer-deps
 
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "version=$(npm why --json playwright | jq --raw-output '.[].version' )" >> $GITHUB_OUTPUT
+
+      - name: Restore cached playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: '~/.cache/ms-playwright'
+          key: '${{ runner.os }}-${{ matrix.node-version }}-playwright-${{ steps.playwright-version.outputs.version }}'
+          # As a fallback, if the Playwright version has changed, try use the
+          # most recently cached version. There's a good chance that at least one
+          # of the browser binary versions haven't been updated, so Playwright can
+          # skip installing that in the next step.
+          # Note: When falling back to an old cache, `cache-hit` (used below)
+          # will be `false`. This allows us to restore the potentially out of
+          # date cache, but still let Playwright decide if it needs to download
+          # new binaries or not.
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-playwright-
+
+      # If the Playwright browser binaries weren't restored, we tell
+      # playwright to install everything for us.
+      - name: Install Playwright browsers with dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npm run playwright -- install --with-deps
+
+      # If the Playwright browser binaries were restored, we tell
+      # playwright to install just system deps.
+      - name: Install Playwright's dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npm run playwright -- install-deps
+
       - name: Test multiple browsers
         if: ${{ env.TEST_PREVIOUSLY_PASSED != 'true' }}
         run: |
-          npx playwright install --with-deps
           npm run sdk:test:multiBrowsers
 
       - name: Cache successful test results

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sdk:lint": "npm run sdk:lint:eslint && npm run sdk:lint:prettier",
     "sdk:lint:fix": "npm run sdk:lint:eslint:fix && npm run sdk:lint:prettier",
     "commitlint": "commitlint",
+    "playwright": "playwright",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -8,6 +8,6 @@ export default {
   nodeResolve: true,
   files: ['src/**/*.test.ts'],
   plugins: [vitePlugin()],
-  browsers: [playwrightLauncher({ product: 'chromium', concurrency: 5 })],
+  browsers: [playwrightLauncher({ product: 'chromium', concurrency: 1 })],
   filterBrowserLogs: removeViteLogging
 };


### PR DESCRIPTION
Devops suggested we should cache the browsers we install to :
* speed up our tests
* Avoid being rate-limited by the servers we are downloading these from.