### PR TITLE
add some badges to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+---
+  ![GitHub Release Date](https://img.shields.io/github/release-date/embrace-io/embrace-web-sdk)
+    ![GitHub commit activity](https://img.shields.io/github/commit-activity/t/embrace-io/embrace-web-sdk)
+    [![Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-orange)](./LICENSE.txt)
+    ![GitHub top language](https://img.shields.io/github/languages/top/embrace-io/embrace-web-sdk)
+    ![Build and tests status](https://github.com/embrace-io/embrace-web-sdk/actions/workflows/ci-nodejs.yml/badge.svg)
+---
+
 ## Publishing
 
 To publish a new version of the sdk, you need to run `npm publish`. It will create a clean build under `build` folder


### PR DESCRIPTION
this will generate some badges. Example

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/S215IBu9kfHXNs3PdXXg/77db36f7-ddc4-460e-84d1-07365a51e408.png)


Note that all of those saying "repo not found" are because our repo isn't public yet. The only badge I was trying to add here was actually the one about test coverage, but it seems like we would need to integrate with codecov (or some other provider) to do that or to do some manual work on where we store our coverage (which I am followinf up with devops separately here https://embrace-io.slack.com/archives/C2F256D9U/p1743547163691359)