### PR TITLE
fix: update package.lock files after renaming the package

### DIFF
--- a/demo/frontend/package-lock.json
+++ b/demo/frontend/package-lock.json
@@ -33,7 +33,7 @@
       }
     },
     "../..": {
-      "name": "@embraceio/embrace-web-sdk",
+      "name": "@embrace-io/web-sdk",
       "version": "0.0.10",
       "license": "Apache-2.0",
       "dependencies": {
@@ -55,9 +55,9 @@
         "@commitlint/config-conventional": "^19.8.0",
         "@eslint/js": "^9.23.0",
         "@remcovaes/web-test-runner-vite-plugin": "^1.2.2",
-        "@types/chai": "^5.2.0",
+        "@types/chai": "^5.2.1",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^22.13.16",
+        "@types/node": "^22.14.0",
         "@types/sinon": "^17.0.4",
         "@types/sinon-chai": "^4.0.0",
         "@web/test-runner": "^0.20.0",
@@ -92,7 +92,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.23.0",
-        "@types/node": "^22.13.16",
+        "@types/node": "^22.14.0",
         "eslint": "^9.23.0",
         "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-prettier": "^5.2.5",
@@ -4081,9 +4081,9 @@
         "@opentelemetry/sdk-trace-web": "1.30.0",
         "@opentelemetry/web-common": "0.57.0",
         "@remcovaes/web-test-runner-vite-plugin": "^1.2.2",
-        "@types/chai": "^5.2.0",
+        "@types/chai": "^5.2.1",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^22.13.16",
+        "@types/node": "^22.14.0",
         "@types/sinon": "^17.0.4",
         "@types/sinon-chai": "^4.0.0",
         "@web/test-runner": "^0.20.0",
@@ -4112,7 +4112,7 @@
       "requires": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.23.0",
-        "@types/node": "^22.13.16",
+        "@types/node": "^22.14.0",
         "commander": "^13.1.0",
         "eslint": "^9.23.0",
         "eslint-config-prettier": "^10.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@embraceio/embrace-web-sdk",
+  "name": "@embrace-io/web-sdk",
   "version": "0.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@embraceio/embrace-web-sdk",
+      "name": "@embrace-io/web-sdk",
       "version": "0.0.10",
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
Follow up to https://github.com/embrace-io/embrace-web-sdk/pull/179. We forgot to run npm install after the rename