### PR TITLE
chore: point sdk telemetry to prod embrace apis

### DIFF
--- a/src/exporters/EmbraceLogExporter/EmbraceLogExporter.test.ts
+++ b/src/exporters/EmbraceLogExporter/EmbraceLogExporter.test.ts
@@ -89,7 +89,7 @@ describe('EmbraceLogExporter', () => {
       firefoxWebkitContentLength,
     ]);
     expect(fakeFetchGetUrl()).to.equal(
-      'https://a-testAppID.data.stg.emb-eng.com/v2/logs'
+      'https://a-testAppID.data.emb-api.com/v2/logs'
     );
     const body = fakeFetchGetBody();
     void expect(body).not.to.be.null;

--- a/src/exporters/EmbraceTraceExporter/EmbraceTraceExporter.test.ts
+++ b/src/exporters/EmbraceTraceExporter/EmbraceTraceExporter.test.ts
@@ -77,7 +77,7 @@ describe('EmbraceTraceExporter', () => {
       firefoxWebkitContentLength,
     ]);
     expect(fakeFetchGetUrl()).to.equal(
-      'https://a-testAppID.data.stg.emb-eng.com/v2/spans'
+      'https://a-testAppID.data.emb-api.com/v2/spans'
     );
     // assert that the decompressed and decoded body is the expected one
     const body = fakeFetchGetBody();

--- a/src/exporters/utils.test.ts
+++ b/src/exporters/utils.test.ts
@@ -18,7 +18,7 @@ describe('utils', () => {
     it('should return correct data URL', () => {
       const appID = 'testAppID';
       const url = getDataURL(appID);
-      expect(url).to.equal(`https://a-${appID}.data.stg.emb-eng.com`);
+      expect(url).to.equal(`https://a-${appID}.data.emb-api.com`);
     });
   });
 });

--- a/src/exporters/utils.ts
+++ b/src/exporters/utils.ts
@@ -6,4 +6,4 @@ export const getEmbraceHeaders = (
   'X-EM-DID': userID,
 });
 export const getDataURL = (appID: string): string =>
-  `https://a-${appID}.data.stg.emb-eng.com`;
+  `https://a-${appID}.data.emb-api.com`;


### PR DESCRIPTION
(AI generated)
### TL;DR

Updated the Embrace data endpoint URL in the SDK.

### What changed?

Changed the Embrace data endpoint URL from `data.stg.emb-eng.com` to `data.emb-api.com` in the following locations:
- `getDataURL` utility function
- Tests for EmbraceLogExporter
- Tests for EmbraceTraceExporter

