### PR TITLE
chore: update demo appID and remove old symbol upload token

### DIFF
--- a/demo/frontend/package.json
+++ b/demo/frontend/package.json
@@ -10,8 +10,8 @@
     "demo:frontend:dev": "vite",
     "demo:frontend:compile": "tsc -b && vite build",
     "demo:frontend:lint": "eslint .",
-    "demo:frontend:upload:sourcemaps": "web-cli upload -t 9819ef05be634fb39720d5f7dffb6404 -a pa6hp --app-version 0.0.1",
-    "demo:frontend:upload:sourcemaps:dry": "web-cli upload -d -t 9819ef05be634fb39720d5f7dffb6404 -a pa6hp --app-version 0.0.1",
+    "demo:frontend:upload:sourcemaps": "web-cli upload -a 5przi --app-version 0.0.1",
+    "demo:frontend:upload:sourcemaps:dry": "web-cli upload -d -a 5przi --app-version 0.0.1",
     "demo:frontend:preview": "vite preview"
   },
   "dependencies": {

--- a/demo/frontend/scripts/runDemo.sh
+++ b/demo/frontend/scripts/runDemo.sh
@@ -17,7 +17,7 @@ npm run cli:compile
 cd ../demo/frontend
 rm -rf node_modules
 npm ci
-sed 's/VITE_APP_ID=your_app_id/VITE_APP_ID=pa6hp/g' .env.template > .env
+sed 's/VITE_APP_ID=your_app_id/VITE_APP_ID=5przi/g' .env.template > .env
 rm -rf build dist
 npm run demo:frontend:compile
 #find the path for the generated bundle


### PR DESCRIPTION
### TL;DR

Updated app ID from `pa6hp` to `5przi` in frontend demo configuration.

### What changed?

- Updated the app ID from `pa6hp` to `5przi` in `package.json` for sourcemap upload scripts
- Removed the token parameter (`-t 9819ef05be634fb39720d5f7dffb6404`) from the sourcemap upload commands. THIS WASN'T A VAID TOKEN ANYWAYS, DON'T WORRY ABOUT SECURITY EXPOSURE HERE 😉 
- Updated the app ID in `runDemo.sh` script to use the new app ID when generating the `.env` file
