### PR TITLE
fix: github drafter not working from a public repo

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -5,6 +5,36 @@ on:
     branches: [main]
 
 jobs:
-  release-drafter:
-    uses: embrace-io/actions/.github/workflows/release-drafter.yml@master
-    secrets: inherit
+  next-release:
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate next version
+        id: calver
+        run: |
+          today=$(date +%Y%m%d)
+          release=1
+
+          while [ ! -z $(git tag -l ${today}.${release}) ]; do
+            release=$((release+1))
+          done
+
+          next_version="${today}.${release}"
+          echo "version=${next_version}" >> $GITHUB_OUTPUT
+
+      - uses: embrace-io/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: true
+          name: ${{ steps.calver.outputs.version }}
+          tag: ${{ steps.calver.outputs.version }}
+          version: ${{ steps.calver.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -29,7 +29,7 @@ jobs:
           next_version="${today}.${release}"
           echo "version=${next_version}" >> $GITHUB_OUTPUT
 
-      - uses: embrace-io/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
           config-name: release-drafter.yml
           disable-autolabeler: true


### PR DESCRIPTION
Our release drafter action stopped working once we made our repo public. I am guessing this may be due to the conflict of permissions between the public repo and the private action. Here I am copying the setup from https://github.com/embrace-io/embrace-docs which is also public. I will double-check with devops to confirm this approach before merging