### PR TITLE
chore: update cicd worflow to publish to npm instead of nexus

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -349,14 +349,12 @@ jobs:
           cache: npm
 
       - name: Install NPM dependencies
-        env:
-          NEXUS_NPM_TOKEN: ${{ secrets.NEXUS_NPM_TOKEN }}
         run: |
-          npm config set @embrace-io:registry https://repo.embrace.io/repository/web-testing/
-          npm config set //repo.embrace.io/repository/web-testing/:_authToken: "$NEXUS_NPM_TOKEN"
           npm ci
 
       - name: Run 'npm publish'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
           npm publish
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![codecov](https://codecov.io/gh/embrace-io/embrace-web-sdk/graph/badge.svg?token=88948NPGPI)](https://codecov.io/gh/embrace-io/embrace-web-sdk)
 ![GitHub Release Date](https://img.shields.io/github/release-date/embrace-io/embrace-web-sdk)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/t/embrace-io/embrace-web-sdk)
@@ -6,15 +5,10 @@
 ![GitHub top language](https://img.shields.io/github/languages/top/embrace-io/embrace-web-sdk)
 ![Build and tests status](https://github.com/embrace-io/embrace-web-sdk/actions/workflows/ci-nodejs.yml/badge.svg)
 
-
 ## Publishing
 
 To publish a new version of the sdk, you need to run `npm publish`. It will create a clean build under `build` folder
 including ESM modules as .js files and .d.ts type definition, it will then publish the package to an npm repo.
-Note: there is no public npm registry yet, so you can't publish the package to npmjs.com.
-For development, login to https://repo.embrace.io/repository/web-testing/ and publish the package there.
-For login in, you can run
-`npm login --scope=@embraceio --registry=https://repo.embrace.io/repository/web-testing/`
 
 ## Testing
 
@@ -28,8 +22,6 @@ TODO: add nyc for coverage
 TODO:
 
 * Add Lerna to manage testing across packages (demo, sdk, cli),
-* Publish to npm,
 * Publish typedoc doc
-* Add CI/CD pipeline
 * Add amannn/action-semantic-pull-request@v5
 * Add semantic-release

--- a/cli/package.json
+++ b/cli/package.json
@@ -9,6 +9,9 @@
   "module": "build/index.js",
   "esnext": "build/index.js",
   "types": "build/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prepublishOnly": "npm run cli:compile:clean & npm run cli:compile",
     "cli:test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
   "types": "build/src/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prepublishOnly": "npm run sdk:compile:clean & npm run sdk:compile",
     "sdk:docs": "typedoc --readme none && touch docs/.nojekyll",


### PR DESCRIPTION
### TL;DR

Update npm publishing configuration to use the public npm registry instead of the private Nexus repository.

### What changed?

- Removed Nexus NPM token configuration from the CI workflow
- Added `NODE_AUTH_TOKEN` environment variable for npm publish
- Added `"publishConfig": { "access": "public" }` to both the main package.json and cli/package.json
- Updated README.md to remove references to the private Nexus repository
- Removed outdated TODOs from README.md related to npm publishing and CI/CD pipeline
