### PR TITLE
chore: add more metadata to the cli package for publishing

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -27,12 +27,30 @@
     "LICENSE",
     "README.md"
   ],
+  "bugs": {
+    "url": "https://github.com/embrace-io/embrace-web-sdk/issues",
+    "email": "support@embrace.io"
+  },
   "exports": {
     "import": "./build/index.js",
     "default": "./build/index.js"
   },
+  "homepage": "https://github.com/embrace-io/embrace-web-sdk",
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embrace-io/embrace-web-sdk.git"
+  },
+  "keywords": [
+    "embrace",
+    "web",
+    "tracking",
+    "observability",
+    "instrumentation",
+    "telemetry",
+    "cli"
+  ],
   "dependencies": {
     "commander": "^13.1.0"
   },

--- a/cli/package.json
+++ b/cli/package.json
@@ -49,6 +49,7 @@
     "observability",
     "instrumentation",
     "telemetry",
+    "otel",
     "cli"
   ],
   "dependencies": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -40,7 +40,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/embrace-io/embrace-web-sdk.git"
+    "url": "git+https://github.com/embrace-io/embrace-web-sdk.git",
+    "directory": "cli"
   },
   "keywords": [
     "embrace",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "web",
     "tracking",
     "observability",
+    "otel",
     "instrumentation",
     "telemetry"
   ],


### PR DESCRIPTION
### TL;DR

Added package metadata to the CLI package.json file.

### What changed?

Enhanced the CLI package.json file with additional metadata:
- Added bugs reporting information with GitHub issues URL and support email
- Added homepage URL pointing to the GitHub repository
- Added repository information with git URL
- Added relevant keywords for better discoverability (embrace, web, tracking, observability, instrumentation, telemetry, cli)
