### PR TITLE
fix: update visibility from published sdk in npm to be public

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -361,7 +361,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: |
-          npm publish
+          npm publish --access public
 
   # not used yet, there are no "production" releases
   report-release-slack:


### PR DESCRIPTION
### TL;DR

Added `--access public` flag to npm publish command in CI workflow.

### What changed?

Modified the npm publish command in the CI workflow to include the `--access public` flag, ensuring packages are published with public access on npm.
