### PR TITLE
fix: update publishing token for npm, using newly created embrace-ci user's token

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -359,7 +359,7 @@ jobs:
 
       - name: Run 'npm publish'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
         run: |
           npm publish --access public
 


### PR DESCRIPTION
### TL;DR

Updated the npm publish authentication token in the CI workflow.

### What changed?

Changed the environment variable used for npm authentication from `secrets.NODE_AUTH_TOKEN` to `secrets.NPMJS_TOKEN` in the GitHub Actions workflow file.

see (internal) slack discussion https://embrace-io.slack.com/archives/C2F256D9U/p1744043199964869?thread_ts=1737747735.789779&cid=C2F256D9U