### PR TITLE
chore: add provenance linking between npmjs published package and github build

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -338,6 +338,8 @@ jobs:
       - test-multiple-browsers
       - lint
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     timeout-minutes: 10
     if: ${{ needs.environment.outputs.name == 'production' }}
     strategy:
@@ -361,7 +363,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
         run: |
-          npm publish --access public
+          npm publish --provenance --access public
 
   # not used yet, there are no "production" releases
   report-release-slack:


### PR DESCRIPTION
### TL;DR

Enable npm package provenance for published packages.

### What changed?

- Added `id-token: write` permission to the publish job in the CI workflow
- Updated the npm publish command to include the `--provenance` flag

### How to test?

1. Verify that the CI workflow completes successfully when publishing a package
2. Check that the published package on npm includes provenance information in its metadata

### Why make this change?

Adding npm provenance provides supply chain security benefits by creating verifiable links between packages and their source code/build environments. This helps users verify that packages were built from the expected source code and through the intended CI process, reducing the risk of compromised packages.