### PR TITLE
fix: add missing registry to our publishing GA

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -354,6 +354,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install NPM dependencies
         run: |


### PR DESCRIPTION
Add `registry-url: 'https://registry.npmjs.org'` to our github action. I completely missed it in the previous version. See [docs](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry)
Specifically the note about 

```
Please note that you need to set the registry-url to https://registry.npmjs.org/ in setup-node to properly configure your credentials.
```