### PR TITLE
chore: validate sdk and cli versions are always in sync

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,7 +89,7 @@ export default tseslint.config({
       [
         {
           regex: `SDK_VERSION = '(?!${sdkPackageInfo.version}).*'`,
-          message: `SDK_VERSION version mismatch. It should the package,json version ${sdkPackageInfo.version}.`,
+          message: `SDK_VERSION version mismatch. It should match the package.json version ${sdkPackageInfo.version}.`,
           replacement: `SDK_VERSION = '${sdkPackageInfo.version}'`,
         },
         {
@@ -97,8 +97,7 @@ export default tseslint.config({
           message: `CLI_VERSION version mismatch. It should always match the one listed in both package.json (${sdkPackageInfo.version}) and cli/package.json (${cliPackageInfo.version}) and those 2 should be in sync.`,
           replacement: `CLI_VERSION = '${cliPackageInfo.version}'`,
         },
-        // TODO we validate CLI_VERSION against both package.json and cli/package.json as a way to make sure the 2 package files are in sync.
-        // We should create a custom eslint rule that reads one package and compare it to the other directly.
+        // we validate the version in the cli version against the sdk version, to make sure both the sdk and cli versions are in sync
         {
           regex: `CLI_VERSION = '(?!${sdkPackageInfo.version}).*'`,
           message: `CLI_VERSION version mismatch. It should always match the one listed in both package.json (${sdkPackageInfo.version}) and cli/package.json (${cliPackageInfo.version}) and those 2 should be in sync.`,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,11 +89,19 @@ export default tseslint.config({
       [
         {
           regex: `SDK_VERSION = '(?!${sdkPackageInfo.version}).*'`,
+          message: `SDK_VERSION version mismatch. It should the package,json version ${sdkPackageInfo.version}.`,
           replacement: `SDK_VERSION = '${sdkPackageInfo.version}'`,
         },
         {
           regex: `CLI_VERSION = '(?!${cliPackageInfo.version}).*'`,
+          message: `CLI_VERSION version mismatch. It should always match the one listed in both package.json (${sdkPackageInfo.version}) and cli/package.json (${cliPackageInfo.version}) and those 2 should be in sync.`,
           replacement: `CLI_VERSION = '${cliPackageInfo.version}'`,
+        },
+        // TODO we validate CLI_VERSION against both package.json and cli/package.json as a way to make sure the 2 package files are in sync.
+        // We should create a custom eslint rule that reads one package and compare it to the other directly.
+        {
+          regex: `CLI_VERSION = '(?!${sdkPackageInfo.version}).*'`,
+          message: `CLI_VERSION version mismatch. It should always match the one listed in both package.json (${sdkPackageInfo.version}) and cli/package.json (${cliPackageInfo.version}) and those 2 should be in sync.`,
         },
       ],
     ],
@@ -101,10 +109,7 @@ export default tseslint.config({
   languageOptions: {
     globals: globals.browser,
     parserOptions: {
-      project: [
-        './tsconfig.test.json',
-        './cli/tsconfig.json',
-      ],
+      project: ['./tsconfig.test.json', './cli/tsconfig.json'],
       tsconfigRootDir: import.meta.dirname,
     },
   },


### PR DESCRIPTION
### TL;DR

Enhanced ESLint configuration with better version mismatch detection and error messages.

### What changed?

- Added descriptive error messages for SDK_VERSION and CLI_VERSION mismatches
- Added a new validation rule to ensure CLI_VERSION matches the SDK version in package.json
- Added a TODO comment about creating a custom ESLint rule to directly compare package versions
- Reformatted the project array in parserOptions for better readability