### PR TITLE
EMBR-7257 - Implement session breadcrumb API

### DIFF
--- a/src/api-sessions/api/SessionAPI/SessionAPI.test.ts
+++ b/src/api-sessions/api/SessionAPI/SessionAPI.test.ts
@@ -25,6 +25,7 @@ describe('SessionAPI', () => {
       startSessionSpan: sinon.stub(),
       endSessionSpan: sinon.stub(),
       endSessionSpanInternal: sinon.stub(),
+      addBreadcrumb: sinon.stub(),
     };
     sessionAPI.setGlobalSessionManager(sessionManager);
     const result = sessionAPI.getSpanSessionManager();

--- a/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.test.ts
+++ b/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.test.ts
@@ -42,4 +42,10 @@ describe('NoOpSpanSessionManager', () => {
       noOpSpanSessionManager.endSessionSpanInternal();
     }).to.not.throw();
   });
+
+  it('should do nothing for addBreadcrumb', () => {
+    expect(() => {
+      noOpSpanSessionManager.addBreadcrumb('name');
+    }).to.not.throw();
+  });
 });

--- a/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.ts
+++ b/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.ts
@@ -23,4 +23,8 @@ export class NoOpSpanSessionManager implements SpanSessionManager {
   public startSessionSpan(): void {
     // do nothing.
   }
+
+  public addBreadcrumb(_name: string): void {
+    // do nothing.
+  }
 }

--- a/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.test.ts
+++ b/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.test.ts
@@ -22,6 +22,7 @@ describe('ProxySpanSessionManager', () => {
       startSessionSpan: sinon.stub(),
       endSessionSpan: sinon.stub(),
       endSessionSpanInternal: sinon.stub(),
+      addBreadcrumb: sinon.stub(),
     };
   });
 
@@ -80,6 +81,14 @@ describe('ProxySpanSessionManager', () => {
     proxySpanSessionManager.endSessionSpanInternal(reason);
     expect(mockDelegate.endSessionSpanInternal).to.have.been.calledOnceWith(
       reason
+    );
+  });
+
+  it('should delegate addBreadcrumb to the delegate', () => {
+    proxySpanSessionManager.setDelegate(mockDelegate);
+    proxySpanSessionManager.addBreadcrumb('some breadcrumb');
+    expect(mockDelegate.addBreadcrumb).to.have.been.calledOnceWith(
+      'some breadcrumb'
     );
   });
 });

--- a/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.ts
+++ b/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.ts
@@ -38,4 +38,8 @@ export class ProxySpanSessionManager implements SpanSessionManager {
   public startSessionSpan() {
     this.getDelegate().startSessionSpan();
   }
+
+  public addBreadcrumb(name: string): void {
+    this.getDelegate().addBreadcrumb(name);
+  }
 }

--- a/src/api-sessions/manager/types.ts
+++ b/src/api-sessions/manager/types.ts
@@ -11,6 +11,8 @@ export interface SpanSessionManager {
 
   endSessionSpan: () => void;
 
+  addBreadcrumb: (name: string) => void;
+
   // todo move this to another class SpanSessionManagerInternal that is only accessible from within our code, but expose the external one without the method to the users.
   endSessionSpanInternal: (reason: ReasonSessionEnded) => void;
 }

--- a/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
+++ b/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
@@ -96,4 +96,34 @@ describe('EmbraceSpanSessionManager', () => {
       'trying to end a session, but there is no session in progress. This is a no-op.'
     );
   });
+
+  it('should not fail if trying to add breadcrumb to non active session', () => {
+    manager.addBreadcrumb('some breadcrumb');
+
+    expect(diag.getDebugLogs()).to.have.lengthOf(1);
+    expect(diag.getDebugLogs()[0]).to.equal(
+      'trying to add breadcrumb to a session, but there is no session in progress. This is a no-op.'
+    );
+  });
+
+  it('should add breadcrumb to session span', () => {
+    manager.startSessionSpan();
+    void expect(manager.getSessionSpan()).to.not.be.null;
+    void expect(manager.getSessionId()).to.not.be.null;
+    void expect(manager.getSessionStartTime()).to.not.be.null;
+
+    manager.addBreadcrumb('some breadcrumb');
+    manager.endSessionSpan();
+
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(1);
+
+    expect(sessionSpan.events[0].name).to.equal('emb-breadcrumb');
+    expect(sessionSpan.events[0].attributes).to.have.property(
+      'message',
+      'some breadcrumb'
+    );
+  });
 });

--- a/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
+++ b/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
@@ -87,4 +87,20 @@ export class EmbraceSpanSessionManager implements SpanSessionManager {
       },
     });
   }
+
+  public addBreadcrumb(name: string) {
+    if (!this._sessionSpan) {
+      this._diag.debug(
+        'trying to add breadcrumb to a session, but there is no session in progress. This is a no-op.'
+      );
+      return;
+    }
+    this._sessionSpan.addEvent(
+      'emb-breadcrumb',
+      {
+        message: name,
+      },
+      this._perf.getNowMillis()
+    );
+  }
 }


### PR DESCRIPTION
Support to do:


```typescript
import { session } from '@embrace-io/web-sdk';

session.addBreadcrumb("something happened");
```
