### PR TITLE
EMBR-7259 - Create high level API that allows calling methods without getting the manager

### DIFF
--- a/src/api-logs/api/LogAPI/LogAPI.test.ts
+++ b/src/api-logs/api/LogAPI/LogAPI.test.ts
@@ -1,12 +1,22 @@
-import { expect } from 'chai';
+import * as chai from 'chai';
 import * as sinon from 'sinon';
 import { type LogManager, ProxyLogManager } from '../../manager/index.js';
 import { LogAPI } from './LogAPI.js';
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+const { expect } = chai;
 
 afterEach(() => {
   sinon.restore();
 });
 describe('LogAPI', () => {
+  let logAPI: LogAPI;
+
+  beforeEach(() => {
+    logAPI = LogAPI.getInstance();
+  });
+
   it('should return the same instance', () => {
     const instance1 = LogAPI.getInstance();
     const instance2 = LogAPI.getInstance();
@@ -18,10 +28,37 @@ describe('LogAPI', () => {
     const logManager: LogManager = {
       // Mock implementation of LogManager
       message: sinon.stub(),
+      logException: sinon.stub(),
     };
     logAPI.setGlobalLogManager(logManager);
     const result = logAPI.getLogManager();
     expect(result).to.be.instanceOf(ProxyLogManager);
     expect((result as ProxyLogManager).getDelegate()).to.equal(logManager);
+  });
+
+  it('should forward calls to the log manager', () => {
+    const mockLogManager: LogManager = {
+      // Mock implementation of LogManager
+      message: sinon.stub(),
+      logException: sinon.stub(),
+    };
+    logAPI.setGlobalLogManager(mockLogManager);
+
+    logAPI.message('This is an info log', 'info', { key: 'value' });
+    expect(mockLogManager.message).to.have.been.calledOnceWith(
+      'This is an info log',
+      'info',
+      { key: 'value' }
+    );
+
+    const ts = Date.now();
+    const err = new Error();
+    logAPI.logException(ts, err, true, { key: 'value' });
+    expect(mockLogManager.logException).to.have.been.calledOnceWith(
+      ts,
+      err,
+      true,
+      { key: 'value' }
+    );
   });
 });

--- a/src/api-logs/api/LogAPI/LogAPI.ts
+++ b/src/api-logs/api/LogAPI/LogAPI.ts
@@ -1,7 +1,9 @@
-import { ProxyLogManager, type LogManager } from '../../manager/index.js';
+import type { AttributeValue } from '@opentelemetry/api';
+import { type LogManager, ProxyLogManager } from '../../manager/index.js';
+import type { LogSeverity } from '../../manager/types.js';
 import type { LogAPIArgs } from './types.js';
 
-export class LogAPI {
+export class LogAPI implements LogManager {
   private static _instance?: LogAPI;
   private readonly _proxyLogManager;
 
@@ -25,5 +27,23 @@ export class LogAPI {
 
   public setGlobalLogManager(logManager: LogManager): void {
     this._proxyLogManager.setDelegate(logManager);
+  }
+
+  public message(
+    message: string,
+    level: LogSeverity,
+    attributes?: Record<string, AttributeValue | undefined>,
+    includeStacktrace?: boolean
+  ) {
+    this.getLogManager().message(message, level, attributes, includeStacktrace);
+  }
+
+  public logException(
+    timestamp: number,
+    error: Error,
+    handled: boolean,
+    attributes?: Record<string, AttributeValue | undefined>
+  ) {
+    this.getLogManager().logException(timestamp, error, handled, attributes);
   }
 }

--- a/src/api-sessions/api/SessionAPI/SessionAPI.test.ts
+++ b/src/api-sessions/api/SessionAPI/SessionAPI.test.ts
@@ -1,20 +1,33 @@
-import { expect } from 'chai';
+import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {
   ProxySpanSessionManager,
   type SpanSessionManager,
 } from '../../manager/index.js';
 import { SessionAPI } from './SessionAPI.js';
+import type { HrTime, Span } from '@opentelemetry/api';
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+const { expect } = chai;
 
 afterEach(() => {
   sinon.restore();
 });
+
 describe('SessionAPI', () => {
+  let sessionAPI: SessionAPI;
+
+  beforeEach(() => {
+    sessionAPI = SessionAPI.getInstance();
+  });
+
   it('should return the same instance', () => {
     const instance1 = SessionAPI.getInstance();
     const instance2 = SessionAPI.getInstance();
     expect(instance1).to.equal(instance2);
   });
+
   it('should return the global session manager', () => {
     const sessionAPI = SessionAPI.getInstance();
     const sessionManager: SpanSessionManager = {
@@ -33,5 +46,45 @@ describe('SessionAPI', () => {
     expect((result as ProxySpanSessionManager).getDelegate()).to.equal(
       sessionManager
     );
+  });
+
+  it('should forward calls to the session manager', () => {
+    const mockSpanSessionManager: SpanSessionManager = {
+      getSessionId: sinon.stub().returns('mockSessionId'),
+      getSessionSpan: sinon.stub().returns({} as Span),
+      getSessionStartTime: sinon.stub().returns([0, 0] as HrTime),
+      startSessionSpan: sinon.stub(),
+      endSessionSpan: sinon.stub(),
+      endSessionSpanInternal: sinon.stub(),
+      addBreadcrumb: sinon.stub(),
+    };
+    sessionAPI.setGlobalSessionManager(mockSpanSessionManager);
+
+    void expect(sessionAPI.getSessionId()).to.not.be.null;
+    void expect(mockSpanSessionManager.getSessionId).to.have.been.calledOnce;
+
+    void expect(sessionAPI.getSessionSpan()).to.not.be.null;
+    void expect(mockSpanSessionManager.getSessionSpan).to.have.been.calledOnce;
+
+    void expect(sessionAPI.getSessionStartTime()).to.not.be.null;
+    void expect(mockSpanSessionManager.getSessionStartTime).to.have.been
+      .calledOnce;
+
+    sessionAPI.startSessionSpan();
+    void expect(mockSpanSessionManager.startSessionSpan).to.have.been
+      .calledOnce;
+
+    sessionAPI.endSessionSpan();
+    void expect(mockSpanSessionManager.endSessionSpan).to.have.been.calledOnce;
+
+    sessionAPI.endSessionSpanInternal('timer');
+    void expect(
+      mockSpanSessionManager.endSessionSpanInternal
+    ).to.have.been.calledOnceWith('timer');
+
+    sessionAPI.addBreadcrumb('br-name');
+    void expect(
+      mockSpanSessionManager.addBreadcrumb
+    ).to.have.been.calledOnceWith('br-name');
   });
 });

--- a/src/api-sessions/api/SessionAPI/SessionAPI.ts
+++ b/src/api-sessions/api/SessionAPI/SessionAPI.ts
@@ -3,8 +3,10 @@ import {
   type SpanSessionManager,
 } from '../../manager/index.js';
 import type { SessionAPIArgs } from './types.js';
+import type { ReasonSessionEnded } from '../../manager/types.js';
+import type { HrTime } from '@opentelemetry/api';
 
-export class SessionAPI {
+export class SessionAPI implements SpanSessionManager {
   private static _instance?: SessionAPI;
   private readonly _proxySpanSessionManager;
 
@@ -28,5 +30,33 @@ export class SessionAPI {
 
   public setGlobalSessionManager(sessionManager: SpanSessionManager): void {
     this._proxySpanSessionManager.setDelegate(sessionManager);
+  }
+
+  public endSessionSpan() {
+    this.getSpanSessionManager().endSessionSpan();
+  }
+
+  public endSessionSpanInternal(reason: ReasonSessionEnded) {
+    this.getSpanSessionManager().endSessionSpanInternal(reason);
+  }
+
+  public getSessionId(): string | null {
+    return this.getSpanSessionManager().getSessionId();
+  }
+
+  public getSessionSpan() {
+    return this.getSpanSessionManager().getSessionSpan();
+  }
+
+  public getSessionStartTime(): HrTime | null {
+    return this.getSpanSessionManager().getSessionStartTime();
+  }
+
+  public startSessionSpan() {
+    this.getSpanSessionManager().startSessionSpan();
+  }
+
+  public addBreadcrumb(name: string): void {
+    this.getSpanSessionManager().addBreadcrumb(name);
   }
 }

--- a/src/api-traces/api/TraceAPI/TraceAPI.test.ts
+++ b/src/api-traces/api/TraceAPI/TraceAPI.test.ts
@@ -1,18 +1,30 @@
-import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { ProxyTraceManager, type TraceManager } from '../../manager/index.js';
-import { TraceAPI } from './TraceAPI.js';
 import type { Span } from '@opentelemetry/api';
+import * as chai from 'chai';
+import sinonChai from 'sinon-chai';
+import { TraceAPI } from './TraceAPI.js';
+
+chai.use(sinonChai);
+const { expect } = chai;
 
 afterEach(() => {
   sinon.restore();
 });
+
 describe('TraceAPI', () => {
+  let traceAPI: TraceAPI;
+
+  beforeEach(() => {
+    traceAPI = TraceAPI.getInstance();
+  });
+
   it('should return the same instance', () => {
     const instance1 = TraceAPI.getInstance();
     const instance2 = TraceAPI.getInstance();
     expect(instance1).to.equal(instance2);
   });
+
   it('should return the global trace manager', () => {
     const traceAPI = TraceAPI.getInstance();
     const traceManager: TraceManager = {
@@ -23,5 +35,18 @@ describe('TraceAPI', () => {
     const result = traceAPI.getTraceManager();
     expect(result).to.be.instanceOf(ProxyTraceManager);
     expect((result as ProxyTraceManager).getDelegate()).to.equal(traceManager);
+  });
+
+  it('should forward calls to the trace manager', () => {
+    const mockTraceManager: TraceManager = {
+      // Mock implementation of TraceManager
+      startPerformanceSpan: sinon.stub().returns({} as Span),
+    };
+    traceAPI.setGlobalTraceManager(mockTraceManager);
+
+    traceAPI.startPerformanceSpan('span-name');
+    void expect(
+      mockTraceManager.startPerformanceSpan
+    ).to.have.been.calledOnceWith('span-name');
   });
 });

--- a/src/api-traces/api/TraceAPI/TraceAPI.ts
+++ b/src/api-traces/api/TraceAPI/TraceAPI.ts
@@ -1,7 +1,8 @@
+import type { Span, SpanOptions } from '@opentelemetry/api';
 import { ProxyTraceManager, type TraceManager } from '../../manager/index.js';
 import type { TraceAPIArgs } from './types.js';
 
-export class TraceAPI {
+export class TraceAPI implements TraceManager {
   private static _instance?: TraceAPI;
   private readonly _proxyTraceManager;
 
@@ -25,5 +26,12 @@ export class TraceAPI {
 
   public setGlobalTraceManager(traceManager: TraceManager): void {
     this._proxyTraceManager.setDelegate(traceManager);
+  }
+
+  public startPerformanceSpan(
+    name: string,
+    options?: SpanOptions
+  ): Span | null {
+    return this.getTraceManager().startPerformanceSpan(name, options);
   }
 }

--- a/src/api-users/api/UserAPI/UserAPI.test.ts
+++ b/src/api-users/api/UserAPI/UserAPI.test.ts
@@ -1,8 +1,15 @@
-import { expect } from 'chai';
+import * as chai from 'chai';
 import * as sinon from 'sinon';
 import type { UserManager } from '../../manager/index.js';
-import { ProxyUserManager } from '../../manager/index.js';
+import {
+  KEY_ENDUSER_PSEUDO_ID,
+  ProxyUserManager,
+} from '../../manager/index.js';
 import { UserAPI } from './UserAPI.js';
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+const { expect } = chai;
 
 describe('UserAPI', () => {
   let userAPI: UserAPI;
@@ -39,5 +46,25 @@ describe('UserAPI', () => {
     expect((userManager as ProxyUserManager).getDelegate()).to.equal(
       mockUserManager
     );
+  });
+
+  it('should forward calls to the user manager', () => {
+    const mockUserManager: UserManager = {
+      // Mock implementation of UserManager
+      getUser: sinon.stub().returns({ id: 'mockUserId' }),
+      setUser: sinon.stub(),
+      clearUser: sinon.stub(),
+    };
+    userAPI.setGlobalUserManager(mockUserManager);
+
+    void expect(userAPI.getUser()).to.not.be.null;
+    void expect(mockUserManager.getUser).to.have.been.calledOnce;
+
+    const user = { [KEY_ENDUSER_PSEUDO_ID]: 'newUserId' };
+    userAPI.setUser(user);
+    expect(mockUserManager.setUser).to.have.been.calledOnceWith(user);
+
+    userAPI.clearUser();
+    void expect(mockUserManager.clearUser).to.have.been.calledOnce;
   });
 });

--- a/src/api-users/api/UserAPI/UserAPI.ts
+++ b/src/api-users/api/UserAPI/UserAPI.ts
@@ -1,7 +1,8 @@
 import { ProxyUserManager, type UserManager } from '../../manager/index.js';
 import type { UserAPIArgs } from './types.js';
+import type { User } from '../../manager/types.js';
 
-export class UserAPI {
+export class UserAPI implements UserManager {
   private static _instance?: UserAPI;
   private readonly _proxyUserManager;
 
@@ -25,5 +26,17 @@ export class UserAPI {
 
   public setGlobalUserManager(userManager: UserManager): void {
     this._proxyUserManager.setDelegate(userManager);
+  }
+
+  public clearUser(): void {
+    this.getUserManager().clearUser();
+  }
+
+  public getUser(): User | null {
+    return this.getUserManager().getUser();
+  }
+
+  public setUser(user: User): void {
+    this.getUserManager().setUser(user);
   }
 }


### PR DESCRIPTION
This should allow us to do things like:

```
import { session } from '@embrace-io/web-sdk';

session.addBreadcrumb("something happened");
```
