### PR TITLE
ci: adjust github releases workflow to match sem ver

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,15 +1,65 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
 categories:
-  - title: 'Changes'
-  - title: 'Dependencies'
+  - title: '⚠️ BREAKING CHANGES'
+    collapse-after: 5
+    labels:
+      - 'breaking'
+  - title: '🤖️ Dependencies'
     collapse-after: 5
     labels:
       - 'dependencies'
+  - title: '🧰 Maintenance'
+    collapse-after: 5
+    labels:
+      - 'maintenance'
+  - title: '🐛 Bug Fixes'
+    collapse-after: 5
+    labels:
+      - 'fix'
+  - title: '🚀 Features'
+    collapse-after: 5
+    labels:
+      - 'feat'
 
-version-template: $MAJOR.$MINOR
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+
+autolabeler:
+  - label: 'maintenance'
+    title:
+      - '/(EMBR-[0-9]+\s+)(build|ci|docs|style|refactor|perf|test|chore).*/'
+  - label: 'fix'
+    title:
+      - '/(EMBR-[0-9]+\s+)(fix|revert).*/'
+  - label: 'feat'
+    title:
+      - '/(EMBR-[0-9]+\s+)(feat).*/'
+  - label: 'major'
+    body:
+      - '/(BREAKING CHANGE)/'
+  - label: 'minor'
+    title: # SAME AS 'feat'
+      - '/(EMBR-[0-9]+\s+)(feat).*/'
+  - label: 'patch'
+    title: # SAME AS 'fix or maintenance'
+      - '/((EMBR-[0-9]+\s+)(fix|revert|build|ci|docs|style|refactor|perf|test|chore).*/'
 
 template: |
   ## What's Changed
 
   $CHANGES
+
+  $CONTRIBUTORS
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -3,38 +3,24 @@ name: Draft Release
 on:
   push:
     branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
 
 jobs:
   next-release:
     permissions:
       contents: write
-      pull-requests: read
+      # write permission is required for autolabeler
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Generate next version
-        id: calver
-        run: |
-          today=$(date +%Y%m%d)
-          release=1
-
-          while [ ! -z $(git tag -l ${today}.${release}) ]; do
-            release=$((release+1))
-          done
-
-          next_version="${today}.${release}"
-          echo "version=${next_version}" >> $GITHUB_OUTPUT
-
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
-        with:
-          config-name: release-drafter.yml
-          disable-autolabeler: true
-          name: ${{ steps.calver.outputs.version }}
-          tag: ${{ steps.calver.outputs.version }}
-          version: ${{ steps.calver.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -58,14 +58,12 @@ npm run sdk:test:watch
 
 New releases of the SDK are triggered through [Github Releases](https://github.com/embrace-io/embrace-web-sdk/releases).
 Commits merged to main are added to the next Draft release. Once these are ready the Draft can be set to Published to
-trigger a publish of the SDK packages to NPM. Prior to publishing there should be at least one commit on main since the
-last release that:
-* Bumps the version in package.json
-* Makes sure that same version is reflected in
-  * cli/package.json
-  * cli/src/constants.ts
-  * src/resources/constants/index.ts
-* Run `npm i` in the following locations:
-  * ./
-  * cli/
-  * demo/frontend/
+trigger a publish of the SDK packages to NPM.
+
+Note: the level of the version bump (major, minor, patch) is determined by the type of changes made to the SDK since the
+last release. You can see the requirements for each type of bump in
+our [release-drafter config -> autolabeler](./.github/release-drafter.yml)
+
+The release version will be generated based on the content of the pull requests merged since the last release. We
+use https://github.com/release-drafter/release-drafter to generate new releases and https://commitlint.js.org/ to make
+sure PRs follow our commit convention

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -14,6 +14,8 @@ export default {
       2,
       'always',
       [
+        'build',
+        'ci',
         'feat',
         'fix',
         'docs',


### PR DESCRIPTION
### TL;DR

Enhanced release management with improved automation and versioning strategy.

### What changed?

- Updated release-drafter configuration with:
  - Structured categorization for changes (breaking changes, maintenance, bug fixes, features)
  - Version resolver based on PR labels (major, minor, patch)
  - Autolabeler to automatically categorize PRs based on title and body content
  - Improved release template with contributors section

- Simplified release-drafter workflow:
  - Added support for PR events to enable auto labeling
  - Removed manual version calculation in favor of automated versioning
  - Added proper permissions for autolabeler functionality

- Updated DEVELOPING.md with:
  - Improved formatting for better readability
  - Expanded version bump instructions with additional files to update
  - Added documentation about versioning strategy and commit conventions

- Added additional commit types to commitlint config (build, ci)

### How to test?

1. Create a PR with a title following the format "EMBR-XXXX feat: new feature"
2. Verify the PR gets automatically labeled as "feat" and "minor"
3. Merge the PR to main and check that the draft release is updated with the change in the correct category
4. Publish a release and verify the version is incremented correctly
