### PR TITLE
fix: commitlint reporting all false positives

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,11 +1,3 @@
-import rules from '@commitlint/rules';
-
-const removeEMBRNumberHeader = rule => (parsed, _when, _value) => {
-  // remove EMBR-<number> from the header. We use it to link to internal Notion tickets
-  parsed.header = parsed.header.replace(/(EMBR-[0-9]+\s+)/, '');
-  return rule(parsed, _when, _value);
-};
-
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
@@ -25,17 +17,14 @@ export default {
         'perf',
         'test',
         'chore',
-        'revert'
-      ]
-    ]
+        'revert',
+      ],
+    ],
   },
-  plugins: [
-    {
-      rules: {
-        'type-enum': removeEMBRNumberHeader(rules['type-enum']),
-        'subject-empty': removeEMBRNumberHeader(rules['type-enum']),
-        'type-empty': removeEMBRNumberHeader(rules['type-enum'])
-      }
-    }
-  ]
+  parserPreset: {
+    parserOpts: {
+      headerPattern: /^(?:EMBR-[0-9]+\s+)?(\w*)(?:\((.*)\))?: (.*)$/,
+      headerCorrespondence: ['type', 'scope', 'subject'],
+    },
+  },
 };


### PR DESCRIPTION
### TL;DR

Refactor commitlint configuration to use parserPreset instead of custom plugins. The previous approach was reporting always "valid" no matter what was the input 😞 

Testing I did now

Passing
`echo "EMBR-123 fix: something" | npm run commitlint`
`echo "EMBR-123 feat: something" | npm run commitlint`
`echo "fix: something" | npm run commitlint`

Failing
`echo "EMBR-123 something" | npm run commitlint`
`echo "EMBR-123" | npm run commitlint`
`echo "123 feat: something" | npm run commitlint`
`echo "EMBR- feat: something" | npm run commitlint`
