### PR TITLE
ci: run commitlint on dependabot PRs and pushes to main too

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -253,7 +253,6 @@ jobs:
     needs: configure
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### TL;DR

Remove the conditional check that prevents CI from running on Dependabot PRs and pushes to main. The check for pushes to main will be valuable to make sure squashed commits still have the same format as PR ones