### PR TITLE
fix: typescript build broken

### DIFF
--- a/src/api-traces/manager/types.ts
+++ b/src/api-traces/manager/types.ts
@@ -1,5 +1,4 @@
-import type { Span } from '@opentelemetry/api';
-import type { SpanOptions } from '@opentelemetry/api/build/src/trace/SpanOptions';
+import type { Span, SpanOptions } from '@opentelemetry/api';
 
 export interface TraceManager {
   startPerformanceSpan: (name: string, options?: SpanOptions) => Span | null;

--- a/src/managers/EmbraceTraceManager/EmbraceTraceManager.ts
+++ b/src/managers/EmbraceTraceManager/EmbraceTraceManager.ts
@@ -1,7 +1,6 @@
-import { type Span, trace } from '@opentelemetry/api';
+import { type Span, type SpanOptions, trace } from '@opentelemetry/api';
 import type { TraceManager } from '../../api-traces/index.js';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
-import type { SpanOptions } from '@opentelemetry/api/build/src/trace/SpanOptions';
 
 export class EmbraceTraceManager implements TraceManager {
   public startPerformanceSpan(name: string, options: SpanOptions = {}): Span {


### PR DESCRIPTION
## Goal

Simplify imports from the OpenTelemetry API by importing both `Span` and `SpanOptions` types directly from the main package instead of importing `SpanOptions` from a build path.

## Testing

This change only affects type imports and doesn't modify any runtime behavior, so existing tests should continue to pass without modification.