### PR TITLE
Fix doc to reflect startPerformanceSpan method

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For the most basic usage simply start a span and end it after some operation com
 ```typescript
 import { trace } from '@embrace-io/web-sdk';
 
-const span = trace.startSpan("span-name");
+const span = trace.startPerformanceSpan("span-name");
 
 someAsyncOperation().then(() => span.end());
 ```

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ import { trace } from '@embrace-io/web-sdk';
 
 const span = trace.startPerformanceSpan("span-name");
 
-someAsyncOperation().then(() => span.end());
+someAsyncOperation().then(() => span?.end());
 ```
 
 Attributes and events can also be added to the span either on start or later during its lifespan. Our API wraps that of


### PR DESCRIPTION
## Goal

Doc is wrong, method should be `startPerformanceSpan`
