### PR TITLE
ci: turn off body-max-line-length commitlint rule

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,6 +2,7 @@ export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'header-max-length': [2, 'always', 100],
+    'body-max-line-length': [0, 'always', 100],
     'type-enum': [
       2,
       'always',


### PR DESCRIPTION
## Goal

Disable the `body-max-line-length` rule in the commitlint configuration to allow commit message bodies to exceed 100 characters without triggering validation errors.

Example:  [this](https://github.com/embrace-io/embrace-web-sdk/actions/runs/14411431668/job/40420045031) was failing, and it should pass