### PR TITLE
ci: remove CONTRIBUTORS from release template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -60,6 +60,4 @@ template: |
 
   $CHANGES
 
-  $CONTRIBUTORS
-
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION


### PR DESCRIPTION
Github already added it by default as a footer, so it was duplicated

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/S215IBu9kfHXNs3PdXXg/4eca947e-88e7-4b7b-9d8a-fdef8b6e7e34.png)

