### PR TITLE
ci: remove support for forks to be labeled by the release drafter

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
     types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
Github is reporting the pull_request_target events as invalid, the use case for those was an edge case for PRs coming from forks. I can just remove it for now 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/S215IBu9kfHXNs3PdXXg/0f9e936f-a2b6-4c74-adc1-4efffe4e5673.png)

