### PR TITLE
fix: identify the release version

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -361,7 +361,8 @@ jobs:
             echo "Version is empty. Exiting"
             exit 1
           fi
-          echo 'version=$version' >> $GITHUB_OUTPUT
+          echo "version=$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Typo in our yaml workflow. Double quotes will allow for the version variable to be replaced