### PR TITLE
fix: make release run from main instead of a detached head so we can commit the bump in the version

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -371,6 +371,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Update package.json version
         run: |
+          # checkout the main branch to commit to it later. As this is trigger by a release, actions/checkout@v4
+          # had left the current shell in a detached HEAD pointing to the commit of the release tag
+          git checkout --progress --force -B main refs/remotes/origin/main
           version="${{ steps.extract_version.outputs.version }}"
            if [ -z "$version"]; then
             echo 'Version is empty. Exiting'


### PR DESCRIPTION
see Run actions/checkout@v4 job from https://github.com/embrace-io/embrace-web-sdk/actions/runs/14413197888/job/40425376470 as an example. When triggering from a release, you can not commit unless you switch back to main.

Releases always happen from main, and new merges update the latest draft release, still pointing to main, so this is not changing the commit we point at, it is just reenabling the branch. 