### PR TITLE
ci: make EMBR-XXX identifier optional for autolabeler of PRs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -38,22 +38,22 @@ version-resolver:
 autolabeler:
   - label: 'maintenance'
     title:
-      - '/(EMBR-[0-9]+\s+)(build|ci|docs|style|refactor|perf|test|chore).*/'
+      - '/(EMBR-[0-9]+\s+)?(build|ci|docs|style|refactor|perf|test|chore).*/'
   - label: 'fix'
     title:
-      - '/(EMBR-[0-9]+\s+)(fix|revert).*/'
+      - '/(EMBR-[0-9]+\s+)?(fix|revert).*/'
   - label: 'feat'
     title:
-      - '/(EMBR-[0-9]+\s+)(feat).*/'
+      - '/(EMBR-[0-9]+\s+)?(feat).*/'
   - label: 'major'
     body:
       - '/(BREAKING CHANGE)/'
   - label: 'minor'
     title: # SAME AS 'feat'
-      - '/(EMBR-[0-9]+\s+)(feat).*/'
+      - '/(EMBR-[0-9]+\s+)?(feat).*/'
   - label: 'patch'
     title: # SAME AS 'fix or maintenance'
-      - '/(EMBR-[0-9]+\s+)(fix|revert|build|ci|docs|style|refactor|perf|test|chore).*/'
+      - '/(EMBR-[0-9]+\s+)?(fix|revert|build|ci|docs|style|refactor|perf|test|chore).*/'
 
 template: |
   ## What's Changed


### PR DESCRIPTION
## Goal

Make EMBR ticket numbers optional in PR titles for autolabeling. This change modifies the regex patterns in the release-drafter.yml file to make the EMBR ticket reference optional when determining PR labels based on title.

### Testing
Example working from the chrome console now

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/S215IBu9kfHXNs3PdXXg/fcc27672-c7b6-4951-993b-a94fdca92877.png)

