### PR TITLE
ci: checkout not finding main branch on github action

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -352,6 +352,8 @@ jobs:
         node-version: ['${{ needs.configure.outputs.NODE_VERSION }}']
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Extract Version
         id: extract_version
         run: |


### PR DESCRIPTION
## Goal

Update the `actions/checkout@v4` step in the CI workflow to fetch the complete Git history by setting `fetch-depth: 0`. This ensures that the workflow has access to the full commit history, which is likely needed for the subsequent "Extract Version" step to properly determine version information.

Failed action https://github.com/embrace-io/embrace-web-sdk/actions/runs/14447000810/job/40510560985
