### PR TITLE
chore: change logException signature to accept optional timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,24 @@ log.message('Loading not finished in time.', 'error', {
   propertyB: 'valueB'
 });
 ```
+## Adding exceptions
+
+The SDK automatically captures unhandled exceptions.
+
+If there is a need to a log a handled exception, this can be done manually by calling the logException method:
+
+```typescript
+import { log } from '@embrace-io/web-sdk';
+
+try {
+  // some operation...
+} catch (e) {
+  log.logException(e as Error, true, {
+     propertyA: 'valueA',
+     propertyB: 'valueB'
+  });
+}
+```
 
 ## Enriching with metadata
 

--- a/src/api-logs/api/LogAPI/LogAPI.ts
+++ b/src/api-logs/api/LogAPI/LogAPI.ts
@@ -30,12 +30,12 @@ export class LogAPI implements LogManager {
   }
 
   public logException(
-    timestamp: number,
     error: Error,
     handled: boolean,
-    attributes?: Record<string, AttributeValue | undefined>
+    attributes?: Record<string, AttributeValue | undefined>,
+    timestamp?: number
   ) {
-    this.getLogManager().logException(timestamp, error, handled, attributes);
+    this.getLogManager().logException(error, handled, attributes, timestamp);
   }
 
   public message(

--- a/src/api-logs/manager/NoOpLogManager/NoOpLogManager.ts
+++ b/src/api-logs/manager/NoOpLogManager/NoOpLogManager.ts
@@ -3,10 +3,10 @@ import type { LogManager, LogSeverity } from '../index.js';
 
 export class NoOpLogManager implements LogManager {
   public logException(
-    _timestamp: number,
     _error: Error,
     _handled: boolean,
-    _attributes?: Record<string, AttributeValue | undefined>
+    _attributes?: Record<string, AttributeValue | undefined>,
+    _timestamp?: number
   ) {
     // no op
   }

--- a/src/api-logs/manager/ProxyLogManager/ProxyLogManager.ts
+++ b/src/api-logs/manager/ProxyLogManager/ProxyLogManager.ts
@@ -16,12 +16,12 @@ export class ProxyLogManager implements LogManager {
   }
 
   public logException(
-    timestamp: number,
     error: Error,
     handled: boolean,
-    attributes?: Record<string, AttributeValue | undefined>
+    attributes?: Record<string, AttributeValue | undefined>,
+    timestamp?: number
   ) {
-    this.getDelegate().logException(timestamp, error, handled, attributes);
+    this.getDelegate().logException(error, handled, attributes, timestamp);
   }
 
   public message(

--- a/src/api-logs/manager/types.ts
+++ b/src/api-logs/manager/types.ts
@@ -9,10 +9,10 @@ export interface LogManager {
   ) => void;
 
   logException: (
-    timestamp: number,
     error: Error,
     handled: boolean,
-    attributes?: Record<string, AttributeValue | undefined>
+    attributes?: Record<string, AttributeValue | undefined>,
+    timestamp?: number
   ) => void;
 }
 

--- a/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
+++ b/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
@@ -17,9 +17,10 @@ export class GlobalExceptionInstrumentation extends EmbraceInstrumentationBase {
     });
     this._onErrorHandler = (event: ErrorEvent) => {
       this.logManager.logException(
-        this.perf.epochMillisFromOriginOffset(event.timeStamp),
         event.error as Error,
-        false
+        false,
+        {},
+        this.perf.epochMillisFromOriginOffset(event.timeStamp)
       );
     };
     this._onUnhandledRejectionHandler = (event: PromiseRejectionEvent) => {
@@ -36,9 +37,10 @@ export class GlobalExceptionInstrumentation extends EmbraceInstrumentationBase {
       }
 
       this.logManager.logException(
-        this.perf.epochMillisFromOriginOffset(event.timeStamp),
         error,
-        false
+        false,
+        {},
+        this.perf.epochMillisFromOriginOffset(event.timeStamp)
       );
     };
 

--- a/src/managers/EmbraceLogManager/EmbraceLogManager.ts
+++ b/src/managers/EmbraceLogManager/EmbraceLogManager.ts
@@ -44,17 +44,16 @@ export class EmbraceLogManager implements LogManager {
   public logException(
     error: Error,
     handled: boolean,
-    attributes?: Record<string, AttributeValue | undefined>,
-    timestamp?: number
+    attributes: Record<string, AttributeValue | undefined> = {},
+    timestamp: number = this._perf.getNowMillis()
   ) {
-    timestamp = timestamp ? timestamp : this._perf.getNowMillis();
     this._logger.emit({
       timestamp,
       severityNumber: SeverityNumber.ERROR,
       severityText: 'ERROR',
       body: error.message || '',
       attributes: {
-        ...(attributes || {}),
+        ...attributes,
         [KEY_EMB_TYPE]: EMB_TYPES.SystemException,
         [KEY_EMB_EXCEPTION_HANDLING]: handled ? 'HANDLED' : 'UNHANDLED',
         [ATTR_EXCEPTION_TYPE]: error.constructor.name,

--- a/src/managers/EmbraceLogManager/EmbraceLogManager.ts
+++ b/src/managers/EmbraceLogManager/EmbraceLogManager.ts
@@ -42,18 +42,19 @@ export class EmbraceLogManager implements LogManager {
   }
 
   public logException(
-    timestamp: number,
     error: Error,
     handled: boolean,
-    attributes?: Record<string, AttributeValue | undefined>
+    attributes?: Record<string, AttributeValue | undefined>,
+    timestamp?: number
   ) {
+    timestamp = timestamp ? timestamp : this._perf.getNowMillis();
     this._logger.emit({
       timestamp,
       severityNumber: SeverityNumber.ERROR,
       severityText: 'ERROR',
       body: error.message || '',
       attributes: {
-        ...attributes,
+        ...(attributes || {}),
         [KEY_EMB_TYPE]: EMB_TYPES.SystemException,
         [KEY_EMB_EXCEPTION_HANDLING]: handled ? 'HANDLED' : 'UNHANDLED',
         [ATTR_EXCEPTION_TYPE]: error.constructor.name,


### PR DESCRIPTION
## Goal

Change logException to take an optional timestamp parameter. If not received, we use now()

## Testing

<!-- Describe how this change has been tested -->