### PR TITLE
ci: give github action permissions to write to the repo at the job level

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -399,6 +399,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
     timeout-minutes: 10
     if: ${{ needs.environment.outputs.name == 'production' }}
     strategy:


### PR DESCRIPTION
## Goal

ci: give github action permissions to write to the repo at the job level