### PR TITLE
chore: re-export Span

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,2 +1,3 @@
 export { initSDK } from './initSDK.js';
+export type { Span } from '@opentelemetry/api';
 export { DiagLogLevel } from '@opentelemetry/api';


### PR DESCRIPTION
## Goal

Let's a user do:

```
  const spanRef = useRef<sdk.Span | null>();

  useEffect(() => {
    spanRef.current = trace.startPerformanceSpan('Wizard flow');
  }, []);
```

There's a bunch of OTel interfaces we could probably re-export just sticking with `Span` for now since it is the return type of `startPerformanceSpan` 
