### PR TITLE
chore: protect against the SDK being initialized multiple times

### DIFF
--- a/src/sdk/registry.ts
+++ b/src/sdk/registry.ts
@@ -1,0 +1,19 @@
+import type { SDKControl, SDKRegistryManager } from './types.js';
+
+class Registry implements SDKRegistryManager {
+  private _sdk: SDKControl | null = null;
+
+  public register: (sdk: SDKControl) => void = sdk => {
+    this._sdk = sdk;
+  };
+
+  public clear: () => void = () => {
+    this._sdk = null;
+  };
+
+  public registered: () => SDKControl | null = () => {
+    return this._sdk;
+  };
+}
+
+export const registry = new Registry();

--- a/src/sdk/registry.ts
+++ b/src/sdk/registry.ts
@@ -1,13 +1,28 @@
 import type { SDKControl, SDKRegistryManager } from './types.js';
+import type { DiagLogger } from '@opentelemetry/api';
+import { diag } from '@opentelemetry/api';
 
 class Registry implements SDKRegistryManager {
   private _sdk: SDKControl | null = null;
+  private readonly _diag: DiagLogger;
+
+  public constructor({
+    diagLogger = diag.createComponentLogger({ namespace: 'embrace-registry' }),
+  }: { diagLogger?: DiagLogger } = {}) {
+    this._diag = diagLogger;
+  }
 
   public register: (sdk: SDKControl) => void = sdk => {
+    if (this._sdk !== null) {
+      this._diag.warn('previously registered sdk will be overwritten');
+    }
     this._sdk = sdk;
   };
 
   public clear: () => void = () => {
+    if (this._sdk === null) {
+      this._diag.warn('sdk already cleared, this is a no-op');
+    }
     this._sdk = null;
   };
 

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -215,3 +215,9 @@ export interface DefaultInstrumenationConfig {
     'enabled'
   >;
 }
+
+export interface SDKRegistryManager {
+  register: (sdk: SDKControl) => void;
+  clear: () => void;
+  registered: () => SDKControl | null;
+}


### PR DESCRIPTION
## Goal

I think a few different ways to handle this let me know what you think about this approach, with this we could potentially expose the `registry` to the user for grabbing the setup SDK elsewhere in their app