### PR TITLE
chore: make app version optional during cli processing

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -50,9 +50,7 @@ program
     new Option(
       '--app-version <appVersion>',
       'Application Version. Usually the version of the app under package.json -> version'
-    )
-      .env('EMB_APP_VERSION')
-      .makeOptionMandatory()
+    ).env('EMB_APP_VERSION')
   )
   .addOption(
     new Option('--cli-version [cliVersion]', 'Version of this CLI tool')

--- a/cli/src/validateInput.ts
+++ b/cli/src/validateInput.ts
@@ -32,11 +32,10 @@ export const validateInput = ({
   if (!jsFilePath.trim()) {
     return 'JS file path cannot be empty.';
   }
-  if (!appVersion.trim()) {
-    return 'appVersion cannot be empty.';
-  }
-  if (appVersion.length > 20) {
-    return 'appVersion cannot be longer than 20 characters.';
+  if (appVersion) {
+    if (appVersion.length > 20) {
+      return 'appVersion cannot be longer than 20 characters.';
+    }
   }
   if (!mapFilePath.trim()) {
     return 'Map file path cannot be empty.';


### PR DESCRIPTION
## Goal

Make the `appVersion` parameter optional in the CLI tool. This change allows the app version to be provided during SDK initialization instead of requiring it as a mandatory CLI parameter. If neither is provided, the SDK will report the app version as "EmbIOAppVersionX.X.X".

## Testing

The changes have been tested to ensure that:
- The CLI works correctly when `appVersion` is not provided
- The source code processing functions properly with or without an app version
- Input validation correctly handles both cases (with and without app version)
- When an app version is provided, it's still properly injected into the source code