### PR TITLE
chore: bump version to 0.0.16

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embrace-io/web-cli",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@embrace-io/web-cli",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "13.1.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -3,7 +3,7 @@
   "bin": {
     "embrace-web-cli": "build/index.js"
   },
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Embrace Web CLI to help setup the Embrace SDK in your web app",
   "type": "module",
   "module": "build/index.js",
@@ -70,7 +70,7 @@
     "typescript": "5.8.3",
     "typescript-eslint": "8.29.1"
   },
-  "engines" : {
-    "node" : ">=22.0.0"
+  "engines": {
+    "node": ">=22.0.0"
   }
 }

--- a/cli/src/constants.ts
+++ b/cli/src/constants.ts
@@ -1,4 +1,4 @@
-export const CLI_VERSION = '0.0.15';
+export const CLI_VERSION = '0.0.16';
 export const CLI_NAME = '@embrace-io/web-cli';
 export const CLI_DESCRIPTION =
   'Embrace Web CLI to help setup the Embrace SDK in your web app';

--- a/demo/frontend/package-lock.json
+++ b/demo/frontend/package-lock.json
@@ -29,7 +29,7 @@
     },
     "../..": {
       "name": "@embrace-io/web-sdk",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.0",
@@ -78,7 +78,7 @@
     },
     "../../cli": {
       "name": "@embrace-io/web-cli",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embrace-io/web-sdk",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@embrace-io/web-sdk",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@embrace-io/web-sdk",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Embrace Web SDK",
   "type": "module",
   "jsdelivr": "build/esm/bundle.js",

--- a/src/resources/constants/index.ts
+++ b/src/resources/constants/index.ts
@@ -2,7 +2,7 @@
 // It needs to always remain 32 chars long, so we don't mess with the sourcemaps location after replacing the bundle id with the real 32 chars long bundle ID
 export const TEMPLATE_BUNDLE_ID = 'EmbIOBundleIDfd6996f1007b363f87a';
 export const TEMPLATE_APP_VERSION = 'EmbIOAppVersionX.X.X';
-export const SDK_VERSION = '0.0.15';
+export const SDK_VERSION = '0.0.16';
 export const EMBRACE_SERVICE_NAME = 'embrace-web-sdk';
 // NATIVE_FRAMEWORK is the representation Embrace BE uses to differentiate between
 // sdks. It is an enum, so we just send a number here


### PR DESCRIPTION
## Goal

Bump version from 0.0.15 to 0.0.16 across the web SDK and CLI packages.

## Testing

Version numbers have been updated in all package.json and package-lock.json files to maintain consistency across the codebase.