### PR TITLE
fix: web-cli bin name changed, update the demo

### DIFF
--- a/demo/frontend/package-lock.json
+++ b/demo/frontend/package-lock.json
@@ -73,7 +73,7 @@
         "sinon-chai": "4.0.0",
         "typedoc": "0.28.2",
         "typescript": "5.8.3",
-        "typescript-eslint": "8.29.1"
+        "typescript-eslint": "8.30.1"
       }
     },
     "../../cli": {
@@ -99,7 +99,7 @@
         "prettier": "3.5.3",
         "rimraf": "6.0.1",
         "typescript": "5.8.3",
-        "typescript-eslint": "8.29.1"
+        "typescript-eslint": "8.30.1"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -2665,7 +2665,7 @@
         "prettier": "3.5.3",
         "rimraf": "6.0.1",
         "typescript": "5.8.3",
-        "typescript-eslint": "8.29.1"
+        "typescript-eslint": "8.30.1"
       }
     },
     "@embrace-io/web-sdk": {
@@ -2708,7 +2708,7 @@
         "sinon-chai": "4.0.0",
         "typedoc": "0.28.2",
         "typescript": "5.8.3",
-        "typescript-eslint": "8.29.1",
+        "typescript-eslint": "8.30.1",
         "uuid": "11.1.0",
         "web-vitals": "4.2.4"
       }

--- a/demo/frontend/package.json
+++ b/demo/frontend/package.json
@@ -8,8 +8,8 @@
     "demo:frontend:install:clean": "rimraf node_modules",
     "demo:frontend:dev": "vite",
     "demo:frontend:compile": "tsc -b && vite build",
-    "demo:frontend:upload:sourcemaps": "web-cli upload -a 5przi --app-version 0.0.1",
-    "demo:frontend:upload:sourcemaps:dry": "web-cli upload -d -a 5przi --app-version 0.0.1",
+    "demo:frontend:upload:sourcemaps": "embrace-web-cli upload -a 5przi --app-version 0.0.1",
+    "demo:frontend:upload:sourcemaps:dry": "embrace-web-cli upload -d -a 5przi --app-version 0.0.1",
     "demo:frontend:preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Goal

Update the sourcemap upload commands to use `embrace-web-cli` instead of `web-cli`.