### PR TITLE
chore: document how data is exported

### DIFF
--- a/DATA_EXPORT.md
+++ b/DATA_EXPORT.md
@@ -1,0 +1,29 @@
+# SDK Data Export
+
+## When is data sent?
+
+Telemetry data for Spans and Logs are exported from the SDK independently. Spans are sent as a batch whenever a session
+ends, this is managed by the [EmbraceSessionBatchedSpanProcessor](./src/processors/EmbraceSessionBatchedSpanProcessor/EmbraceSessionBatchedSpanProcessor.ts).
+Logs are also batched but can be sent throughout a session, this is managed by a [BatchLogRecordProcessor](https://github.com/open-telemetry/opentelemetry-js/blob/experimental/v0.57.0/experimental/packages/sdk-logs/src/platform/browser/export/BatchLogRecordProcessor.ts).
+
+## How is data sent?
+
+Data from the SDK is sent to Embrace using a CORS HTTP POST request. The data is gzip compressed and encoding as
+[OTLP JSON Protobuf](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding). We make use of the
+[keepalive property](https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive) of the browser's Fetch API to
+help ensure the transmission of data even if the page has been closed. If possible we will attempt to retry request
+failures following an exponential backoff. See [FetchTransport](./src/transport/FetchTransport/FetchTransport.ts) and
+[RetryingTransport](src/transport/RetryingTransport/RetryingTransport.ts) for more details. 
+
+> [!NOTE]
+> The Fetch API's `keepalive` property is supported by all modern browsers, however it was a relatively recent addition
+> to Firefox and may not exist on some older versions of that browser in particular. Refer to this [Browser compatibility chart](https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive#browser_compatibility)
+> for more details.
+
+## What happens with custom export?
+
+If you [provide your own custom exporter](./README.md#custom-exporters) then batching of spans and logs are managed by a
+[BatchLogRecordProcessor](https://github.com/open-telemetry/opentelemetry-js/blob/experimental/v0.57.0/experimental/packages/sdk-logs/src/platform/browser/export/BatchLogRecordProcessor.ts)
+and [BatchSpanProcessor](https://github.com/open-telemetry/opentelemetry-js/blob/v1.30.0/packages/opentelemetry-sdk-trace-base/src/platform/browser/export/BatchSpanProcessor.ts)
+respectively.
+

--- a/DATA_EXPORT.md
+++ b/DATA_EXPORT.md
@@ -8,7 +8,7 @@ Logs are also batched but can be sent throughout a session, this is managed by a
 
 ## How is data sent?
 
-Data from the SDK is sent to Embrace using a CORS HTTP POST request. The data is gzip compressed and encoding as
+Data from the SDK is sent to Embrace using a CORS HTTP POST request. The data is gzip compressed and encoded as
 [OTLP JSON Protobuf](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding). We make use of the
 [keepalive property](https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive) of the browser's Fetch API to
 help ensure the transmission of data even if the page has been closed. If possible we will attempt to retry request

--- a/README.md
+++ b/README.md
@@ -342,6 +342,12 @@ sdk.initSDK({
 });
 ```
 
+## FAQ
+
+### How is data exported from the SDK
+
+Refer to [DATA_EXPORT.md](/.DATA_EXPORT.md) for details on how data is exported from the SDK.
+
 ## Support
 
 If you have a feature suggestion or have spotted something that doesn't look right please open

--- a/src/processors/EmbraceSessionBatchedSpanProcessor/EmbraceSessionBatchedSpanProcessor.ts
+++ b/src/processors/EmbraceSessionBatchedSpanProcessor/EmbraceSessionBatchedSpanProcessor.ts
@@ -34,17 +34,27 @@ export class EmbraceSessionBatchedSpanProcessor extends EmbraceProcessor {
 
   public onEnd(span: ReadableSpan): void {
     if (this._shutdownOnce.isCalled) {
-      this.diag.debug('Span ended after processor shutdown. Ignoring span.');
+      this.diag.debug('span ended after processor shutdown. Ignoring span.');
       return;
     }
 
     if (!isSessionSpan(span)) {
-      this.diag.debug('Non-session span ended. Adding to pending spans queue.');
+      this.diag.debug('non-session span ended. Adding to pending spans queue.');
       this._pendingSpans.push(span);
     } else {
-      // TODO: handle errors
-      this.diag.debug('Session span ended. Exporting all pending spans.');
-      void internal._export(this._exporter, [span, ...this._pendingSpans]);
+      this.diag.debug('session span ended. Exporting all pending spans.');
+      internal
+        ._export(this._exporter, [span, ...this._pendingSpans])
+        .catch((reason: unknown) => {
+          let msg = 'unknown reason';
+          if (reason && reason instanceof Error) {
+            msg = reason.message;
+          } else if (typeof reason === 'string') {
+            msg = reason;
+          }
+
+          this.diag.error(`spans failed to export: ${msg}`);
+        });
       this._pendingSpans = [];
     }
   }

--- a/src/processors/EmbraceSessionBatchedSpanProcessor/EmbraceSessionBatchedSpanProcessor.ts
+++ b/src/processors/EmbraceSessionBatchedSpanProcessor/EmbraceSessionBatchedSpanProcessor.ts
@@ -1,4 +1,9 @@
-import { BindOnceFuture, internal } from '@opentelemetry/core';
+import type { ExportResult } from '@opentelemetry/core';
+import {
+  BindOnceFuture,
+  ExportResultCode,
+  internal,
+} from '@opentelemetry/core';
 import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-web'; // TODO: don't rely on internal API
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
 import type { SessionSpan } from '../../instrumentations/index.js';
@@ -45,8 +50,18 @@ export class EmbraceSessionBatchedSpanProcessor extends EmbraceProcessor {
       this.diag.debug('session span ended. Exporting all pending spans.');
       internal
         ._export(this._exporter, [span, ...this._pendingSpans])
+        .then((result: ExportResult) => {
+          if (result.code === ExportResultCode.FAILED) {
+            this.diag.error(
+              `spans failed to export: ${result.error?.message || 'unknown error'}`
+            );
+          }
+        })
+        // Seems like everything related to the export logic does a good job of catching and only ever resolving with
+        // an ExportResult even on failure: https://github.com/open-telemetry/opentelemetry-js/blob/cf6dffeebcf72c42b2cb4d2bf2db720369b53081/packages/opentelemetry-core/src/internal/exporter.ts#L37
+        // Keep this block just in case that assumption changes in a future version
         .catch((reason: unknown) => {
-          let msg = 'unknown reason';
+          let msg = 'unknown error';
           if (reason && reason instanceof Error) {
             msg = reason.message;
           } else if (typeof reason === 'string') {

--- a/src/transport/RetryingTransport/constants.ts
+++ b/src/transport/RetryingTransport/constants.ts
@@ -2,4 +2,4 @@ export const MAX_ATTEMPTS = 5;
 export const INITIAL_BACKOFF = 1000;
 export const MAX_BACKOFF = 5000;
 export const BACKOFF_MULTIPLIER = 1.5;
-export const JITTER = 0.2;
+export const JITTER = 20;


### PR DESCRIPTION
## Goal

Documenting how we export data from the SDK. In reviewing the code I think the only issue I noticed was that we aren't currently ever returning an error as 'retryable' so the retry logic isn't being used: https://github.com/embrace-io/embrace-web-sdk/blob/7276b54b2ca914fbd80bd863457ca06721eaeb1a/src/transport/FetchTransport/FetchTransport.ts#L87

Will file a follow-up for that specifically