### PR TITLE
ci: disable release of major versions until we go out of beta

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -41,9 +41,10 @@ autolabeler:
   - label: 'feat'
     title:
       - '/(EMBR-[0-9]+\s+)?(feat).*/'
-  - label: 'major'
-    body:
-      - '/(BREAKING CHANGE)/'
+  # No major releases until we go out of beta
+  # - label: 'major'
+  #   body:
+  #     - '/(BREAKING CHANGE)/'
   - label: 'minor'
     title: # SAME AS 'feat'
       - '/(EMBR-[0-9]+\s+)?(feat).*/'


### PR DESCRIPTION
## Goal

Disable automatic labeling of PRs as 'major' based on 'BREAKING CHANGE' text in the body until we exit beta phase.