### PR TITLE
ci: new workflow to manually trigger releases going through a PR

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,9 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 
+exclude-labels:
+  - 'release'
+
 categories:
   - title: '⚠️ BREAKING CHANGES'
     collapse-after: 5

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -8,7 +8,7 @@ on:
     types: [released]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 env:
@@ -389,9 +389,8 @@ jobs:
         if: ${{ failure() || cancelled() }}
         run: |
           rm -f ${{ env.TYPE_CHECK_STATUS_FILE }}
-  # this jobs updates the version in package.json and package-lock.json for both the cli and sdk before publishing
-  # to npm and based on the github release version
-  publish:
+
+  publish-sdk:
     needs:
       - configure
       - environment
@@ -401,7 +400,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: write
     timeout-minutes: 10
     if: ${{ needs.environment.outputs.name == 'production' }}
     strategy:
@@ -410,63 +408,58 @@ jobs:
         node-version: ['${{ needs.configure.outputs.NODE_VERSION }}']
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Extract Version
-        id: extract_version
-        run: |
-          version="${{ github.event.release.tag_name }}"
-          version=$(echo "$version" | sed 's/^v//')
-          if [ z "$version"]; then
-            echo "Version is empty. Exiting"
-            exit 1
-          fi
-          echo "version=$version"
-          echo "version=$version" >> $GITHUB_OUTPUT
+
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
           registry-url: 'https://registry.npmjs.org'
-      - name: Update package.json version
+
+      - name: Install NPM dependencies
         run: |
-          # checkout the main branch to commit to it later. As this is trigger by a release, actions/checkout@v4
-          # had left the current shell in a detached HEAD pointing to the commit of the release tag
-          git checkout --progress --force -B main refs/remotes/origin/main
-          version="${{ steps.extract_version.outputs.version }}"
-           if [ -z "$version"]; then
-            echo 'Version is empty. Exiting'
-            exit 1
-          fi
-          echo 'Updating package.json version to $version'
-          # update sdk version
-          jq --arg version "$version" '.version = $version' package.json > tmp.json && mv tmp.json package.json
-          npm i
-          # update cli version
-          cd cli
-          jq --arg version "$version" '.version = $version' package.json > tmp.json && mv tmp.json package.json
-          npm i
-          # update demo versions
-          cd ../demo/frontend
-          npm i
-          cd ../frontend-cdn
-          npm i
-      - name: Commit version change
-        run: |
-          git config --global user.name 'embrace-ci'
-          git config --global user.email 'embrace-ci@users.noreply.github.com'
-          git add package.json package-lock.json cli/package.json cli/package-lock.json demo/frontend/package.json demo/frontend/package-lock.json demo/frontend-cdn/package.json demo/frontend-cdn/package-lock.json
-          git commit --author '${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>' -m "deploy: update version to ${{ steps.extract_version.outputs.version }}"
-          git pull --rebase && git push
-      - uses: actions/checkout@v4
-      - name: Publish sdk
+          npm ci --strict-peer-deps
+
+      - name: Run 'npm publish'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
         run: |
           npm publish --provenance --access public
-      - name: Publish cli
+  publish-cli:
+    needs:
+      - configure
+      - environment
+      - test-multiple-browsers
+      - lint
+      - type-check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
         working-directory: ./cli
+    permissions:
+      id-token: write
+    timeout-minutes: 10
+    if: ${{ needs.environment.outputs.name == 'production' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['${{ needs.configure.outputs.NODE_VERSION }}']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install NPM dependencies
+        run: |
+          npm ci --strict-peer-deps
+
+      - name: Run 'npm publish'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
         run: |
@@ -476,7 +469,7 @@ jobs:
   report-release-slack:
     runs-on: ubuntu-latest
     if: ${{ needs.environment.outputs.name == 'production' }}
-    needs: [publish]
+    needs: [publish-sdk, publish-cli]
     steps:
       - name: "Send to #mission-web Slack channel/workflow"
         continue-on-error: true

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: embrace-io/release-drafter-public@919cc578730ffaf9ff0e2cc3d0509edac3f74ae4 # fork from v6.1.0
+      - uses: embrace-io/release-drafter@c3db6ed8d1ba035bbf9edcd5d89c1d5064d98dfb # fork from v6.1.0
         with:
           # only create a release if the last commit merged starts with "release". Coming from .github/workflows/release.yaml
           disable-releaser: ${{ startsWith(github.event.head_commit.message, 'release') }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+      - uses: embrace-io/release-drafter-public@919cc578730ffaf9ff0e2cc3d0509edac3f74ae4 # fork from v6.1.0
+        with:
+          # only create a release if the last commit merged starts with "release". Coming from .github/workflows/release.yaml
+          disable-releaser: ${{ startsWith(github.event.head_commit.message, 'release') }}
+          publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,75 @@
+name: Bump packages version
+
+on: workflow_dispatch
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  next-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 2
+    steps:
+      - uses: embrace-io/release-drafter-public@919cc578730ffaf9ff0e2cc3d0509edac3f74ae4 # fork from v6.1.0
+        id: release_drafter
+        with:
+          # dry run, we just want to identify the next version, not publish it yet
+          dry-release: true
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+      - name: Update package.json version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${{ steps.release_drafter.outputs.resolved_version }}"
+           if [ -z "$version"]; then
+            echo 'Version is empty. Exiting'
+            exit 1
+          fi
+          # bump the version
+          echo 'Updating package.json version to $version'
+          # update sdk version
+          jq --arg version "$version" '.version = $version' package.json > tmp.json && mv tmp.json package.json
+          npm i
+          # update cli version
+          cd cli
+          jq --arg version "$version" '.version = $version' package.json > tmp.json && mv tmp.json package.json
+          npm i
+          # update demo versions
+          cd ../demo/frontend
+          npm i
+          cd ../frontend-cdn
+          npm i
+          # run the linter to update the version hardcoded in code
+          cd ../..
+          npm run sdk:lint:fix
+      - name: commit and create PR with the next release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # get the next version from the release-drafter output
+          NEXT_VERSION="${{ steps.release_drafter.outputs.resolved_version }}"
+          RELEASE_BODY="${{ steps.release_drafter.outputs.body }}"
+          # create a new branch for the release
+          git branch "release-$NEXT_VERSION"
+          # commit the changes
+          git config --global user.name 'embrace-ci'
+          git config --global user.email 'embrace-ci@users.noreply.github.com'
+          git add package.json package-lock.json cli/package.json cli/package-lock.json demo/frontend/package.json demo/frontend/package-lock.json demo/frontend-cdn/package.json demo/frontend-cdn/package-lock.json
+          git commit --author '${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>' -m "release: update version to $NEXT_VERSION"
+          git push origin "release-$NEXT_VERSION"
+          # create a PR with the next version
+          gh pr create --base main --title "release: Bump version to $NEXT_VERSION" --body "$RELEASE_BODY" -a "${{ github.actor }}" --label "release"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 2
     steps:
-      - uses: embrace-io/release-drafter-public@919cc578730ffaf9ff0e2cc3d0509edac3f74ae4 # fork from v6.1.0
+      - uses: embrace-io/release-drafter@c3db6ed8d1ba035bbf9edcd5d89c1d5064d98dfb # fork from v6.1.0
         id: release_drafter
         with:
           # dry run, we just want to identify the next version, not publish it yet

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -11,25 +11,29 @@ npm install
 The code within `src/` is divided as follows:
 
 * `api-*/`
-  * High-level APIs that expose the SDK's functionality. By default these interfaces are backed by no-op implementations
-so that instrumentations and application code that rely on them continue to function in the absence of an initialized SDK. 
+    * High-level APIs that expose the SDK's functionality. By default these interfaces are backed by no-op
+      implementations
+      so that instrumentations and application code that rely on them continue to function in the absence of an
+      initialized SDK.
 * `managers/`
-  * Classes that provide concrete implementations of the interfaces defined in `api-*/`
+    * Classes that provide concrete implementations of the interfaces defined in `api-*/`
 * `exporters/`
-  * Serializes telemetry into payloads for sending data to Embrace
+    * Serializes telemetry into payloads for sending data to Embrace
 * `instrumentations/`
-  * Responsible for producing telemetry signals. Should be loosely coupled with the SDK and only assume functionality
-  provided by high-level APIS (which may be no-ops if the SDK has not been initialized). Should allow themselves to be
-  turned off at any point.
+    * Responsible for producing telemetry signals. Should be loosely coupled with the SDK and only assume functionality
+      provided by high-level APIS (which may be no-ops if the SDK has not been initialized). Should allow themselves to
+      be
+      turned off at any point.
 * `processors/`
-  * Hooks into the creation and finalization of telemetry signals in order to do some additional processing. This can be
-  appending attributes, batching before sending to an exporter, applying limits, etc.
+    * Hooks into the creation and finalization of telemetry signals in order to do some additional processing. This can
+      be
+      appending attributes, batching before sending to an exporter, applying limits, etc.
 * `resources/`
-  * Controls which attributes are included in the Resource object attached to each payload.
+    * Controls which attributes are included in the Resource object attached to each payload.
 * `sdk/`
-  * Main entry point for initializing the SDK
+    * Main entry point for initializing the SDK
 * `transport/`
-  * Low-level facilities for controlling the actual sending of data and error-handling
+    * Low-level facilities for controlling the actual sending of data and error-handling
 
 ## Testing
 
@@ -56,8 +60,9 @@ npm run sdk:test:watch
 
 ## Publishing
 
-New releases of the SDK are triggered through [Github Releases](https://github.com/embrace-io/embrace-web-sdk/releases).
-Commits merged to main are added to the next Draft release. Once these are ready the Draft can be set to Published to
+New releases of the SDK are triggered through a [Github action workflow](.github/workflows/release.yaml).
+When triggered, a new PR with the next version of the SDK is created. This PR contains a changelog.
+Once the PR is reviewed and merged, a new Github release gets created and published, and this will also
 trigger a publish of the SDK packages to NPM.
 
 Note: the level of the version bump (major, minor, patch) is determined by the type of changes made to the SDK since the

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -60,7 +60,7 @@ npm run sdk:test:watch
 
 ## Publishing
 
-New releases of the SDK are triggered through a [Github action workflow](.github/workflows/release.yaml).
+New releases of the SDK are manually triggered through a [Github action workflow](.github/workflows/release.yaml).
 When triggered, a new PR with the next version of the SDK is created. This PR contains a changelog.
 Once the PR is reviewed and merged, a new Github release gets created and published, and this will also
 trigger a publish of the SDK packages to NPM.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -7,6 +7,7 @@ export default {
       2,
       'always',
       [
+        'release',
         'deploy',
         'build',
         'ci',


### PR DESCRIPTION
## Goal

This PR improves the release process by:

1. Splitting the publishing workflow into separate jobs for SDK and CLI
2. Adding a new workflow for version bumping that:
   - Creates a PR with version updates in package.json files
   - Labels PRs with "release" tag
3. Updating release-drafter configuration to:
   - Exclude PRs with "release" label
   - Use a forked version with additional functionality
4. Modifying permissions in CI workflow to be more restrictive
5. Adding "release" as a valid commit type in commitlint config

## Testing

The new flow works as follows:

1) people create PR with new code
2) those PRs get auto-labeled by release-drafter as patch/minor and also categorized as "feature","fix","maintenance", etc
3) PR gets merged, and no release is created neither in draft nor published
4) a new GitHub action available in the GH UI generates a PR for cutting a new release (a button in our repo's github web page)
5) that PR will include all the bumping of the versions + updated constants in code. We review it and merge it
6) when the release PR gets merged, a new release is generated in github and published immediately
7) publishing the GH release trigger a publish in npm