### PR TITLE
fix: checkout new branch during release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
           NEXT_VERSION="${{ steps.release_drafter.outputs.resolved_version }}"
           RELEASE_BODY="${{ steps.release_drafter.outputs.body }}"
           # create a new branch for the release
-          git branch "release-$NEXT_VERSION"
+          git checkout -b "release-$NEXT_VERSION"
           # commit the changes
           git config --global user.name 'embrace-ci'
           git config --global user.email 'embrace-ci@users.noreply.github.com'


### PR DESCRIPTION
## Goal

Fix the release workflow by changing the command to create a new branch for the release. Instead of just creating a branch with `git branch`, this PR changes the command to `git checkout -b` which creates the branch and checks it out in one step, ensuring that subsequent operations are performed on the newly created branch.