### PR TITLE
fix: disable releaser when the commit does NOT start with release

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: embrace-io/release-drafter@c3db6ed8d1ba035bbf9edcd5d89c1d5064d98dfb # fork from v6.1.0
         with:
           # only create a release if the last commit merged starts with "release". Coming from .github/workflows/release.yaml
-          disable-releaser: ${{ startsWith(github.event.head_commit.message, 'release') }}
+          disable-releaser: ${{ !startsWith(github.event.head_commit.message, 'release') }}
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Goal

Fix the release-drafter workflow by correcting the logic in the `disable-releaser` condition. The current implementation incorrectly disables the releaser when the commit message starts with "release", which is the opposite of the intended behavior. This change inverts the condition to properly enable the releaser only when commit messages start with "release".
