### PR TITLE
fix: adjust commit msg to make commitlint happy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,4 +72,4 @@ jobs:
           git commit -m "release: update version to $NEXT_VERSION"
           git push origin "release-$NEXT_VERSION"
           # create a PR with the next version
-          gh pr create --base main --title "release: Bump version to $NEXT_VERSION" --body "$RELEASE_BODY" -a "${{ github.actor }}" --label "release"
+          gh pr create --base main --title "release: bump version to $NEXT_VERSION" --body "$RELEASE_BODY" -a "${{ github.actor }}" --label "release"


### PR DESCRIPTION
## Goal
fix: adjust commit msg to make commitlint happy

example failed action https://github.com/embrace-io/embrace-web-sdk/actions/runs/14498444888/job/40672083380

```
⧗   input: release: Bump version to 0.1.2 (#301)

Co-authored-by: embrace-ci <embrace-ci@users.noreply.github.com>
✖   subject must not be sentence-case, start-case, pascal-case, upper-case [subject-case]
```