### PR TITLE
ci: make the publishing of the release a manual step

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -5,10 +5,10 @@ on:
     branches: [main]
   pull_request:
   release:
-    types: [created]
+    types: [released]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 env:
@@ -29,7 +29,7 @@ jobs:
         id: choose_environment
         run: |
           # Finalized releases get deployed to prod
-          if [ '${{ github.event_name }}' == 'release' ] && [ '${{ github.event.action }}' == 'created' ] && [ '${{ github.event.release.draft }}' == 'false' ]; then
+          if [ '${{ github.event_name }}' == 'release' ] && [ '${{ github.event.action }}' == 'released' ]; then
               echo 'name=production' >> $GITHUB_OUTPUT
           # All pushes to main get deployed to staging
           elif [ '${{ github.ref }}' == 'refs/heads/main' ] && [ '${{ github.event_name }}' == 'push' ]; then
@@ -131,7 +131,7 @@ jobs:
         if: ${{ env.TEST_PREVIOUSLY_PASSED != 'true' }}
         run: |
           # Disable coverage for releases to speed up tests, since nobody will see coverage results anyway
-          if [[ '${{ github.event_name }}/${{ github.event.action }}' == 'release/created' || '${{ github.actor }}' == 'dependabot[bot]' ]]; then
+          if [[ '${{ github.event_name }}/${{ github.event.action }}' == 'release/released' || '${{ github.actor }}' == 'dependabot[bot]' ]]; then
             argsCoverage=''
           else
             argsCoverage='--config=web-test-runner.coverage.config.js'
@@ -152,7 +152,7 @@ jobs:
       # https://github.com/codecov/codecov-action
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
-        if: ${{ env.TEST_PREVIOUSLY_PASSED != 'true' && github.event_name != 'created' && env.TEST_COLLECTED_COVERAGE == 'true' && success()}}
+        if: ${{ env.TEST_PREVIOUSLY_PASSED != 'true' && github.event_name != 'release' && env.TEST_COLLECTED_COVERAGE == 'true' && success()}}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: embrace-io/embrace-web-sdk

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -22,6 +22,5 @@ jobs:
         with:
           # only create a release if the last commit merged starts with "release". Coming from .github/workflows/release.yaml
           disable-releaser: ${{ !startsWith(github.event.head_commit.message, 'release') }}
-          publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -62,8 +62,8 @@ npm run sdk:test:watch
 
 New releases of the SDK are manually triggered through a [Github action workflow](.github/workflows/release.yaml).
 When triggered, a new PR with the next version of the SDK is created. This PR contains a changelog.
-Once the PR is reviewed and merged, a new Github release gets created and published, and this will also
-trigger a publish of the SDK packages to NPM.
+Once the PR is reviewed and merged, a new Github release gets created as a draft. Once that release is manually
+published, it will trigger a publish of the SDK packages to NPM.
 
 Note: the level of the version bump (major, minor, patch) is determined by the type of changes made to the SDK since the
 last release. You can see the requirements for each type of bump in


### PR DESCRIPTION
## Goal

needed to make it a manual step to avoid being published using the GITHUB_TOKEN auth from the release-drafter. That would prevent other action to trigger (the publishing action)