### PR TITLE
chore: clarify various behaviours in README and cover with tests

### DIFF
--- a/demo/frontend/src/otel.ts
+++ b/demo/frontend/src/otel.ts
@@ -11,13 +11,19 @@ import {
 const SAMPLE_APP_ID = import.meta.env.VITE_APP_ID;
 
 const setupOTel = () => {
-  sdk.initSDK({
+  const result = sdk.initSDK({
     appID: SAMPLE_APP_ID,
     spanProcessors: [new SimpleSpanProcessor(new ConsoleSpanExporter())],
     logProcessors: [
       new SimpleLogRecordProcessor(new ConsoleLogRecordExporter()),
     ],
   });
+
+  if (!!result) {
+    console.log('Successfully initialized the Embrace SDK');
+  } else {
+    console.log('Failed to initialize the Embrace SDK');
+  }
 };
 
 export { setupOTel };

--- a/src/testUtils/FailingStorage/FailingStorage.ts
+++ b/src/testUtils/FailingStorage/FailingStorage.ts
@@ -1,0 +1,25 @@
+export class FailingStorage implements Storage {
+  public get length() {
+    return 0;
+  }
+
+  public clear(): void {
+    throw new Error('not implemented');
+  }
+
+  public getItem(_key: string): string | null {
+    throw new Error('not implemented');
+  }
+
+  public key(_index: number): string | null {
+    throw new Error('not implemented');
+  }
+
+  public removeItem(_key: string): void {
+    throw new Error('not implemented');
+  }
+
+  public setItem(_key: string, _value: string): void {
+    throw new Error('not implemented');
+  }
+}

--- a/src/testUtils/FailingStorage/index.ts
+++ b/src/testUtils/FailingStorage/index.ts
@@ -1,0 +1,1 @@
+export { FailingStorage } from './FailingStorage.js';

--- a/src/testUtils/index.ts
+++ b/src/testUtils/index.ts
@@ -19,3 +19,4 @@ export { FakeSpanProcessor } from './FakeSpanProcessor/index.js';
 export { setupTestWebVitalListeners } from './setupTestWebVitalListeners/index.js';
 export { mockSpan } from './mockEntities/index.js';
 export { InMemoryStorage } from './InMemoryStorage/index.js';
+export { FailingStorage } from './FailingStorage/index.js';


### PR DESCRIPTION
## Goal

Clarifying a a few different scenarios that weren't previously in the README:
* how spans that are not ended are treated
* span attribute values must be strings
* setting up console exporters for debugging
* user manager handling cases where storage APIs aren't available