### PR TITLE
ci: prefix semser version level to avoid conflict with dependabot

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,13 +25,14 @@ categories:
 version-resolver:
   major:
     labels:
-      - 'major'
+      - 'semver-major'
   minor:
     labels:
-      - 'minor'
+      - 'semver-minor'
   patch:
     labels:
-      - 'patch'
+      - 'semver-patch'
+      - 'dependencies'
   default: patch
 
 autolabeler:
@@ -45,13 +46,13 @@ autolabeler:
     title:
       - '/(EMBR-[0-9]+\s+)?(feat).*/'
   # No major releases until we go out of beta
-  # - label: 'major'
+  # - label: 'semver-major'
   #   title: # anything with a "!" after the type
   #     - '/(EMBR-[0-9]+\s+)?(fix|revert|build|ci|docs|style|refactor|perf|test|chore|deploy|feat).*/'
-  - label: 'minor'
+  - label: 'semver-minor'
     title: # SAME AS 'feat'
       - '/(EMBR-[0-9]+\s+)?(feat).*/'
-  - label: 'patch'
+  - label: 'semver-patch'
     title: # SAME AS 'fix or maintenance'
       - '/(EMBR-[0-9]+\s+)?(fix|revert|build|ci|docs|style|refactor|perf|test|chore).*/'
 


### PR DESCRIPTION
## Goal

Update the release-drafter configuration to use standardized semantic versioning labels. This change renames the version labels from 'major', 'minor', and 'patch' to 'semver-major', 'semver-minor', and 'semver-patch' respectively. Additionally, it adds the 'dependencies' label to be treated as a patch version change.

I realized dependabot was already labeling its PRs with major minor and patch based on the level of the update from the third party library it was using. This was messing with OUR labeling. For example, if dependabot updates a major version of another library, that would end up meaning a major bump for us. 

This screenshot shows both dependabot labeling and our labeling, ending up with multiple bumping version levels. 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/S215IBu9kfHXNs3PdXXg/8317411f-9cd3-47a7-ac51-eb1bad7d38fc.png)

This change add a prefix so we don't conflict with dependabot. There is no way to turn off dependabot labeling