### PR TITLE
fix: validate tests types during cicd integration, fix existing failing type checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ demo/.DS_Store
 /docs/
 /coverage/
 **/.DS_Store
+/tsconfig.*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "sdk:lint:eslint": "eslint --max-warnings=0 ./src ./cli/src",
     "sdk:lint:prettier": "prettier --write ./src ./cli/src",
     "sdk:lint": "npm run sdk:lint:eslint && npm run sdk:lint:prettier",
-    "sdk:tsc:no:emit": "tsc --build --noEmit tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
+    "sdk:tsc:no:emit": "tsc --build --noEmit tsconfig.json tsconfig.esm.json tsconfig.esnext.json tsconfig.test.json",
     "sdk:lint:fix": "npm run sdk:lint:eslint:fix && npm run sdk:lint:prettier",
     "commitlint": "commitlint",
     "playwright": "playwright",

--- a/src/api-logs/api/LogAPI/LogAPI.test.ts
+++ b/src/api-logs/api/LogAPI/LogAPI.test.ts
@@ -1,12 +1,11 @@
 import * as chai from 'chai';
 import * as sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import { type LogManager, ProxyLogManager } from '../../manager/index.js';
 import { LogAPI } from './LogAPI.js';
-import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 const { expect } = chai;
-
 afterEach(() => {
   sinon.restore();
 });
@@ -53,12 +52,12 @@ describe('LogAPI', () => {
 
     const ts = Date.now();
     const err = new Error();
-    logAPI.logException(ts, err, true, { key: 'value' });
+    logAPI.logException(err, true, { key: 'value' }, ts);
     expect(mockLogManager.logException).to.have.been.calledOnceWith(
-      ts,
       err,
       true,
-      { key: 'value' }
+      { key: 'value' },
+      ts
     );
   });
 });

--- a/src/api-logs/manager/NoOpLogManager/NoOpLogManager.test.ts
+++ b/src/api-logs/manager/NoOpLogManager/NoOpLogManager.test.ts
@@ -18,7 +18,7 @@ describe('NoOpLogManager', () => {
 
   it('should not throw for logException', () => {
     expect(() => {
-      noOpLogManager.logException(Date.now(), new Error(), true);
+      noOpLogManager.logException(new Error(), true, {}, Date.now());
     }).to.not.throw();
   });
 });

--- a/src/api-logs/manager/ProxyLogManager/ProxyLogManager.test.ts
+++ b/src/api-logs/manager/ProxyLogManager/ProxyLogManager.test.ts
@@ -41,9 +41,14 @@ describe('ProxyLogManager', () => {
 
   it('should delegate logException to the delegate', () => {
     proxyLogManager.setDelegate(mockDelegate);
-    proxyLogManager.logException(Date.now(), new Error(), true, {
-      key1: 'value1',
-    });
+    proxyLogManager.logException(
+      new Error(),
+      true,
+      {
+        key1: 'value1',
+      },
+      Date.now()
+    );
     void expect(mockDelegate.logException).to.have.been.calledOnce;
   });
 });


### PR DESCRIPTION
## Goal

We weren't validating typescript check for testing files. This PRs adds such check to our PRs `typecheck` github action step.

I am also fixing a couple of error already there that we missed because of this lack of automated check