### PR TITLE
EMBR-7455 chore: add configuration for creating background sessions

### DIFF
--- a/src/api-sessions/manager/types.ts
+++ b/src/api-sessions/manager/types.ts
@@ -25,4 +25,4 @@ export type ReasonSessionEnded =
   | 'timer' // max_time_reached limit
   | 'manual' // using the public api
   | 'max_size_reached'
-  | 'bkgnd_state'; // visibility change to hidden
+  | 'state_changed'; // visibility change

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,0 +1,1 @@
+export type { VisibilityStateDocument } from './types.js';

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,0 +1,4 @@
+// Useful for testing so that we can pass in a document-like object and change its visibilityState
+export interface VisibilityStateDocument {
+  visibilityState: DocumentVisibilityState;
+}

--- a/src/constants/attributes.ts
+++ b/src/constants/attributes.ts
@@ -18,4 +18,5 @@ export enum EMB_TYPES {
 
 export enum EMB_STATES {
   Foreground = 'foreground',
+  Background = 'background',
 }

--- a/src/instrumentations/session/SpanSessionTimeoutInstrumentation/SpanSessionTimeoutInstrumentation.test.ts
+++ b/src/instrumentations/session/SpanSessionTimeoutInstrumentation/SpanSessionTimeoutInstrumentation.test.ts
@@ -111,7 +111,7 @@ describe('SpanSessionTimeoutInstrumentation', () => {
     const sessionSpanA = finishedSpans[0];
     expect(sessionSpanA.attributes).to.have.property(
       KEY_EMB_SESSION_REASON_ENDED,
-      'unknown'
+      'manual'
     );
     expect(sessionSpanA.attributes).to.have.property(
       ATTR_SESSION_ID,

--- a/src/instrumentations/session/SpanSessionTimeoutInstrumentation/SpanSessionTimeoutInstrumentation.test.ts
+++ b/src/instrumentations/session/SpanSessionTimeoutInstrumentation/SpanSessionTimeoutInstrumentation.test.ts
@@ -111,7 +111,7 @@ describe('SpanSessionTimeoutInstrumentation', () => {
     const sessionSpanA = finishedSpans[0];
     expect(sessionSpanA.attributes).to.have.property(
       KEY_EMB_SESSION_REASON_ENDED,
-      'manual'
+      'unknown'
     );
     expect(sessionSpanA.attributes).to.have.property(
       ATTR_SESSION_ID,

--- a/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.test.ts
+++ b/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.test.ts
@@ -4,51 +4,109 @@ import {
   session,
   type SpanSessionManager,
 } from '../../../api-sessions/index.js';
-import {
-  InMemoryDiagLogger,
-  setupTestTraceExporter,
-} from '../../../testUtils/index.js';
+import { setupTestTraceExporter } from '../../../testUtils/index.js';
 import { EmbraceSpanSessionManager } from '../../../managers/index.js';
 import { SpanSessionVisibilityInstrumentation } from './SpanSessionVisibilityInstrumentation.js';
+import { KEY_EMB_SESSION_REASON_ENDED } from '../../../constants/index.js';
+import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
+import type { VisibilityStateDocument } from './types.js';
 
 const { expect } = chai;
 
 describe('SpanSessionVisibilityInstrumentation', () => {
+  let memoryExporter: InMemorySpanExporter;
   let instrumentation: SpanSessionVisibilityInstrumentation;
   let spanSessionManager: SpanSessionManager;
-  let diag: InMemoryDiagLogger;
 
   before(() => {
-    void setupTestTraceExporter();
+    memoryExporter = setupTestTraceExporter();
   });
 
   beforeEach(() => {
-    diag = new InMemoryDiagLogger();
     spanSessionManager = new EmbraceSpanSessionManager();
     session.setGlobalSessionManager(spanSessionManager);
-    instrumentation = new SpanSessionVisibilityInstrumentation({ diag });
   });
 
   afterEach(() => {
     instrumentation.disable();
+    memoryExporter.reset();
     sinon.restore();
   });
 
   it('should initialize', () => {
+    instrumentation = new SpanSessionVisibilityInstrumentation();
     expect(instrumentation).to.be.instanceOf(
       SpanSessionVisibilityInstrumentation
     );
   });
 
   it('should start a session when visibility changes to visible', () => {
+    instrumentation = new SpanSessionVisibilityInstrumentation();
     void expect(spanSessionManager.getSessionSpan()).to.be.null;
     window.dispatchEvent(new Event('visibilitychange'));
-    spanSessionManager.startSessionSpan();
     void expect(spanSessionManager.getSessionSpan()).to.not.be.null;
   });
 
-  it.skip('should end a session when visibility is hidden', () => {
-    // TODO: implement test. This requires mocking the document.visibilityState readonlu property, which may require a mocked DOM.
-    //  there are no native events that can be dispatched to trigger the a change in this property
+  it('should end the previous a session and start a new one when visibility changes to visible', () => {
+    instrumentation = new SpanSessionVisibilityInstrumentation();
+    spanSessionManager.startSessionSpan();
+    void expect(spanSessionManager.getSessionSpan()).to.not.be.null;
+    window.dispatchEvent(new Event('visibilitychange'));
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.attributes).to.have.property(
+      KEY_EMB_SESSION_REASON_ENDED,
+      'state_changed'
+    );
+
+    void expect(spanSessionManager.getSessionSpan()).to.not.be.null;
+  });
+
+  it('should end a session when visibility is hidden and not start a new one by default', () => {
+    const visibilityDoc: VisibilityStateDocument = {
+      visibilityState: 'hidden',
+    };
+
+    instrumentation = new SpanSessionVisibilityInstrumentation({
+      visibilityDoc,
+    });
+
+    spanSessionManager.startSessionSpan();
+    void expect(spanSessionManager.getSessionSpan()).to.not.be.null;
+    window.dispatchEvent(new Event('visibilitychange'));
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.attributes).to.have.property(
+      KEY_EMB_SESSION_REASON_ENDED,
+      'state_changed'
+    );
+
+    void expect(spanSessionManager.getSessionSpan()).to.be.null;
+  });
+
+  it('should end a session when visibility is hidden and start a new one when background sessions are enabled', () => {
+    const visibilityDoc: VisibilityStateDocument = {
+      visibilityState: 'hidden',
+    };
+
+    instrumentation = new SpanSessionVisibilityInstrumentation({
+      visibilityDoc,
+      backgroundSessions: true,
+    });
+
+    spanSessionManager.startSessionSpan();
+    void expect(spanSessionManager.getSessionSpan()).to.not.be.null;
+    window.dispatchEvent(new Event('visibilitychange'));
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.attributes).to.have.property(
+      KEY_EMB_SESSION_REASON_ENDED,
+      'state_changed'
+    );
+
+    void expect(spanSessionManager.getSessionSpan()).not.to.be.null;
   });
 });

--- a/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.test.ts
+++ b/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.test.ts
@@ -9,7 +9,7 @@ import { EmbraceSpanSessionManager } from '../../../managers/index.js';
 import { SpanSessionVisibilityInstrumentation } from './SpanSessionVisibilityInstrumentation.js';
 import { KEY_EMB_SESSION_REASON_ENDED } from '../../../constants/index.js';
 import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
-import type { VisibilityStateDocument } from './types.js';
+import type { VisibilityStateDocument } from '../../../common/index.js';
 
 const { expect } = chai;
 

--- a/src/instrumentations/session/SpanSessionVisibilityInstrumentation/types.ts
+++ b/src/instrumentations/session/SpanSessionVisibilityInstrumentation/types.ts
@@ -1,9 +1,5 @@
 import type { EmbraceInstrumentationBaseArgs } from '../../EmbraceInstrumentationBase/index.js';
-
-// Useful for testing so that we can pass in a document-like object and change its visibilityState
-export interface VisibilityStateDocument {
-  visibilityState: DocumentVisibilityState;
-}
+import type { VisibilityStateDocument } from '../../../common/index.js';
 
 export type SpanSessionVisibilityInstrumentationArgs = Pick<
   EmbraceInstrumentationBaseArgs,

--- a/src/instrumentations/session/SpanSessionVisibilityInstrumentation/types.ts
+++ b/src/instrumentations/session/SpanSessionVisibilityInstrumentation/types.ts
@@ -1,6 +1,14 @@
 import type { EmbraceInstrumentationBaseArgs } from '../../EmbraceInstrumentationBase/index.js';
 
+// Useful for testing so that we can pass in a document-like object and change its visibilityState
+export interface VisibilityStateDocument {
+  visibilityState: DocumentVisibilityState;
+}
+
 export type SpanSessionVisibilityInstrumentationArgs = Pick<
   EmbraceInstrumentationBaseArgs,
   'diag'
->;
+> & {
+  backgroundSessions?: boolean;
+  visibilityDoc?: VisibilityStateDocument;
+};

--- a/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
+++ b/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
@@ -8,7 +8,7 @@ import {
   setupTestTraceExporter,
 } from '../../testUtils/index.js';
 import { EmbraceSpanSessionManager } from './EmbraceSpanSessionManager.js';
-import type { VisibilityStateDocument } from './types.js';
+import type { VisibilityStateDocument } from '../../common/index.js';
 
 chai.use(sinonChai);
 const { expect } = chai;
@@ -83,7 +83,7 @@ describe('EmbraceSpanSessionManager', () => {
     const sessionSpan = finishedSpans[0];
     expect(sessionSpan.attributes).to.have.property(
       KEY_EMB_SESSION_REASON_ENDED,
-      'unknown'
+      'manual'
     );
     expect(sessionSpan.attributes).to.have.property(ATTR_SESSION_ID, sessionID);
   });

--- a/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
+++ b/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
@@ -8,6 +8,7 @@ import {
   setupTestTraceExporter,
 } from '../../testUtils/index.js';
 import { EmbraceSpanSessionManager } from './EmbraceSpanSessionManager.js';
+import type { VisibilityStateDocument } from './types.js';
 
 chai.use(sinonChai);
 const { expect } = chai;
@@ -82,7 +83,7 @@ describe('EmbraceSpanSessionManager', () => {
     const sessionSpan = finishedSpans[0];
     expect(sessionSpan.attributes).to.have.property(
       KEY_EMB_SESSION_REASON_ENDED,
-      'manual'
+      'unknown'
     );
     expect(sessionSpan.attributes).to.have.property(ATTR_SESSION_ID, sessionID);
   });
@@ -160,5 +161,33 @@ describe('EmbraceSpanSessionManager', () => {
       'manual'
     );
     expect(sessionSpan.attributes).to.have.property('emb.type', 'ux.session');
+  });
+
+  it('should start a foreground session when the document is visible', () => {
+    const visibilityDoc: VisibilityStateDocument = {
+      visibilityState: 'visible',
+    };
+    const manager = new EmbraceSpanSessionManager({ visibilityDoc });
+    manager.startSessionSpan();
+    manager.endSessionSpan();
+
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.attributes).to.have.property('emb.state', 'foreground');
+  });
+
+  it('should start a background session when the document is hidden', () => {
+    const visibilityDoc: VisibilityStateDocument = {
+      visibilityState: 'hidden',
+    };
+    const manager = new EmbraceSpanSessionManager({ visibilityDoc });
+    manager.startSessionSpan();
+    manager.endSessionSpan();
+
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.attributes).to.have.property('emb.state', 'background');
   });
 });

--- a/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
+++ b/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
@@ -22,7 +22,10 @@ import {
 } from '../../constants/index.js';
 import type { PerformanceManager } from '../../utils/index.js';
 import { generateUUID, OTelPerformanceManager } from '../../utils/index.js';
-import type { EmbraceSpanSessionManagerArgs } from './types.js';
+import type {
+  EmbraceSpanSessionManagerArgs,
+  VisibilityStateDocument,
+} from './types.js';
 
 export class EmbraceSpanSessionManager implements SpanSessionManager {
   private _activeSessionId: string | null = null;
@@ -30,10 +33,12 @@ export class EmbraceSpanSessionManager implements SpanSessionManager {
   private _sessionSpan: Span | null = null;
   private readonly _diag: DiagLogger;
   private readonly _perf: PerformanceManager;
+  private readonly _visibilityDoc: VisibilityStateDocument;
 
   public constructor({
     diag: diagParam,
     perf,
+    visibilityDoc = window.document,
   }: EmbraceSpanSessionManagerArgs = {}) {
     this._diag =
       diagParam ??
@@ -41,6 +46,7 @@ export class EmbraceSpanSessionManager implements SpanSessionManager {
         namespace: 'EmbraceSpanSessionManager',
       });
     this._perf = perf ?? new OTelPerformanceManager();
+    this._visibilityDoc = visibilityDoc;
   }
 
   // the external api doesn't include a reason, and if a users uses it to end a session, the reason will be 'user_ended'
@@ -106,7 +112,7 @@ export class EmbraceSpanSessionManager implements SpanSessionManager {
   public startSessionSpan() {
     //if there was a session in progress already, finish it first.
     if (this._sessionSpan) {
-      this.endSessionSpanInternal('manual');
+      this.endSessionSpanInternal('unknown');
     }
     const tracer = trace.getTracer('embrace-web-sdk-sessions');
     this._activeSessionId = generateUUID();
@@ -114,7 +120,10 @@ export class EmbraceSpanSessionManager implements SpanSessionManager {
     this._sessionSpan = tracer.startSpan('emb-session', {
       attributes: {
         [KEY_EMB_TYPE]: EMB_TYPES.Session,
-        [KEY_EMB_STATE]: EMB_STATES.Foreground,
+        [KEY_EMB_STATE]:
+          this._visibilityDoc.visibilityState === 'hidden'
+            ? EMB_STATES.Background
+            : EMB_STATES.Foreground,
         [ATTR_SESSION_ID]: this._activeSessionId,
       },
     });

--- a/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
+++ b/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
@@ -22,10 +22,8 @@ import {
 } from '../../constants/index.js';
 import type { PerformanceManager } from '../../utils/index.js';
 import { generateUUID, OTelPerformanceManager } from '../../utils/index.js';
-import type {
-  EmbraceSpanSessionManagerArgs,
-  VisibilityStateDocument,
-} from './types.js';
+import type { EmbraceSpanSessionManagerArgs } from './types.js';
+import type { VisibilityStateDocument } from '../../common/index.js';
 
 export class EmbraceSpanSessionManager implements SpanSessionManager {
   private _activeSessionId: string | null = null;
@@ -112,7 +110,7 @@ export class EmbraceSpanSessionManager implements SpanSessionManager {
   public startSessionSpan() {
     //if there was a session in progress already, finish it first.
     if (this._sessionSpan) {
-      this.endSessionSpanInternal('unknown');
+      this.endSessionSpanInternal('manual');
     }
     const tracer = trace.getTracer('embrace-web-sdk-sessions');
     this._activeSessionId = generateUUID();

--- a/src/managers/EmbraceSpanSessionManager/types.ts
+++ b/src/managers/EmbraceSpanSessionManager/types.ts
@@ -1,7 +1,13 @@
 import type { DiagLogger } from '@opentelemetry/api';
 import type { PerformanceManager } from '../../utils/index.js';
 
+// Useful for testing so that we can pass in a document-like object and change its visibilityState
+export interface VisibilityStateDocument {
+  visibilityState: DocumentVisibilityState;
+}
+
 export interface EmbraceSpanSessionManagerArgs {
   diag?: DiagLogger;
   perf?: PerformanceManager;
+  visibilityDoc?: VisibilityStateDocument;
 }

--- a/src/managers/EmbraceSpanSessionManager/types.ts
+++ b/src/managers/EmbraceSpanSessionManager/types.ts
@@ -1,10 +1,6 @@
 import type { DiagLogger } from '@opentelemetry/api';
 import type { PerformanceManager } from '../../utils/index.js';
-
-// Useful for testing so that we can pass in a document-like object and change its visibilityState
-export interface VisibilityStateDocument {
-  visibilityState: DocumentVisibilityState;
-}
+import type { VisibilityStateDocument } from '../../common/index.js';
 
 export interface EmbraceSpanSessionManagerArgs {
   diag?: DiagLogger;


### PR DESCRIPTION
## Goal

Adding a configuration parameter to `SpanSessionVisibilityInstrumentation` to have it create sessions when the document becomes hidden, defaulting to false for now