### PR TITLE
chore: make sure parents can be set for performance spans

### DIFF
--- a/src/api-traces/api/TraceAPI/TraceAPI.ts
+++ b/src/api-traces/api/TraceAPI/TraceAPI.ts
@@ -1,6 +1,9 @@
-import type { SpanOptions } from '@opentelemetry/api';
 import { ProxyTraceManager, type TraceManager } from '../../manager/index.js';
-import type { PerformanceSpan, TraceAPIArgs } from './types.js';
+import type {
+  PerformanceSpan,
+  PerformanceSpanOptions,
+  TraceAPIArgs,
+} from './types.js';
 
 export class TraceAPI implements TraceManager {
   private static _instance?: TraceAPI;
@@ -30,7 +33,7 @@ export class TraceAPI implements TraceManager {
 
   public startPerformanceSpan(
     name: string,
-    options?: SpanOptions
+    options?: PerformanceSpanOptions
   ): PerformanceSpan | null {
     return this.getTraceManager().startPerformanceSpan(name, options);
   }

--- a/src/api-traces/api/TraceAPI/index.ts
+++ b/src/api-traces/api/TraceAPI/index.ts
@@ -1,2 +1,6 @@
 export { TraceAPI } from './TraceAPI.js';
-export type { PerformanceSpan, PerformanceSpanFailedOptions } from './types.js';
+export type {
+  PerformanceSpan,
+  PerformanceSpanFailedOptions,
+  PerformanceSpanOptions,
+} from './types.js';

--- a/src/api-traces/api/TraceAPI/types.ts
+++ b/src/api-traces/api/TraceAPI/types.ts
@@ -1,4 +1,5 @@
 import type { ProxyTraceManager } from '../../manager/index.js';
+import type { SpanOptions } from '@opentelemetry/api';
 import { type Span, type TimeInput } from '@opentelemetry/api';
 
 export interface TraceAPIArgs {
@@ -14,3 +15,7 @@ export type PerformanceSpanFailureCode = 'failure' | 'user_abandon';
 export interface PerformanceSpan extends Span {
   fail: (options?: PerformanceSpanFailedOptions) => void;
 }
+
+export type PerformanceSpanOptions = SpanOptions & {
+  parentSpan?: Span;
+};

--- a/src/api-traces/api/index.ts
+++ b/src/api-traces/api/index.ts
@@ -2,4 +2,5 @@ export { TraceAPI } from './TraceAPI/index.js';
 export type {
   PerformanceSpan,
   PerformanceSpanFailedOptions,
+  PerformanceSpanOptions,
 } from './TraceAPI/index.js';

--- a/src/api-traces/index.ts
+++ b/src/api-traces/index.ts
@@ -4,4 +4,5 @@ export { NoOpTraceManager, ProxyTraceManager } from './manager/index.js';
 export type {
   PerformanceSpan,
   PerformanceSpanFailedOptions,
+  PerformanceSpanOptions,
 } from './api/index.js';

--- a/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.ts
+++ b/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.ts
@@ -1,11 +1,13 @@
-import type { SpanOptions } from '@opentelemetry/api';
 import type { TraceManager } from '../index.js';
-import type { PerformanceSpan } from '../../api/index.js';
+import type {
+  PerformanceSpan,
+  PerformanceSpanOptions,
+} from '../../api/index.js';
 
 export class NoOpTraceManager implements TraceManager {
   public startPerformanceSpan(
     _name: string,
-    _options?: SpanOptions
+    _options?: PerformanceSpanOptions
   ): PerformanceSpan | null {
     return null;
   }

--- a/src/api-traces/manager/ProxyTraceManager/ProxyTraceManager.ts
+++ b/src/api-traces/manager/ProxyTraceManager/ProxyTraceManager.ts
@@ -1,7 +1,9 @@
-import type { SpanOptions } from '@opentelemetry/api';
 import type { TraceManager } from '../index.js';
 import { NoOpTraceManager } from '../NoOpTraceManager/index.js';
-import type { PerformanceSpan } from '../../api/index.js';
+import type {
+  PerformanceSpan,
+  PerformanceSpanOptions,
+} from '../../api/index.js';
 
 const NOOP_TRACE_MANAGER = new NoOpTraceManager();
 
@@ -18,7 +20,7 @@ export class ProxyTraceManager implements TraceManager {
 
   public startPerformanceSpan(
     name: string,
-    options?: SpanOptions
+    options?: PerformanceSpanOptions
   ): PerformanceSpan | null {
     return this.getDelegate().startPerformanceSpan(name, options);
   }

--- a/src/api-traces/manager/types.ts
+++ b/src/api-traces/manager/types.ts
@@ -1,9 +1,8 @@
-import type { SpanOptions } from '@opentelemetry/api';
-import type { PerformanceSpan } from '../api/index.js';
+import type { PerformanceSpan, PerformanceSpanOptions } from '../api/index.js';
 
 export interface TraceManager {
   startPerformanceSpan: (
     name: string,
-    options?: SpanOptions
+    options?: PerformanceSpanOptions
   ) => PerformanceSpan | null;
 }

--- a/src/managers/EmbraceTraceManager/EmbraceTraceManager.ts
+++ b/src/managers/EmbraceTraceManager/EmbraceTraceManager.ts
@@ -1,17 +1,26 @@
-import { type SpanOptions, trace } from '@opentelemetry/api';
-import type { TraceManager, PerformanceSpan } from '../../api-traces/index.js';
+import { trace, context } from '@opentelemetry/api';
+import type {
+  TraceManager,
+  PerformanceSpan,
+  PerformanceSpanOptions,
+} from '../../api-traces/index.js';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
 import { EmbracePerformanceSpan } from './EmbracePerformanceSpan.js';
 
 export class EmbraceTraceManager implements TraceManager {
   public startPerformanceSpan(
     name: string,
-    options: SpanOptions = {}
+    options: PerformanceSpanOptions = {}
   ): PerformanceSpan {
     const tracer = trace.getTracer('embrace-web-sdk-traces');
 
     options.attributes = options.attributes ? options.attributes : {};
     options.attributes[KEY_EMB_TYPE] = EMB_TYPES.Perf;
-    return new EmbracePerformanceSpan(tracer.startSpan(name, options));
+
+    const ctx = options.parentSpan
+      ? trace.setSpan(context.active(), options.parentSpan)
+      : undefined;
+
+    return new EmbracePerformanceSpan(tracer.startSpan(name, options, ctx));
   }
 }


### PR DESCRIPTION
## Goal

Added tests to cover creating a performance span with a parent, also ended up adding a `parentSpan` option to the API to make it a bit easier to do 