### PR TITLE
breaking: consistently group optional parameters in exported API

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,10 @@ trigger a network request to export the data:
 import { log } from '@embrace-io/web-sdk';
 
 log.message('Loading not finished in time.', 'error', {
-  propertyA: 'valueA',
-  propertyB: 'valueB'
+  attributes: {
+     propertyA: 'valueA',
+     propertyB: 'valueB'
+  }
 });
 ```
 
@@ -140,8 +142,10 @@ try {
   // some operation...
 } catch (e) {
   log.logException(e as Error, true, {
-    propertyA: 'valueA',
-    propertyB: 'valueB'
+     attributes: {
+       propertyA: 'valueA',
+       propertyB: 'valueB'
+     }
   });
 }
 ```

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -20,6 +20,7 @@ export default {
         'test',
         'chore',
         'revert',
+        'breaking',
       ],
     ],
   },

--- a/src/api-logs/api/LogAPI/LogAPI.test.ts
+++ b/src/api-logs/api/LogAPI/LogAPI.test.ts
@@ -43,21 +43,28 @@ describe('LogAPI', () => {
     };
     logAPI.setGlobalLogManager(mockLogManager);
 
-    logAPI.message('This is an info log', 'info', { key: 'value' });
+    logAPI.message('This is an info log', 'info', {
+      attributes: { key: 'value' },
+    });
     expect(mockLogManager.message).to.have.been.calledOnceWith(
       'This is an info log',
       'info',
-      { key: 'value' }
+      {
+        attributes: { key: 'value' },
+      }
     );
 
     const ts = Date.now();
     const err = new Error();
-    logAPI.logException(err, true, { key: 'value' }, ts);
-    expect(mockLogManager.logException).to.have.been.calledOnceWith(
-      err,
-      true,
-      { key: 'value' },
-      ts
-    );
+    logAPI.logException(err, {
+      handled: true,
+      attributes: { key: 'value' },
+      timestamp: ts,
+    });
+    expect(mockLogManager.logException).to.have.been.calledOnceWith(err, {
+      handled: true,
+      attributes: { key: 'value' },
+      timestamp: ts,
+    });
   });
 });

--- a/src/api-logs/api/LogAPI/LogAPI.ts
+++ b/src/api-logs/api/LogAPI/LogAPI.ts
@@ -1,5 +1,8 @@
-import type { AttributeValue } from '@opentelemetry/api';
-import type { LogSeverity } from '../../manager/index.js';
+import type {
+  LogExceptionOptions,
+  LogMessageOptions,
+  LogSeverity,
+} from '../../manager/index.js';
 import { type LogManager, ProxyLogManager } from '../../manager/index.js';
 import type { LogAPIArgs } from './types.js';
 
@@ -29,21 +32,15 @@ export class LogAPI implements LogManager {
     this._proxyLogManager.setDelegate(logManager);
   }
 
-  public logException(
-    error: Error,
-    handled: boolean,
-    attributes?: Record<string, AttributeValue | undefined>,
-    timestamp?: number
-  ) {
-    this.getLogManager().logException(error, handled, attributes, timestamp);
+  public logException(error: Error, options?: LogExceptionOptions) {
+    this.getLogManager().logException(error, options);
   }
 
   public message(
     message: string,
     level: LogSeverity,
-    attributes?: Record<string, AttributeValue | undefined>,
-    includeStacktrace?: boolean
+    options?: LogMessageOptions
   ) {
-    this.getLogManager().message(message, level, attributes, includeStacktrace);
+    this.getLogManager().message(message, level, options);
   }
 }

--- a/src/api-logs/manager/NoOpLogManager/NoOpLogManager.test.ts
+++ b/src/api-logs/manager/NoOpLogManager/NoOpLogManager.test.ts
@@ -11,14 +11,19 @@ describe('NoOpLogManager', () => {
   it('should not throw for message', () => {
     expect(() => {
       noOpLogManager.message('logging an error log', 'error', {
-        key1: 'value1',
+        attributes: {
+          key1: 'value1',
+        },
       });
     }).to.not.throw();
   });
 
   it('should not throw for logException', () => {
     expect(() => {
-      noOpLogManager.logException(new Error(), true, {}, Date.now());
+      noOpLogManager.logException(new Error(), {
+        handled: true,
+        timestamp: Date.now(),
+      });
     }).to.not.throw();
   });
 });

--- a/src/api-logs/manager/NoOpLogManager/NoOpLogManager.ts
+++ b/src/api-logs/manager/NoOpLogManager/NoOpLogManager.ts
@@ -1,21 +1,19 @@
-import type { AttributeValue } from '@opentelemetry/api';
-import type { LogManager, LogSeverity } from '../index.js';
+import type {
+  LogExceptionOptions,
+  LogManager,
+  LogMessageOptions,
+  LogSeverity,
+} from '../index.js';
 
 export class NoOpLogManager implements LogManager {
-  public logException(
-    _error: Error,
-    _handled: boolean,
-    _attributes?: Record<string, AttributeValue | undefined>,
-    _timestamp?: number
-  ) {
+  public logException(_error: Error, _options?: LogExceptionOptions) {
     // no op
   }
 
   public message(
     _message: string,
     _level: LogSeverity,
-    _attributes?: Record<string, AttributeValue | undefined>,
-    _includeStacktrace?: boolean
+    _options?: LogMessageOptions
   ) {
     // no op
   }

--- a/src/api-logs/manager/ProxyLogManager/ProxyLogManager.test.ts
+++ b/src/api-logs/manager/ProxyLogManager/ProxyLogManager.test.ts
@@ -34,21 +34,22 @@ describe('ProxyLogManager', () => {
   it('should delegate message to the delegate', () => {
     proxyLogManager.setDelegate(mockDelegate);
     proxyLogManager.message('logging a log', 'info', {
-      key1: 'value1',
+      attributes: {
+        key1: 'value1',
+      },
     });
     void expect(mockDelegate.message).to.have.been.calledOnce;
   });
 
   it('should delegate logException to the delegate', () => {
     proxyLogManager.setDelegate(mockDelegate);
-    proxyLogManager.logException(
-      new Error(),
-      true,
-      {
+    proxyLogManager.logException(new Error(), {
+      handled: true,
+      attributes: {
         key1: 'value1',
       },
-      Date.now()
-    );
+      timestamp: Date.now(),
+    });
     void expect(mockDelegate.logException).to.have.been.calledOnce;
   });
 });

--- a/src/api-logs/manager/ProxyLogManager/ProxyLogManager.ts
+++ b/src/api-logs/manager/ProxyLogManager/ProxyLogManager.ts
@@ -1,5 +1,9 @@
-import type { AttributeValue } from '@opentelemetry/api';
-import type { LogManager, LogSeverity } from '../index.js';
+import type {
+  LogExceptionOptions,
+  LogManager,
+  LogMessageOptions,
+  LogSeverity,
+} from '../index.js';
 import { NoOpLogManager } from '../NoOpLogManager/index.js';
 
 const NOOP_LOG_MANAGER = new NoOpLogManager();
@@ -15,21 +19,15 @@ export class ProxyLogManager implements LogManager {
     this._delegate = delegate;
   }
 
-  public logException(
-    error: Error,
-    handled: boolean,
-    attributes?: Record<string, AttributeValue | undefined>,
-    timestamp?: number
-  ) {
-    this.getDelegate().logException(error, handled, attributes, timestamp);
+  public logException(error: Error, options?: LogExceptionOptions) {
+    this.getDelegate().logException(error, options);
   }
 
   public message(
     message: string,
     level: LogSeverity,
-    attributes?: Record<string, AttributeValue | undefined>,
-    includeStacktrace?: boolean
+    options?: LogMessageOptions
   ) {
-    this.getDelegate().message(message, level, attributes, includeStacktrace);
+    this.getDelegate().message(message, level, options);
   }
 }

--- a/src/api-logs/manager/index.ts
+++ b/src/api-logs/manager/index.ts
@@ -1,3 +1,8 @@
-export type { LogManager, LogSeverity } from './types.js';
+export type {
+  LogManager,
+  LogSeverity,
+  LogExceptionOptions,
+  LogMessageOptions,
+} from './types.js';
 export { NoOpLogManager } from './NoOpLogManager/index.js';
 export { ProxyLogManager } from './ProxyLogManager/index.js';

--- a/src/api-logs/manager/types.ts
+++ b/src/api-logs/manager/types.ts
@@ -1,19 +1,24 @@
 import type { AttributeValue } from '@opentelemetry/api';
 
+export type LogMessageOptions = {
+  attributes?: Record<string, AttributeValue | undefined>;
+  includeStacktrace?: boolean;
+};
+
+export type LogExceptionOptions = {
+  handled?: boolean;
+  attributes?: Record<string, AttributeValue | undefined>;
+  timestamp?: number;
+};
+
 export interface LogManager {
   message: (
     message: string,
     level: LogSeverity,
-    attributes?: Record<string, AttributeValue | undefined>,
-    includeStacktrace?: boolean
+    options?: LogMessageOptions
   ) => void;
 
-  logException: (
-    error: Error,
-    handled: boolean,
-    attributes?: Record<string, AttributeValue | undefined>,
-    timestamp?: number
-  ) => void;
+  logException: (error: Error, options?: LogExceptionOptions) => void;
 }
 
 export type LogSeverity = 'info' | 'warning' | 'error';

--- a/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
+++ b/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
@@ -16,12 +16,9 @@ export class GlobalExceptionInstrumentation extends EmbraceInstrumentationBase {
       config: {},
     });
     this._onErrorHandler = (event: ErrorEvent) => {
-      this.logManager.logException(
-        event.error as Error,
-        false,
-        {},
-        this.perf.epochMillisFromOriginOffset(event.timeStamp)
-      );
+      this.logManager.logException(event.error as Error, {
+        timestamp: this.perf.epochMillisFromOriginOffset(event.timeStamp),
+      });
     };
     this._onUnhandledRejectionHandler = (event: PromiseRejectionEvent) => {
       let error: Error;
@@ -36,12 +33,9 @@ export class GlobalExceptionInstrumentation extends EmbraceInstrumentationBase {
         error.stack = '';
       }
 
-      this.logManager.logException(
-        error,
-        false,
-        {},
-        this.perf.epochMillisFromOriginOffset(event.timeStamp)
-      );
+      this.logManager.logException(error, {
+        timestamp: this.perf.epochMillisFromOriginOffset(event.timeStamp),
+      });
     };
 
     if (this._config.enabled) {

--- a/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
+++ b/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
@@ -17,6 +17,7 @@ export class GlobalExceptionInstrumentation extends EmbraceInstrumentationBase {
     });
     this._onErrorHandler = (event: ErrorEvent) => {
       this.logManager.logException(event.error as Error, {
+        handled: false,
         timestamp: this.perf.epochMillisFromOriginOffset(event.timeStamp),
       });
     };
@@ -34,6 +35,7 @@ export class GlobalExceptionInstrumentation extends EmbraceInstrumentationBase {
       }
 
       this.logManager.logException(error, {
+        handled: false,
         timestamp: this.perf.epochMillisFromOriginOffset(event.timeStamp),
       });
     };

--- a/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
+++ b/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
@@ -48,7 +48,9 @@ describe('EmbraceLogManager', () => {
         'this is an info log without stacktrace and one attribute',
         'info',
         {
-          attr_key: 'attr value',
+          attributes: {
+            attr_key: 'attr value',
+          },
         }
       );
     }).to.not.throw();
@@ -73,7 +75,9 @@ describe('EmbraceLogManager', () => {
   it('should log a warning log with stacktrace', () => {
     expect(() => {
       manager.message('this is a warning log with stacktrace', 'warning', {
-        attr_key: 'attr value',
+        attributes: {
+          attr_key: 'attr value',
+        },
       });
     }).to.not.throw();
 
@@ -92,14 +96,9 @@ describe('EmbraceLogManager', () => {
 
   it('should log a warning log without stacktrace', () => {
     expect(() => {
-      manager.message(
-        'this is a warning log with stacktrace',
-        'warning',
-        {
-          attr_key: 'attr value',
-        },
-        false
-      );
+      manager.message('this is a warning log with stacktrace', 'warning', {
+        includeStacktrace: false,
+      });
     }).to.not.throw();
 
     const finishedLogs = memoryExporter.getFinishedLogRecords();
@@ -109,18 +108,40 @@ describe('EmbraceLogManager', () => {
     expect(log.body).to.equal('this is a warning log with stacktrace');
     expect(log.severityNumber).to.be.equal(SeverityNumber.WARN);
     expect(log.severityText).to.be.equal('WARNING');
+    expect(log.attributes).to.deep.equal({
+      [KEY_EMB_TYPE]: 'sys.log',
+    });
+  });
 
-    expect(log.attributes).to.have.property('attr_key', 'attr value');
-    expect(log.attributes).to.have.property(KEY_EMB_TYPE, 'sys.log');
-    expect(log.attributes).to.not.have.property(
-      KEY_EMB_JS_EXCEPTION_STACKTRACE
-    );
+  it('should log a warning log without stacktrace and attributes', () => {
+    expect(() => {
+      manager.message('this is a warning log with stacktrace', 'warning', {
+        attributes: {
+          attr_key: 'attr value',
+        },
+        includeStacktrace: false,
+      });
+    }).to.not.throw();
+
+    const finishedLogs = memoryExporter.getFinishedLogRecords();
+    expect(finishedLogs).to.have.lengthOf(1);
+    const log = finishedLogs[0];
+
+    expect(log.body).to.equal('this is a warning log with stacktrace');
+    expect(log.severityNumber).to.be.equal(SeverityNumber.WARN);
+    expect(log.severityText).to.be.equal('WARNING');
+    expect(log.attributes).to.deep.equal({
+      [KEY_EMB_TYPE]: 'sys.log',
+      attr_key: 'attr value',
+    });
   });
 
   it('should log an error log with stacktrace', () => {
     expect(() => {
       manager.message('this is an error log with stacktrace', 'error', {
-        attr_key: 'attr value',
+        attributes: {
+          attr_key: 'attr value',
+        },
       });
     }).to.not.throw();
 
@@ -137,16 +158,33 @@ describe('EmbraceLogManager', () => {
     expect(log.attributes).to.have.property(KEY_EMB_JS_EXCEPTION_STACKTRACE);
   });
 
+  it('should log an error log with default options', () => {
+    expect(() => {
+      manager.message('this is an error log with stacktrace', 'error');
+    }).to.not.throw();
+
+    const finishedLogs = memoryExporter.getFinishedLogRecords();
+    expect(finishedLogs).to.have.lengthOf(1);
+    const log = finishedLogs[0];
+
+    expect(log.body).to.equal('this is an error log with stacktrace');
+    expect(log.severityNumber).to.be.equal(SeverityNumber.ERROR);
+    expect(log.severityText).to.be.equal('ERROR');
+
+    expect(log.attributes).to.have.property(KEY_EMB_TYPE, 'sys.log');
+    expect(log.attributes).to.have.property(KEY_EMB_JS_EXCEPTION_STACKTRACE);
+    expect(Object.keys(log.attributes)).to.have.lengthOf(2);
+  });
+
   it('should log an exception with stacktrace', () => {
     expect(() => {
-      manager.logException(
-        new Error('this is an exception'),
-        true,
-        {
+      manager.logException(new Error('this is an exception'), {
+        handled: true,
+        attributes: {
           attr_key: 'attr value',
         },
-        perf.getNowMillis()
-      );
+        timestamp: perf.getNowMillis(),
+      });
     }).to.not.throw();
 
     const finishedLogs = memoryExporter.getFinishedLogRecords();
@@ -172,9 +210,41 @@ describe('EmbraceLogManager', () => {
     expect(log.attributes).to.have.property(ATTR_EXCEPTION_STACKTRACE);
   });
 
-  it('should log an exception without required attributes', () => {
+  it('should log an exception with attributes', () => {
     expect(() => {
-      manager.logException(new Error('this is an exception'), false);
+      manager.logException(new Error('this is an exception'), {
+        attributes: {
+          attr_key: 'attr value',
+        },
+      });
+    }).to.not.throw();
+
+    const finishedLogs = memoryExporter.getFinishedLogRecords();
+    expect(finishedLogs).to.have.lengthOf(1);
+    const log = finishedLogs[0];
+
+    expect(log.body).to.equal('this is an exception');
+    expect(log.severityNumber).to.be.equal(SeverityNumber.ERROR);
+    expect(log.severityText).to.be.equal('ERROR');
+
+    expect(log.attributes).to.have.property('attr_key', 'attr value');
+    expect(log.attributes).to.have.property(KEY_EMB_TYPE, 'sys.exception');
+    expect(log.attributes).to.have.property(
+      KEY_EMB_EXCEPTION_HANDLING,
+      'UNHANDLED'
+    );
+    expect(log.attributes).to.have.property(ATTR_EXCEPTION_TYPE, 'Error');
+    expect(log.attributes).to.have.property('exception.name', 'Error');
+    expect(log.attributes).to.have.property(
+      ATTR_EXCEPTION_MESSAGE,
+      'this is an exception'
+    );
+    expect(log.attributes).to.have.property(ATTR_EXCEPTION_STACKTRACE);
+  });
+
+  it('should log an exception with default options', () => {
+    expect(() => {
+      manager.logException(new Error('this is an exception'));
     }).to.not.throw();
 
     const finishedLogs = memoryExporter.getFinishedLogRecords();

--- a/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
+++ b/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
@@ -179,7 +179,6 @@ describe('EmbraceLogManager', () => {
   it('should log an exception with stacktrace', () => {
     expect(() => {
       manager.logException(new Error('this is an exception'), {
-        handled: true,
         attributes: {
           attr_key: 'attr value',
         },
@@ -231,7 +230,7 @@ describe('EmbraceLogManager', () => {
     expect(log.attributes).to.have.property(KEY_EMB_TYPE, 'sys.exception');
     expect(log.attributes).to.have.property(
       KEY_EMB_EXCEPTION_HANDLING,
-      'UNHANDLED'
+      'HANDLED'
     );
     expect(log.attributes).to.have.property(ATTR_EXCEPTION_TYPE, 'Error');
     expect(log.attributes).to.have.property('exception.name', 'Error');
@@ -261,7 +260,7 @@ describe('EmbraceLogManager', () => {
     expect(log.attributes).to.have.property(KEY_EMB_TYPE, 'sys.exception');
     expect(log.attributes).to.have.property(
       KEY_EMB_EXCEPTION_HANDLING,
-      'UNHANDLED'
+      'HANDLED'
     );
     expect(log.attributes).to.have.property(ATTR_EXCEPTION_TYPE, 'Error');
     expect(log.attributes).to.have.property('exception.name', 'Error');
@@ -270,5 +269,32 @@ describe('EmbraceLogManager', () => {
       'this is an exception'
     );
     expect(log.attributes).to.have.property(ATTR_EXCEPTION_STACKTRACE);
+  });
+
+  it('should allow logging an exception has unhandled', () => {
+    expect(() => {
+      manager.logException(new Error('this is an exception'), {
+        handled: false,
+      });
+    }).to.not.throw();
+
+    const finishedLogs = memoryExporter.getFinishedLogRecords();
+    expect(finishedLogs).to.have.lengthOf(1);
+    const log = finishedLogs[0];
+
+    expect(log.body).to.equal('this is an exception');
+    expect(log.severityNumber).to.be.equal(SeverityNumber.ERROR);
+    expect(log.severityText).to.be.equal('ERROR');
+    void expect(hrTimeToMilliseconds(log.hrTime)).to.be.lessThanOrEqual(
+      perf.getNowMillis()
+    );
+
+    expect(log.attributes).to.have.property(KEY_EMB_TYPE, 'sys.exception');
+    expect(log.attributes).to.have.property(
+      KEY_EMB_EXCEPTION_HANDLING,
+      'UNHANDLED'
+    );
+    expect(log.attributes).to.have.property(ATTR_EXCEPTION_TYPE, 'Error');
+    expect(log.attributes).to.have.property('exception.name', 'Error');
   });
 });

--- a/src/managers/EmbraceLogManager/EmbraceLogManager.ts
+++ b/src/managers/EmbraceLogManager/EmbraceLogManager.ts
@@ -48,7 +48,7 @@ export class EmbraceLogManager implements LogManager {
   public logException(
     error: Error,
     {
-      handled = false,
+      handled = true,
       attributes = {},
       timestamp = this._perf.getNowMillis(),
     }: LogExceptionOptions = {}

--- a/src/managers/EmbraceLogManager/EmbraceLogManager.ts
+++ b/src/managers/EmbraceLogManager/EmbraceLogManager.ts
@@ -18,6 +18,10 @@ import {
   type PerformanceManager,
 } from '../../utils/index.js';
 import type { EmbraceLogManagerArgs } from './types.js';
+import type {
+  LogExceptionOptions,
+  LogMessageOptions,
+} from '../../api-logs/manager/index.js';
 
 export class EmbraceLogManager implements LogManager {
   private readonly _perf: PerformanceManager;
@@ -43,9 +47,11 @@ export class EmbraceLogManager implements LogManager {
 
   public logException(
     error: Error,
-    handled: boolean,
-    attributes: Record<string, AttributeValue | undefined> = {},
-    timestamp: number = this._perf.getNowMillis()
+    {
+      handled = false,
+      attributes = {},
+      timestamp = this._perf.getNowMillis(),
+    }: LogExceptionOptions = {}
   ) {
     this._logger.emit({
       timestamp,
@@ -67,8 +73,7 @@ export class EmbraceLogManager implements LogManager {
   public message(
     message: string,
     severity: LogSeverity,
-    attributes?: Record<string, AttributeValue | undefined>,
-    includeStacktrace = true
+    { attributes = {}, includeStacktrace = true }: LogMessageOptions = {}
   ) {
     this._logMessage({
       message,


### PR DESCRIPTION
## Goal

Make the log API consistent with the other ones we expose where the optional parameters are all grouped together in a single `options` argument after the required ones. Labelling the commit as "feat" so that we bump the minor version since this is a breaking change for the interface (though not the major version since we're still on 0.x)

## Testing

Added a few more tests where different options are specified / omitted to confirm the defaults are being applied correctly