### PR TITLE
chore: bump max commit header length

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,7 +2,7 @@ export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'header-max-length': [2, 'always', 150],
-    'body-max-line-length': [0, 'always', 100],
+    'body-max-line-length': [0, 'always', 300],
     'type-enum': [
       2,
       'always',

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,7 @@
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'header-max-length': [2, 'always', 100],
+    'header-max-length': [2, 'always', 150],
     'body-max-line-length': [0, 'always', 100],
     'type-enum': [
       2,


### PR DESCRIPTION
## Goal

The current length of 100 was a bit restrictive, we were having some dependabot PRs failing due to surpassing this string length: https://github.com/embrace-io/embrace-web-sdk/actions/runs/14763000958/job/41447932730?pr=334