### PR TITLE
fix: add missing module export definition in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "README.md"
   ],
   "exports": {
+    "module": "./build/esm/index.js",
     "types": "./build/index.d.ts",
-    "import": "./build/esm/index.js",
     "require": "./build/src/index.js",
     "default": "./build/src/index.js",
-    "module": "./build/esm/index.js"
+    "import": "./build/esm/index.js"
   },
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "types": "./build/index.d.ts",
     "import": "./build/esm/index.js",
     "require": "./build/src/index.js",
-    "default": "./build/src/index.js"
+    "default": "./build/src/index.js",
+    "module": "./build/esm/index.js"
   },
   "author": "Embrace <support@embrace.io> (https://embrace.io/)",
   "bugs": {


### PR DESCRIPTION
## Goal

Fixes an issue when building the app with webpack and tsconfig using common.js modules. This config properly tells webpack which file to use when importing the sdk. 

Before
```
Object.defineProperty(exports, "__esModule", ({ value: true }));
var web_sdk_1 = __webpack_require__(/*! @embrace-io/web-sdk */ "./node_modules/@embrace-io/web-sdk/build/src/index.js");
var result = web_sdk_1.sdk.initSDK({
    appID: 'abc12',
    appVersion: 'YOUR_APP_VERSION',
});
...
```

After
```
Object.defineProperty(exports, "__esModule", ({ value: true }));
var web_sdk_1 = __webpack_require__(/*! @embrace-io/web-sdk */ "../../build/esm/index.js");
var result = web_sdk_1.sdk.initSDK({
    appID: 'abc12',
    appVersion: 'YOUR_APP_VERSION',
});
```

Also for some weird reason `module` needs to go first in the `exports` declaration 🙃 

## Testing

Tested with webpack-example, frontend. CDN should not be affected