### PR TITLE
chore: limit dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "npm"
     directories:
       - "/"
       - "/cli"
       - "/demo/frontend"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 50
     groups:
       eslint:


### PR DESCRIPTION
## Goal

Daily updates are getting a bit too noisy, roll back to weekly