### PR TITLE
chore: [BREAKING CHANGE] rename startPerformanceSpan method to startSpan

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For the most basic usage simply start a span and end it after some operation com
 ```typescript
 import { trace } from '@embrace-io/web-sdk';
 
-const span = trace.startPerformanceSpan("span-name");
+const span = trace.startSpan("span-name");
 
 someAsyncOperation()
   .then(() => span?.end())

--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -33,7 +33,7 @@ const App = () => {
   };
 
   const handleStartSpan = () => {
-    const span = trace.startPerformanceSpan('demo-span');
+    const span = trace.startSpan('demo-span');
 
     if (span) {
       setSpans([...spans, span]);

--- a/src/api-traces/api/TraceAPI/TraceAPI.test.ts
+++ b/src/api-traces/api/TraceAPI/TraceAPI.test.ts
@@ -29,7 +29,7 @@ describe('TraceAPI', () => {
     const traceAPI = TraceAPI.getInstance();
     const traceManager: TraceManager = {
       // Mock implementation of TraceManager
-      startPerformanceSpan: sinon.stub().returns({} as Span),
+      startSpan: sinon.stub().returns({} as Span),
     };
     traceAPI.setGlobalTraceManager(traceManager);
     const result = traceAPI.getTraceManager();
@@ -40,13 +40,13 @@ describe('TraceAPI', () => {
   it('should forward calls to the trace manager', () => {
     const mockTraceManager: TraceManager = {
       // Mock implementation of TraceManager
-      startPerformanceSpan: sinon.stub().returns({} as Span),
+      startSpan: sinon.stub().returns({} as Span),
     };
     traceAPI.setGlobalTraceManager(mockTraceManager);
 
-    traceAPI.startPerformanceSpan('span-name');
-    void expect(
-      mockTraceManager.startPerformanceSpan
-    ).to.have.been.calledOnceWith('span-name');
+    traceAPI.startSpan('span-name');
+    void expect(mockTraceManager.startSpan).to.have.been.calledOnceWith(
+      'span-name'
+    );
   });
 });

--- a/src/api-traces/api/TraceAPI/TraceAPI.ts
+++ b/src/api-traces/api/TraceAPI/TraceAPI.ts
@@ -31,10 +31,10 @@ export class TraceAPI implements TraceManager {
     this._proxyTraceManager.setDelegate(traceManager);
   }
 
-  public startPerformanceSpan(
+  public startSpan(
     name: string,
     options?: PerformanceSpanOptions
   ): PerformanceSpan | null {
-    return this.getTraceManager().startPerformanceSpan(name, options);
+    return this.getTraceManager().startSpan(name, options);
   }
 }

--- a/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.test.ts
+++ b/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.test.ts
@@ -9,9 +9,8 @@ describe('NoOpTraceManager', () => {
     noOpTraceManager = new NoOpTraceManager();
   });
 
-  it('should return null for startPerformanceSpan', () => {
-    const span: Span | null =
-      noOpTraceManager.startPerformanceSpan('span-name');
+  it('should return null for startSpan', () => {
+    const span: Span | null = noOpTraceManager.startSpan('span-name');
     void expect(span).to.be.null;
   });
 });

--- a/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.ts
+++ b/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.ts
@@ -5,7 +5,7 @@ import type {
 } from '../../api/index.js';
 
 export class NoOpTraceManager implements TraceManager {
-  public startPerformanceSpan(
+  public startSpan(
     _name: string,
     _options?: PerformanceSpanOptions
   ): PerformanceSpan | null {

--- a/src/api-traces/manager/ProxyTraceManager/ProxyTraceManager.test.ts
+++ b/src/api-traces/manager/ProxyTraceManager/ProxyTraceManager.test.ts
@@ -16,7 +16,7 @@ describe('ProxyTraceManager', () => {
   beforeEach(() => {
     proxyTraceManager = new ProxyTraceManager();
     mockDelegate = {
-      startPerformanceSpan: sinon.stub().returns({} as Span),
+      startSpan: sinon.stub().returns({} as Span),
     };
   });
 
@@ -31,9 +31,9 @@ describe('ProxyTraceManager', () => {
     expect(delegate).to.equal(mockDelegate);
   });
 
-  it('should delegate startPerformanceSpan to the delegate', () => {
+  it('should delegate startSpan to the delegate', () => {
     proxyTraceManager.setDelegate(mockDelegate);
-    const span = proxyTraceManager.startPerformanceSpan('span-name');
+    const span = proxyTraceManager.startSpan('span-name');
     expect(span).to.deep.equal({});
   });
 });

--- a/src/api-traces/manager/ProxyTraceManager/ProxyTraceManager.ts
+++ b/src/api-traces/manager/ProxyTraceManager/ProxyTraceManager.ts
@@ -18,10 +18,10 @@ export class ProxyTraceManager implements TraceManager {
     this._delegate = delegate;
   }
 
-  public startPerformanceSpan(
+  public startSpan(
     name: string,
     options?: PerformanceSpanOptions
   ): PerformanceSpan | null {
-    return this.getDelegate().startPerformanceSpan(name, options);
+    return this.getDelegate().startSpan(name, options);
   }
 }

--- a/src/api-traces/manager/types.ts
+++ b/src/api-traces/manager/types.ts
@@ -1,7 +1,7 @@
 import type { PerformanceSpan, PerformanceSpanOptions } from '../api/index.js';
 
 export interface TraceManager {
-  startPerformanceSpan: (
+  startSpan: (
     name: string,
     options?: PerformanceSpanOptions
   ) => PerformanceSpan | null;

--- a/src/managers/EmbraceTraceManager/EmbraceTraceManager.test.ts
+++ b/src/managers/EmbraceTraceManager/EmbraceTraceManager.test.ts
@@ -27,7 +27,7 @@ describe('EmbraceTraceManager', () => {
   });
 
   it('should start and end a perf span', () => {
-    const span = manager.startPerformanceSpan('perf-span');
+    const span = manager.startSpan('perf-span');
     void expect(span).to.not.be.null;
     expect(() => {
       span.end();
@@ -44,7 +44,7 @@ describe('EmbraceTraceManager', () => {
   });
 
   it('should offer a method for ending a failed perf span', () => {
-    const span = manager.startPerformanceSpan('perf-span');
+    const span = manager.startSpan('perf-span');
     void expect(span).to.not.be.null;
     span.fail();
     const finishedSpans = memoryExporter.getFinishedSpans();
@@ -56,7 +56,7 @@ describe('EmbraceTraceManager', () => {
   });
 
   it('should allow the code and end time of a failed perf span to be overwritten', () => {
-    const span = manager.startPerformanceSpan('perf-span', {
+    const span = manager.startSpan('perf-span', {
       startTime: 1741650200000,
     });
     void expect(span).to.not.be.null;
@@ -77,10 +77,10 @@ describe('EmbraceTraceManager', () => {
   });
 
   it('should allow perf spans to be created in parent-child relationships', () => {
-    const parentSpan = manager.startPerformanceSpan('parent-perf-span');
+    const parentSpan = manager.startSpan('parent-perf-span');
     void expect(parentSpan).to.not.be.null;
 
-    const childSpan = manager.startPerformanceSpan('child-perf-span', {
+    const childSpan = manager.startSpan('child-perf-span', {
       parentSpan,
     });
     void expect(childSpan).to.not.be.null;

--- a/src/managers/EmbraceTraceManager/EmbraceTraceManager.ts
+++ b/src/managers/EmbraceTraceManager/EmbraceTraceManager.ts
@@ -8,7 +8,7 @@ import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
 import { EmbracePerformanceSpan } from './EmbracePerformanceSpan.js';
 
 export class EmbraceTraceManager implements TraceManager {
-  public startPerformanceSpan(
+  public startSpan(
     name: string,
     options: PerformanceSpanOptions = {}
   ): PerformanceSpan {

--- a/src/sdk/initSDK.test.ts
+++ b/src/sdk/initSDK.test.ts
@@ -216,9 +216,9 @@ describe('initSDK', () => {
       (user.getUserManager() as ProxyUserManager).getDelegate()
     ).to.be.instanceOf(EmbraceUserManager);
 
-    embtrace.startPerformanceSpan('my performance span')?.end();
+    embtrace.startSpan('my performance span')?.end();
     // shouldn't get exported
-    embtrace.startPerformanceSpan('my unfinished performance span');
+    embtrace.startSpan('my unfinished performance span');
 
     log.message('my custom log', 'info');
 
@@ -354,9 +354,9 @@ describe('initSDK', () => {
       // Needed to allow the browser detector resources to be grabbed
       await new Promise(r => setTimeout(r, 1));
 
-      embtrace.startPerformanceSpan('my performance span')?.end();
+      embtrace.startSpan('my performance span')?.end();
       // shouldn't get exported
-      embtrace.startPerformanceSpan('my unfinished performance span');
+      embtrace.startSpan('my unfinished performance span');
 
       session.getSpanSessionManager().endSessionSpan();
 


### PR DESCRIPTION
## Goal

Rename startPerformanceSpan method to startSpan to avoid the name being related to an internal attribute  

## Testing

n/a