### PR TITLE
chore: rename EmbracePerformanceSpan and PerformanceSpan to remove references to internal implementation

### DIFF
--- a/src/api-traces/api/TraceAPI/TraceAPI.ts
+++ b/src/api-traces/api/TraceAPI/TraceAPI.ts
@@ -1,7 +1,7 @@
 import { ProxyTraceManager, type TraceManager } from '../../manager/index.js';
 import type {
-  PerformanceSpan,
-  PerformanceSpanOptions,
+  EmbraceExtendedSpan,
+  EmbraceExtendedSpanOptions,
   TraceAPIArgs,
 } from './types.js';
 
@@ -33,8 +33,8 @@ export class TraceAPI implements TraceManager {
 
   public startSpan(
     name: string,
-    options?: PerformanceSpanOptions
-  ): PerformanceSpan | null {
+    options?: EmbraceExtendedSpanOptions
+  ): EmbraceExtendedSpan | null {
     return this.getTraceManager().startSpan(name, options);
   }
 }

--- a/src/api-traces/api/TraceAPI/index.ts
+++ b/src/api-traces/api/TraceAPI/index.ts
@@ -1,6 +1,6 @@
 export { TraceAPI } from './TraceAPI.js';
 export type {
-  PerformanceSpan,
-  PerformanceSpanFailedOptions,
-  PerformanceSpanOptions,
+  EmbraceExtendedSpan,
+  EmbraceExtendedSpanFailedOptions,
+  EmbraceExtendedSpanOptions,
 } from './types.js';

--- a/src/api-traces/api/TraceAPI/types.ts
+++ b/src/api-traces/api/TraceAPI/types.ts
@@ -6,16 +6,17 @@ export interface TraceAPIArgs {
   proxyTraceManager: ProxyTraceManager;
 }
 
-export type PerformanceSpanFailedOptions = {
-  code?: PerformanceSpanFailureCode;
+export type EmbraceExtendedSpanFailureCode = 'failure' | 'user_abandon';
+
+export type EmbraceExtendedSpanFailedOptions = {
+  code?: EmbraceExtendedSpanFailureCode;
   endTime?: TimeInput;
 };
-export type PerformanceSpanFailureCode = 'failure' | 'user_abandon';
 
-export interface PerformanceSpan extends Span {
-  fail: (options?: PerformanceSpanFailedOptions) => void;
+export interface EmbraceExtendedSpan extends Span {
+  fail: (options?: EmbraceExtendedSpanFailedOptions) => void;
 }
 
-export type PerformanceSpanOptions = SpanOptions & {
+export type EmbraceExtendedSpanOptions = SpanOptions & {
   parentSpan?: Span;
 };

--- a/src/api-traces/api/index.ts
+++ b/src/api-traces/api/index.ts
@@ -1,6 +1,6 @@
 export { TraceAPI } from './TraceAPI/index.js';
 export type {
-  PerformanceSpan,
-  PerformanceSpanFailedOptions,
-  PerformanceSpanOptions,
+  EmbraceExtendedSpan,
+  EmbraceExtendedSpanFailedOptions,
+  EmbraceExtendedSpanOptions,
 } from './TraceAPI/index.js';

--- a/src/api-traces/index.ts
+++ b/src/api-traces/index.ts
@@ -2,7 +2,7 @@ export { trace } from './traceAPI.js';
 export type { TraceManager } from './manager/index.js';
 export { NoOpTraceManager, ProxyTraceManager } from './manager/index.js';
 export type {
-  PerformanceSpan,
-  PerformanceSpanFailedOptions,
-  PerformanceSpanOptions,
+  EmbraceExtendedSpan,
+  EmbraceExtendedSpanFailedOptions,
+  EmbraceExtendedSpanOptions,
 } from './api/index.js';

--- a/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.ts
+++ b/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.ts
@@ -1,14 +1,14 @@
 import type { TraceManager } from '../index.js';
 import type {
-  PerformanceSpan,
-  PerformanceSpanOptions,
+  EmbraceExtendedSpan,
+  EmbraceExtendedSpanOptions,
 } from '../../api/index.js';
 
 export class NoOpTraceManager implements TraceManager {
   public startSpan(
     _name: string,
-    _options?: PerformanceSpanOptions
-  ): PerformanceSpan | null {
+    _options?: EmbraceExtendedSpanOptions
+  ): EmbraceExtendedSpan | null {
     return null;
   }
 }

--- a/src/api-traces/manager/ProxyTraceManager/ProxyTraceManager.ts
+++ b/src/api-traces/manager/ProxyTraceManager/ProxyTraceManager.ts
@@ -1,8 +1,8 @@
 import type { TraceManager } from '../index.js';
 import { NoOpTraceManager } from '../NoOpTraceManager/index.js';
 import type {
-  PerformanceSpan,
-  PerformanceSpanOptions,
+  EmbraceExtendedSpan,
+  EmbraceExtendedSpanOptions,
 } from '../../api/index.js';
 
 const NOOP_TRACE_MANAGER = new NoOpTraceManager();
@@ -20,8 +20,8 @@ export class ProxyTraceManager implements TraceManager {
 
   public startSpan(
     name: string,
-    options?: PerformanceSpanOptions
-  ): PerformanceSpan | null {
+    options?: EmbraceExtendedSpanOptions
+  ): EmbraceExtendedSpan | null {
     return this.getDelegate().startSpan(name, options);
   }
 }

--- a/src/api-traces/manager/types.ts
+++ b/src/api-traces/manager/types.ts
@@ -1,8 +1,11 @@
-import type { PerformanceSpan, PerformanceSpanOptions } from '../api/index.js';
+import type {
+  EmbraceExtendedSpan,
+  EmbraceExtendedSpanOptions,
+} from '../api/index.js';
 
 export interface TraceManager {
   startSpan: (
     name: string,
-    options?: PerformanceSpanOptions
-  ) => PerformanceSpan | null;
+    options?: EmbraceExtendedSpanOptions
+  ) => EmbraceExtendedSpan | null;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import { log } from './api-logs/index.js';
 import { session } from './api-sessions/index.js';
 import { trace } from './api-traces/index.js';
-import { type PerformanceSpan } from './api-traces/index.js';
+import { type EmbraceExtendedSpan } from './api-traces/index.js';
 import { user } from './api-users/index.js';
 import * as sdk from './sdk/index.js';
 
-export type { PerformanceSpan };
+export type { EmbraceExtendedSpan };
 export { sdk, session, log, trace, user };

--- a/src/managers/EmbraceTraceManager/EmbraceSpan.ts
+++ b/src/managers/EmbraceTraceManager/EmbraceSpan.ts
@@ -9,17 +9,17 @@ import type {
 } from '@opentelemetry/api';
 import { type Span } from '@opentelemetry/api';
 import type {
-  PerformanceSpan,
-  PerformanceSpanFailedOptions,
+  EmbraceExtendedSpan,
+  EmbraceExtendedSpanFailedOptions,
 } from '../../api-traces/index.js';
 import { KEY_EMB_ERROR_CODE } from '../../constants/index.js';
 
 /**
- * EmbracePerformanceSpan for the most part simply delegates to the underlying Span it receives on initialization so
+ * EmbraceSpan for the most part simply delegates to the underlying Span it receives on initialization so
  * that it satisfies the Span interface. In addition, it gives us a spot where we can implement helpers that are part
- * of the PerformanceSpan interface.
+ * of the EmbraceSpan interface.
  */
-export class EmbracePerformanceSpan implements PerformanceSpan {
+export class EmbraceSpan implements EmbraceExtendedSpan {
   private readonly _span: Span;
 
   public constructor(span: Span) {
@@ -82,7 +82,7 @@ export class EmbracePerformanceSpan implements PerformanceSpan {
   }
 
   public fail(
-    options: PerformanceSpanFailedOptions = {
+    options: EmbraceExtendedSpanFailedOptions = {
       code: 'failure',
     }
   ): void {

--- a/src/managers/EmbraceTraceManager/EmbraceTraceManager.ts
+++ b/src/managers/EmbraceTraceManager/EmbraceTraceManager.ts
@@ -1,17 +1,17 @@
 import { trace, context } from '@opentelemetry/api';
 import type {
   TraceManager,
-  PerformanceSpan,
-  PerformanceSpanOptions,
+  EmbraceExtendedSpan,
+  EmbraceExtendedSpanOptions,
 } from '../../api-traces/index.js';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../constants/index.js';
-import { EmbracePerformanceSpan } from './EmbracePerformanceSpan.js';
+import { EmbraceSpan } from './EmbraceSpan.js';
 
 export class EmbraceTraceManager implements TraceManager {
   public startSpan(
     name: string,
-    options: PerformanceSpanOptions = {}
-  ): PerformanceSpan {
+    options: EmbraceExtendedSpanOptions = {}
+  ): EmbraceExtendedSpan {
     const tracer = trace.getTracer('embrace-web-sdk-traces');
 
     options.attributes = options.attributes ? options.attributes : {};
@@ -21,6 +21,6 @@ export class EmbraceTraceManager implements TraceManager {
       ? trace.setSpan(context.active(), options.parentSpan)
       : undefined;
 
-    return new EmbracePerformanceSpan(tracer.startSpan(name, options, ctx));
+    return new EmbraceSpan(tracer.startSpan(name, options, ctx));
   }
 }


### PR DESCRIPTION
## Goal

chore: rename EmbracePerformanceSpan and PerformanceSpan to remove references to internal implementation

## Testing

n/a