### PR TITLE
chore: support major releases and breaking changes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -45,10 +45,12 @@ autolabeler:
   - label: 'feat'
     title:
       - '/(EMBR-[0-9]+\s+)?(feat).*/'
-  # No major releases until we go out of beta
-  # - label: 'semver-major'
-  #   title: # anything with a "!" after the type
-  #     - '/(EMBR-[0-9]+\s+)?(fix|revert|build|ci|docs|style|refactor|perf|test|chore|deploy|feat).*/'
+  - label: 'breaking'
+    title:
+      - '/(EMBR-[0-9]+\s+)?(breaking).*/'
+  - label: 'semver-major'
+    title: # SAME AS 'breaking'
+      - '/(EMBR-[0-9]+\s+)?(breaking).*/'
   - label: 'semver-minor'
     title: # SAME AS 'feat'
       - '/(EMBR-[0-9]+\s+)?(feat).*/'


### PR DESCRIPTION
In order for the release drafter to correctly identify breaking changes and bump our version to 1.0.0 we need to define a regex for commits to look for that include "breaking:" at the start the of the message

So far we have included breaking changes in:
* https://github.com/embrace-io/embrace-web-sdk/pull/386 (we'll have to figure out how to relabel this one retroactively)
* https://github.com/embrace-io/embrace-web-sdk/pull/347