### PR TITLE
chore: support sourcemap uploads in the CDN case

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,20 +321,33 @@ as you refer to that documentation:
    + const { sdk } = window.EmbraceWebSdk;
    ```
 
-2) Because our web-cli does not support the CDN version of the SDK, you will need to make sure to pass in your app
-   version when initializing the sdk. If you don't, then your app version will be reported to Embrace as
-   `EmbIOAppVersionX.X.X`
+2) Our CLI tool does not support injecting an app version when loading from CDN since in that case our SDK is not
+bundled with your code, instead you will need to make sure to pass in your app version when initializing the sdk as in
+the following example:
 
    ```javascript
-     sdk.initSDK({
+   sdk.initSDK({
      appVersion: '0.0.1',
      /*...*/
    });
    ```
 
-3) Because our web-cli does not support the CDN version of the SDK, the sourcemaps upload won't work
-   (see [Upload sourcemaps](#upload-sourcemaps)). You will not see symbolicated stack traces in Embrace.
+3) Similarly, for sourcemap uploads our web-cli looks for a special placeholder string to replace with the real ID of
+the uploaded bundle files. When our SDK is not bundled with your code you will need to provide this placeholder string
+when initializing the sdk as in the following example:
 
+   ```javascript
+   sdk.initSDK({
+     appVersion: '0.0.1',
+     bundleID: 'EmbIOBundleIDfd6996f1007b363f87a',
+     /*...*/
+   });
+   ```
+
+   > [!NOTE]
+   > It is simplest to use this specific string since that is what our CLI tool will look for by default, however any 32
+   > character string would be valid. If you do use another value make sure to specify it using the
+   > `--template-bundle-id` flag when invoking `embrace-web-cli`
 
 ### Async Loading
 

--- a/README.md
+++ b/README.md
@@ -332,9 +332,9 @@ the following example:
    });
    ```
 
-3) Similarly, for sourcemap uploads our web-cli looks for a special placeholder string to replace with the real ID of
-the uploaded bundle files. When our SDK is not bundled with your code you will need to provide this placeholder string
-when initializing the sdk as in the following example:
+3) Similarly, for sourcemap uploads our CLI looks for a special placeholder string to replace with the real ID of the
+uploaded bundle files. When our SDK is not bundled with your code you will need to provide this placeholder string when
+initializing the sdk as in the following example:
 
    ```javascript
    sdk.initSDK({
@@ -347,7 +347,7 @@ when initializing the sdk as in the following example:
    > [!NOTE]
    > It is simplest to use this specific string since that is what our CLI tool will look for by default, however any 32
    > character string would be valid. If you do use another value make sure to specify it using the
-   > `--template-bundle-id` flag when invoking `embrace-web-cli`
+   > `--template-bundle-id` flag when invoking `embrace-web-cli upload`
 
 ### Async Loading
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ initializing the sdk as in the following example:
    ```javascript
    sdk.initSDK({
      appVersion: '0.0.1',
-     bundleID: 'EmbIOBundleIDfd6996f1007b363f87a',
+     templateBundleID: 'EmbIOBundleIDfd6996f1007b363f87a',
      /*...*/
    });
    ```

--- a/src/resources/types.ts
+++ b/src/resources/types.ts
@@ -3,6 +3,6 @@ import type { DiagLogger } from '@opentelemetry/api';
 export interface GetWebSDKResourceArgs {
   diagLogger: DiagLogger;
   appVersion?: string;
-  bundleID?: string;
+  templateBundleID?: string;
   pageSessionStorage: Storage;
 }

--- a/src/resources/types.ts
+++ b/src/resources/types.ts
@@ -3,5 +3,6 @@ import type { DiagLogger } from '@opentelemetry/api';
 export interface GetWebSDKResourceArgs {
   diagLogger: DiagLogger;
   appVersion?: string;
+  bundleID?: string;
   pageSessionStorage: Storage;
 }

--- a/src/resources/webSdkResource.ts
+++ b/src/resources/webSdkResource.ts
@@ -20,7 +20,7 @@ import type { GetWebSDKResourceArgs } from './types.js';
 export const getWebSDKResource = ({
   diagLogger,
   appVersion,
-  bundleID,
+  templateBundleID,
   pageSessionStorage,
 }: GetWebSDKResourceArgs) => {
   /* We need to trim the app  version to remove any leading/trailing spaces
@@ -43,7 +43,7 @@ export const getWebSDKResource = ({
     [ATTR_TELEMETRY_SDK_NAME]: EMBRACE_SERVICE_NAME,
     app_version: processedAppVersion,
     app_framework: NATIVE_FRAMEWORK,
-    bundle_id: bundleID ?? TEMPLATE_BUNDLE_ID,
+    bundle_id: templateBundleID ?? TEMPLATE_BUNDLE_ID,
     sdk_version: SDK_VERSION,
     [ATTR_TELEMETRY_SDK_VERSION]: SDK_VERSION,
     sdk_simple_version: 1,

--- a/src/resources/webSdkResource.ts
+++ b/src/resources/webSdkResource.ts
@@ -20,6 +20,7 @@ import type { GetWebSDKResourceArgs } from './types.js';
 export const getWebSDKResource = ({
   diagLogger,
   appVersion,
+  bundleID,
   pageSessionStorage,
 }: GetWebSDKResourceArgs) => {
   /* We need to trim the app  version to remove any leading/trailing spaces
@@ -42,7 +43,7 @@ export const getWebSDKResource = ({
     [ATTR_TELEMETRY_SDK_NAME]: EMBRACE_SERVICE_NAME,
     app_version: processedAppVersion,
     app_framework: NATIVE_FRAMEWORK,
-    bundle_id: TEMPLATE_BUNDLE_ID,
+    bundle_id: bundleID ?? TEMPLATE_BUNDLE_ID,
     sdk_version: SDK_VERSION,
     [ATTR_TELEMETRY_SDK_VERSION]: SDK_VERSION,
     sdk_simple_version: 1,

--- a/src/sdk/initSDK.test.ts
+++ b/src/sdk/initSDK.test.ts
@@ -235,7 +235,7 @@ describe('initSDK', () => {
     void expect(finishedLogRecords[0].body).to.be.equal('my custom log');
   });
 
-  it('should ensure a provided bundle ID is valid', () => {
+  it('should ensure a provided template bundle ID is valid', () => {
     const diagLogger = new InMemoryDiagLogger();
     const result = initSDK({
       appID: 'abc12',
@@ -408,7 +408,7 @@ describe('initSDK', () => {
       );
     });
 
-    it('should include a custom bundle ID in the resource attributes if provided', async () => {
+    it('should include a custom template bundle ID in the resource attributes if provided', async () => {
       fakeFetchRespondWith('');
       const result = initSDK({
         appID: 'abc12',

--- a/src/sdk/initSDK.test.ts
+++ b/src/sdk/initSDK.test.ts
@@ -235,6 +235,21 @@ describe('initSDK', () => {
     void expect(finishedLogRecords[0].body).to.be.equal('my custom log');
   });
 
+  it('should ensure a provided bundle ID is valid', () => {
+    const diagLogger = new InMemoryDiagLogger();
+    const result = initSDK({
+      appID: 'abc12',
+      bundleID: 'invalid-bundle-id',
+      diagLogger,
+    });
+    void expect(result).to.be.false;
+
+    expect(diagLogger.getErrorLogs()).to.have.lengthOf(1);
+    expect(diagLogger.getErrorLogs()[0]).to.equal(
+      'failed to initialize the SDK: bundleID should be 32 characters long'
+    );
+  });
+
   describe('export to Embrace', () => {
     beforeEach(() => {
       fakeFetchInstall();
@@ -391,6 +406,60 @@ describe('initSDK', () => {
       expect(tracesScopeSpan['spans'][0]['name']).to.be.equal(
         'my performance span'
       );
+    });
+
+    it('should include a custom bundle ID in the resource attributes if provided', async () => {
+      fakeFetchRespondWith('');
+      const result = initSDK({
+        appID: 'abc12',
+        bundleID: 'aaaaBBBBccccDDDDeeeeFFFFggggHHHH',
+        defaultInstrumentationConfig: {
+          omit: new Set([
+            // This instrumentation does its own patching of Fetch which interferes with our test stub
+            '@opentelemetry/instrumentation-fetch',
+            // Document load instrumentation generates a bunch of spans in this test environment
+            '@opentelemetry/instrumentation-document-load',
+          ]),
+        },
+      });
+      void expect(result).not.to.be.false;
+
+      // Needed to allow the browser detector resources to be grabbed
+      await new Promise(r => setTimeout(r, 1));
+
+      session.getSpanSessionManager().endSessionSpan();
+
+      // Needed to allow the transport to actually send its data off to fetch
+      await new Promise(r => setTimeout(r, 1));
+
+      const headers = fakeFetchGetRequestHeaders();
+      expect((headers as Record<string, string>)['X-EM-AID']).to.equal('abc12');
+
+      const body = fakeFetchGetBody();
+      void expect(body).not.to.be.null;
+      const decompressedStream = new Response(body).body?.pipeThrough(
+        new DecompressionStream('gzip')
+      );
+      // translate from Uint8Array to string
+      const text = await new Response(decompressedStream).text();
+      const parsed = JSON.parse(text) as never;
+
+      expect(parsed['resourceSpans']).to.have.lengthOf(1);
+      const resourceSpan = parsed['resourceSpans'][0];
+      const resource = resourceSpan['resource'];
+
+      // Different test environments will include different values for the various browser.* attributes, test on a
+      // subset here rather than the full object
+      expect(resource).to.containSubset({
+        attributes: [
+          { key: 'service.name', value: { stringValue: 'embrace-web-sdk' } },
+          {
+            key: 'bundle_id',
+            value: { stringValue: 'aaaaBBBBccccDDDDeeeeFFFFggggHHHH' },
+          },
+        ],
+        droppedAttributesCount: 0,
+      });
     });
   });
 

--- a/src/sdk/initSDK.test.ts
+++ b/src/sdk/initSDK.test.ts
@@ -239,14 +239,14 @@ describe('initSDK', () => {
     const diagLogger = new InMemoryDiagLogger();
     const result = initSDK({
       appID: 'abc12',
-      bundleID: 'invalid-bundle-id',
+      templateBundleID: 'invalid-bundle-id',
       diagLogger,
     });
     void expect(result).to.be.false;
 
     expect(diagLogger.getErrorLogs()).to.have.lengthOf(1);
     expect(diagLogger.getErrorLogs()[0]).to.equal(
-      'failed to initialize the SDK: bundleID should be 32 characters long'
+      'failed to initialize the SDK: templateBundleID should be 32 characters long'
     );
   });
 
@@ -412,7 +412,7 @@ describe('initSDK', () => {
       fakeFetchRespondWith('');
       const result = initSDK({
         appID: 'abc12',
-        bundleID: 'aaaaBBBBccccDDDDeeeeFFFFggggHHHH',
+        templateBundleID: 'aaaaBBBBccccDDDDeeeeFFFFggggHHHH',
         defaultInstrumentationConfig: {
           omit: new Set([
             // This instrumentation does its own patching of Fetch which interferes with our test stub

--- a/src/sdk/initSDK.ts
+++ b/src/sdk/initSDK.ts
@@ -48,7 +48,7 @@ export const initSDK = (
   {
     appID,
     appVersion,
-    bundleID,
+    templateBundleID,
     resource = Resource.empty(),
     spanExporters = [],
     logExporters = [],
@@ -77,15 +77,15 @@ export const initSDK = (
       logLevel,
     });
 
-    if (bundleID && bundleID.length !== 32) {
-      throw new Error('bundleID should be 32 characters long');
+    if (templateBundleID && templateBundleID.length !== 32) {
+      throw new Error('templateBundleID should be 32 characters long');
     }
 
     const resourceWithWebSDKAttributes = resource.merge(
       getWebSDKResource({
         diagLogger,
         appVersion,
-        bundleID,
+        templateBundleID,
         pageSessionStorage: window.sessionStorage,
       })
     );

--- a/src/sdk/initSDK.ts
+++ b/src/sdk/initSDK.ts
@@ -48,6 +48,7 @@ export const initSDK = (
   {
     appID,
     appVersion,
+    bundleID,
     resource = Resource.empty(),
     spanExporters = [],
     logExporters = [],
@@ -76,10 +77,15 @@ export const initSDK = (
       logLevel,
     });
 
+    if (bundleID && bundleID.length !== 32) {
+      throw new Error('bundleID should be 32 characters long');
+    }
+
     const resourceWithWebSDKAttributes = resource.merge(
       getWebSDKResource({
         diagLogger,
         appVersion,
+        bundleID,
         pageSessionStorage: window.sessionStorage,
       })
     );

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -100,6 +100,15 @@ type BaseSDKInitConfig = {
    */
   logLevel?: DiagLogLevel;
 
+  /**
+   * bundleID should only be provided when loading the SDK from CDN through a script tag. It is used to specify a 32
+   * character placeholder string which will then be substituted by our CLI tool when uploading source maps. See
+   * "Including the SDK as a code snippet from CDN" in our README for more details.
+   *
+   * **default**: undefined
+   */
+  bundleID?: string;
+
   diagLogger?: DiagLogger;
 };
 

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -101,13 +101,13 @@ type BaseSDKInitConfig = {
   logLevel?: DiagLogLevel;
 
   /**
-   * bundleID should only be provided when loading the SDK from CDN through a script tag. It is used to specify a 32
+   * templateBundleID should only be provided when loading the SDK from CDN through a script tag. It is used to specify a 32
    * character placeholder string which will then be substituted by our CLI tool when uploading source maps. See
    * "Including the SDK as a code snippet from CDN" in our README for more details.
    *
    * **default**: undefined
    */
-  bundleID?: string;
+  templateBundleID?: string;
 
   diagLogger?: DiagLogger;
 };


### PR DESCRIPTION
## Goal

This was close to working as is, just needed to provide a way to to specify a bundle ID placeholder in the app's code in the `initSDK` call when the default placeholder isn't available since our SDK code isn't part of the bundle