### PR TITLE
chore: fix indentation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ import { log } from '@embrace-io/web-sdk';
 
 log.message('Loading not finished in time.', 'error', {
   attributes: {
-     propertyA: 'valueA',
-     propertyB: 'valueB'
+    propertyA: 'valueA',
+    propertyB: 'valueB'
   }
 });
 ```
@@ -141,11 +141,12 @@ import { log } from '@embrace-io/web-sdk';
 try {
   // some operation...
 } catch (e) {
-  log.logException(e as Error, true, {
-     attributes: {
-       propertyA: 'valueA',
-       propertyB: 'valueB'
-     }
+  log.logException(e as Error, {
+    handled: true,
+    attributes: {
+      propertyA: 'valueA',
+      propertyB: 'valueB'
+    }
   });
 }
 ```


### PR DESCRIPTION
## Goal

Special Github callouts don't appear to work when indented so switching this to a normal blockquote

Before:
![image](https://github.com/user-attachments/assets/c2b7886d-44df-4085-943c-1be9bc9f7c38)

After:
![image](https://github.com/user-attachments/assets/89ca37c5-da62-4058-b549-c03eabbab426)
