### PR TITLE
chore: add missing setSpan and getSpan methods in TraceAPI and align startSpan method with OTel SDK signature

### DIFF
--- a/src/api-traces/api/TraceAPI/TraceAPI.test.ts
+++ b/src/api-traces/api/TraceAPI/TraceAPI.test.ts
@@ -1,9 +1,10 @@
 import * as sinon from 'sinon';
 import { ProxyTraceManager, type TraceManager } from '../../manager/index.js';
-import type { Span } from '@opentelemetry/api';
+import type { Context, Span } from '@opentelemetry/api';
 import * as chai from 'chai';
 import sinonChai from 'sinon-chai';
 import { TraceAPI } from './TraceAPI.js';
+import type { ExtendedSpan } from './types.js';
 
 chai.use(sinonChai);
 const { expect } = chai;
@@ -30,6 +31,8 @@ describe('TraceAPI', () => {
     const traceManager: TraceManager = {
       // Mock implementation of TraceManager
       startSpan: sinon.stub().returns({} as Span),
+      setSpan: sinon.stub(),
+      getSpan: sinon.stub(),
     };
     traceAPI.setGlobalTraceManager(traceManager);
     const result = traceAPI.getTraceManager();
@@ -41,12 +44,28 @@ describe('TraceAPI', () => {
     const mockTraceManager: TraceManager = {
       // Mock implementation of TraceManager
       startSpan: sinon.stub().returns({} as Span),
+      setSpan: sinon.stub(),
+      getSpan: sinon.stub(),
     };
     traceAPI.setGlobalTraceManager(mockTraceManager);
 
     traceAPI.startSpan('span-name');
     void expect(mockTraceManager.startSpan).to.have.been.calledOnceWith(
       'span-name'
+    );
+
+    const mockContext = {} as Context;
+
+    const mockSpan = {} as ExtendedSpan;
+    traceAPI.setSpan(mockContext, mockSpan);
+    void expect(mockTraceManager.setSpan).to.have.been.calledOnceWith(
+      mockContext,
+      mockSpan
+    );
+
+    traceAPI.getSpan(mockContext);
+    void expect(mockTraceManager.getSpan).to.have.been.calledOnceWith(
+      mockContext
     );
   });
 });

--- a/src/api-traces/api/TraceAPI/TraceAPI.ts
+++ b/src/api-traces/api/TraceAPI/TraceAPI.ts
@@ -4,6 +4,7 @@ import type {
   ExtendedSpanOptions,
   TraceAPIArgs,
 } from './types.js';
+import type { Context } from '@opentelemetry/api';
 
 export class TraceAPI implements TraceManager {
   private static _instance?: TraceAPI;
@@ -33,8 +34,17 @@ export class TraceAPI implements TraceManager {
 
   public startSpan(
     name: string,
-    options?: ExtendedSpanOptions
-  ): ExtendedSpan | null {
-    return this.getTraceManager().startSpan(name, options);
+    options?: ExtendedSpanOptions,
+    context?: Context
+  ): ExtendedSpan {
+    return this.getTraceManager().startSpan(name, options, context);
+  }
+
+  public setSpan(context: Context, span: ExtendedSpan): Context {
+    return this.getTraceManager().setSpan(context, span);
+  }
+
+  public getSpan(context: Context): ExtendedSpan | undefined {
+    return this.getTraceManager().getSpan(context);
   }
 }

--- a/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.test.ts
+++ b/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.test.ts
@@ -1,6 +1,8 @@
-import type { Span } from '@opentelemetry/api';
 import { expect } from 'chai';
 import { NoOpTraceManager } from './NoOpTraceManager.js';
+import { NonRecordingExtendedSpan } from './NonRecordingExtendedSpan.js';
+import type { Context } from '@opentelemetry/api';
+import { ROOT_CONTEXT } from '@opentelemetry/api';
 
 describe('NoOpTraceManager', () => {
   let noOpTraceManager: NoOpTraceManager;
@@ -9,8 +11,21 @@ describe('NoOpTraceManager', () => {
     noOpTraceManager = new NoOpTraceManager();
   });
 
-  it('should return null for startSpan', () => {
-    const span: Span | null = noOpTraceManager.startSpan('span-name');
-    void expect(span).to.be.null;
+  it('should return a non recording span for startSpan', () => {
+    const nonRecordingSpan = noOpTraceManager.startSpan('span-name');
+    void expect(nonRecordingSpan).to.be.instanceOf(NonRecordingExtendedSpan);
+  });
+
+  it('should return ROOT_CONTEXT for setSpan', () => {
+    const context = noOpTraceManager.setSpan(
+      {} as Context,
+      new NonRecordingExtendedSpan()
+    );
+    void expect(context).to.deep.equal(ROOT_CONTEXT);
+  });
+
+  it('should return undefined for getSpan', () => {
+    const span = noOpTraceManager.getSpan({} as Context);
+    void expect(span).to.be.undefined;
   });
 });

--- a/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.ts
+++ b/src/api-traces/manager/NoOpTraceManager/NoOpTraceManager.ts
@@ -1,11 +1,22 @@
 import type { TraceManager } from '../index.js';
 import type { ExtendedSpan, ExtendedSpanOptions } from '../../api/index.js';
+import { NonRecordingExtendedSpan } from './NonRecordingExtendedSpan.js';
+import type { Context } from '@opentelemetry/api';
+import { ROOT_CONTEXT } from '@opentelemetry/api';
 
 export class NoOpTraceManager implements TraceManager {
   public startSpan(
     _name: string,
     _options?: ExtendedSpanOptions
-  ): ExtendedSpan | null {
-    return null;
+  ): ExtendedSpan {
+    return new NonRecordingExtendedSpan();
+  }
+
+  public setSpan(_context: Context, _span: ExtendedSpan): Context {
+    return ROOT_CONTEXT;
+  }
+
+  public getSpan(_context: Context): ExtendedSpan | undefined {
+    return undefined;
   }
 }

--- a/src/api-traces/manager/NoOpTraceManager/NonRecordingExtendedSpan.test.ts
+++ b/src/api-traces/manager/NoOpTraceManager/NonRecordingExtendedSpan.test.ts
@@ -1,0 +1,30 @@
+import * as chai from 'chai';
+import { NonRecordingExtendedSpan } from './NonRecordingExtendedSpan.js';
+import { INVALID_SPAN_CONTEXT } from '@opentelemetry/api';
+
+const { expect } = chai;
+
+describe('NonRecordingExtendedSpan', () => {
+  it('should create a no-op extended span', () => {
+    const nonRecordingSpan = new NonRecordingExtendedSpan();
+
+    void expect(nonRecordingSpan.spanContext()).to.be.deep.equal(
+      INVALID_SPAN_CONTEXT
+    );
+    void expect(nonRecordingSpan.isRecording()).to.be.false;
+
+    // Check that all methods can be called and do not throw errors
+    void expect(() => {
+      nonRecordingSpan.fail();
+      nonRecordingSpan.setAttribute('key', 'value');
+      nonRecordingSpan.setAttributes({ key: 'value' });
+      nonRecordingSpan.addEvent('event');
+      nonRecordingSpan.addLink({ context: INVALID_SPAN_CONTEXT });
+      nonRecordingSpan.addLinks([{ context: INVALID_SPAN_CONTEXT }]);
+      nonRecordingSpan.setStatus({ code: 0 });
+      nonRecordingSpan.updateName('newName');
+      nonRecordingSpan.end();
+      nonRecordingSpan.recordException(new Error('test error'));
+    }).to.not.throw();
+  });
+});

--- a/src/api-traces/manager/NoOpTraceManager/NonRecordingExtendedSpan.ts
+++ b/src/api-traces/manager/NoOpTraceManager/NonRecordingExtendedSpan.ts
@@ -1,0 +1,67 @@
+import type {
+  SpanContext,
+  TimeInput,
+  Link,
+  SpanStatus,
+  Exception,
+  Attributes,
+} from '@opentelemetry/api';
+import { INVALID_SPAN_CONTEXT } from '@opentelemetry/api';
+import type {
+  ExtendedSpan,
+  ExtendedSpanFailedOptions,
+} from '../../api/index.js';
+
+export class NonRecordingExtendedSpan implements ExtendedSpan {
+  private readonly _spanContext: SpanContext;
+
+  public constructor(_spanContext: SpanContext = INVALID_SPAN_CONTEXT) {
+    this._spanContext = _spanContext;
+  }
+
+  public fail(_options?: ExtendedSpanFailedOptions) {}
+
+  public spanContext(): SpanContext {
+    return this._spanContext;
+  }
+
+  public setAttribute(_key: string, _value: unknown): this {
+    return this;
+  }
+
+  public setAttributes(_attributes: Attributes): this {
+    return this;
+  }
+
+  public addEvent(
+    _name: string,
+    _attributesOrStartTime?: Attributes | TimeInput,
+    _startTime?: TimeInput
+  ): this {
+    return this;
+  }
+
+  public addLink(_link: Link): this {
+    return this;
+  }
+
+  public addLinks(_links: Link[]): this {
+    return this;
+  }
+
+  public setStatus(_status: SpanStatus): this {
+    return this;
+  }
+
+  public updateName(_name: string): this {
+    return this;
+  }
+
+  public end(_endTime?: TimeInput): void {}
+
+  public isRecording(): boolean {
+    return false;
+  }
+
+  public recordException(_exception: Exception, _time?: TimeInput): void {}
+}

--- a/src/api-traces/manager/ProxyTraceManager/ProxyTraceManager.ts
+++ b/src/api-traces/manager/ProxyTraceManager/ProxyTraceManager.ts
@@ -1,6 +1,7 @@
 import type { TraceManager } from '../index.js';
 import { NoOpTraceManager } from '../NoOpTraceManager/index.js';
 import type { ExtendedSpan, ExtendedSpanOptions } from '../../api/index.js';
+import type { Context } from '@opentelemetry/api';
 
 const NOOP_TRACE_MANAGER = new NoOpTraceManager();
 
@@ -17,8 +18,17 @@ export class ProxyTraceManager implements TraceManager {
 
   public startSpan(
     name: string,
-    options?: ExtendedSpanOptions
-  ): ExtendedSpan | null {
-    return this.getDelegate().startSpan(name, options);
+    options?: ExtendedSpanOptions,
+    context?: Context
+  ): ExtendedSpan {
+    return this.getDelegate().startSpan(name, options, context);
+  }
+
+  public setSpan(context: Context, span: ExtendedSpan): Context {
+    return this.getDelegate().setSpan(context, span);
+  }
+
+  public getSpan(context: Context): ExtendedSpan | undefined {
+    return this.getDelegate().getSpan(context);
   }
 }

--- a/src/api-traces/manager/types.ts
+++ b/src/api-traces/manager/types.ts
@@ -1,8 +1,14 @@
 import type { ExtendedSpan, ExtendedSpanOptions } from '../api/index.js';
+import type { Context } from '@opentelemetry/api';
 
 export interface TraceManager {
   startSpan: (
     name: string,
-    options?: ExtendedSpanOptions
-  ) => ExtendedSpan | null;
+    options?: ExtendedSpanOptions,
+    context?: Context
+  ) => ExtendedSpan;
+
+  setSpan: (context: Context, span: ExtendedSpan) => Context;
+
+  getSpan: (context: Context) => ExtendedSpan | undefined;
 }

--- a/src/managers/EmbraceTraceManager/EmbraceTraceManager.test.ts
+++ b/src/managers/EmbraceTraceManager/EmbraceTraceManager.test.ts
@@ -5,6 +5,8 @@ import sinonChai from 'sinon-chai';
 import { KEY_EMB_ERROR_CODE, KEY_EMB_TYPE } from '../../constants/index.js';
 import { setupTestTraceExporter } from '../../testUtils/index.js';
 import { EmbraceTraceManager } from './EmbraceTraceManager.js';
+import { context } from '@opentelemetry/api';
+import { EmbraceExtendedSpan } from './EmbraceExtendedSpan.js';
 
 chai.use(sinonChai);
 const { expect } = chai;
@@ -98,5 +100,39 @@ describe('EmbraceTraceManager', () => {
       finishedParentSpan.spanContext().spanId
     );
     void expect(finishedParentSpan.parentSpanId).to.be.undefined;
+  });
+
+  it('should get a context by setting a span', () => {
+    const span = manager.startSpan('test-span');
+    void expect(span).to.not.be.null;
+
+    const newContext = manager.setSpan(context.active(), span);
+    void expect(context).to.not.be.null;
+
+    const retrievedSpan = manager.getSpan(newContext);
+    void expect(retrievedSpan).to.not.be.null;
+    void expect(retrievedSpan?.spanContext().spanId).to.equal(
+      span.spanContext().spanId
+    );
+  });
+
+  it('should return an EmbraceExtendedSpan when getting a span from context', () => {
+    const span = manager.startSpan('test-span');
+    void expect(span).to.not.be.null;
+
+    const newContext = manager.setSpan(context.active(), span);
+    void expect(context).to.not.be.null;
+
+    const retrievedSpan = manager.getSpan(newContext);
+    void expect(retrievedSpan).to.not.be.undefined;
+    void expect(retrievedSpan).to.be.instanceOf(EmbraceExtendedSpan);
+    void expect(retrievedSpan?.spanContext().spanId).to.equal(
+      span.spanContext().spanId
+    );
+  });
+
+  it('should return undefined if no span is found in the context', () => {
+    const span = manager.getSpan(context.active());
+    void expect(span).to.be.undefined;
   });
 });

--- a/src/managers/EmbraceTraceManager/EmbraceTraceManager.ts
+++ b/src/managers/EmbraceTraceManager/EmbraceTraceManager.ts
@@ -1,3 +1,4 @@
+import type { Context } from '@opentelemetry/api';
 import { trace, context } from '@opentelemetry/api';
 import type {
   TraceManager,
@@ -10,17 +11,32 @@ import { EmbraceExtendedSpan } from './EmbraceExtendedSpan.js';
 export class EmbraceTraceManager implements TraceManager {
   public startSpan(
     name: string,
-    options: ExtendedSpanOptions = {}
+    options: ExtendedSpanOptions = {},
+    ctx = context.active()
   ): ExtendedSpan {
     const tracer = trace.getTracer('embrace-web-sdk-traces');
 
     options.attributes = options.attributes ? options.attributes : {};
     options.attributes[KEY_EMB_TYPE] = EMB_TYPES.Perf;
 
-    const ctx = options.parentSpan
+    const activeContext = options.parentSpan
       ? trace.setSpan(context.active(), options.parentSpan)
-      : undefined;
+      : ctx;
 
-    return new EmbraceExtendedSpan(tracer.startSpan(name, options, ctx));
+    return new EmbraceExtendedSpan(
+      tracer.startSpan(name, options, activeContext)
+    );
+  }
+
+  public setSpan = trace.setSpan;
+
+  public getSpan(context: Context) {
+    const span = trace.getSpan(context);
+
+    if (span) {
+      return new EmbraceExtendedSpan(span);
+    }
+
+    return undefined;
   }
 }

--- a/src/sdk/initSDK.test.ts
+++ b/src/sdk/initSDK.test.ts
@@ -216,7 +216,7 @@ describe('initSDK', () => {
       (user.getUserManager() as ProxyUserManager).getDelegate()
     ).to.be.instanceOf(EmbraceUserManager);
 
-    embtrace.startSpan('my performance span')?.end();
+    embtrace.startSpan('my performance span').end();
     // shouldn't get exported
     embtrace.startSpan('my unfinished performance span');
 
@@ -369,7 +369,7 @@ describe('initSDK', () => {
       // Needed to allow the browser detector resources to be grabbed
       await new Promise(r => setTimeout(r, 1));
 
-      embtrace.startSpan('my performance span')?.end();
+      embtrace.startSpan('my performance span').end();
       // shouldn't get exported
       embtrace.startSpan('my unfinished performance span');
 


### PR DESCRIPTION
## Goal

* align startSpan method to the base OTel sdk signature 
* add missing setSpan method
* add missing getSpan method

## Testing

Unit tests and in dashjs