### PR TITLE
chore: automatically end navigation spans on session end

### DIFF
--- a/src/api-sessions/api/SessionAPI/SessionAPI.test.ts
+++ b/src/api-sessions/api/SessionAPI/SessionAPI.test.ts
@@ -40,6 +40,8 @@ describe('SessionAPI', () => {
       endSessionSpanInternal: sinon.stub(),
       addBreadcrumb: sinon.stub(),
       addProperty: sinon.stub(),
+      addSessionEndedListener: sinon.stub(),
+      addSessionStartedListener: sinon.stub(),
     };
     sessionAPI.setGlobalSessionManager(sessionManager);
     const result = sessionAPI.getSpanSessionManager();
@@ -59,6 +61,8 @@ describe('SessionAPI', () => {
       endSessionSpanInternal: sinon.stub(),
       addBreadcrumb: sinon.stub(),
       addProperty: sinon.stub(),
+      addSessionEndedListener: sinon.stub(),
+      addSessionStartedListener: sinon.stub(),
     };
     sessionAPI.setGlobalSessionManager(mockSpanSessionManager);
 
@@ -94,5 +98,13 @@ describe('SessionAPI', () => {
       'custom-key',
       'custom value'
     );
+
+    sessionAPI.addSessionEndedListener(() => {});
+    void expect(mockSpanSessionManager.addSessionEndedListener).to.have.been
+      .calledOnce;
+
+    sessionAPI.addSessionStartedListener(() => {});
+    void expect(mockSpanSessionManager.addSessionStartedListener).to.have.been
+      .calledOnce;
   });
 });

--- a/src/api-sessions/api/SessionAPI/SessionAPI.ts
+++ b/src/api-sessions/api/SessionAPI/SessionAPI.ts
@@ -63,4 +63,12 @@ export class SessionAPI implements SpanSessionManager {
   public startSessionSpan() {
     this.getSpanSessionManager().startSessionSpan();
   }
+
+  public addSessionStartedListener(listener: () => void): () => void {
+    return this.getSpanSessionManager().addSessionStartedListener(listener);
+  }
+
+  public addSessionEndedListener(listener: () => void): () => void {
+    return this.getSpanSessionManager().addSessionEndedListener(listener);
+  }
 }

--- a/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.test.ts
+++ b/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.test.ts
@@ -57,4 +57,16 @@ describe('NoOpSpanSessionManager', () => {
       );
     }).to.not.throw();
   });
+
+  it('should do nothing for addSessionStartedListener', () => {
+    expect(() => {
+      noOpSpanSessionManager.addSessionStartedListener(() => {});
+    }).to.not.throw();
+  });
+
+  it('should do nothing for addSessionEndedListener', () => {
+    expect(() => {
+      noOpSpanSessionManager.addSessionEndedListener(() => {});
+    }).to.not.throw();
+  });
 });

--- a/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.ts
+++ b/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.ts
@@ -31,4 +31,12 @@ export class NoOpSpanSessionManager implements SpanSessionManager {
   public startSessionSpan(): void {
     // do nothing.
   }
+
+  public addSessionStartedListener(_listener: () => void): void {
+    // do nothing.
+  }
+
+  public addSessionEndedListener(_listener: () => void): void {
+    // do nothing.
+  }
 }

--- a/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.ts
+++ b/src/api-sessions/manager/NoOpSpanSessionManager/NoOpSpanSessionManager.ts
@@ -32,11 +32,11 @@ export class NoOpSpanSessionManager implements SpanSessionManager {
     // do nothing.
   }
 
-  public addSessionStartedListener(_listener: () => void): void {
-    // do nothing.
+  public addSessionStartedListener(_listener: () => void): () => void {
+    return () => {};
   }
 
-  public addSessionEndedListener(_listener: () => void): void {
-    // do nothing.
+  public addSessionEndedListener(_listener: () => void): () => void {
+    return () => {};
   }
 }

--- a/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.test.ts
+++ b/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.test.ts
@@ -24,6 +24,8 @@ describe('ProxySpanSessionManager', () => {
       endSessionSpanInternal: sinon.stub(),
       addBreadcrumb: sinon.stub(),
       addProperty: sinon.stub(),
+      addSessionStartedListener: sinon.stub(),
+      addSessionEndedListener: sinon.stub(),
     };
   });
 
@@ -99,6 +101,24 @@ describe('ProxySpanSessionManager', () => {
     expect(mockDelegate.addProperty).to.have.been.calledOnceWith(
       'some-custom-key',
       'some custom value'
+    );
+  });
+
+  it('should delegate addSessionStartedListener to the delegate', () => {
+    const listener = () => {};
+    proxySpanSessionManager.setDelegate(mockDelegate);
+    proxySpanSessionManager.addSessionStartedListener(listener);
+    expect(mockDelegate.addSessionStartedListener).to.have.been.calledOnceWith(
+      listener
+    );
+  });
+
+  it('should delegate addSessionEndedListener to the delegate', () => {
+    const listener = () => {};
+    proxySpanSessionManager.setDelegate(mockDelegate);
+    proxySpanSessionManager.addSessionEndedListener(listener);
+    expect(mockDelegate.addSessionEndedListener).to.have.been.calledOnceWith(
+      listener
     );
   });
 });

--- a/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.ts
+++ b/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.ts
@@ -47,11 +47,11 @@ export class ProxySpanSessionManager implements SpanSessionManager {
     this.getDelegate().startSessionSpan();
   }
 
-  public addSessionStartedListener(listener: () => void): void {
-    this.getDelegate().addSessionStartedListener(listener);
+  public addSessionStartedListener(listener: () => void): () => void {
+    return this.getDelegate().addSessionStartedListener(listener);
   }
 
-  public addSessionEndedListener(listener: () => void): void {
-    this.getDelegate().addSessionEndedListener(listener);
+  public addSessionEndedListener(listener: () => void): () => void {
+    return this.getDelegate().addSessionEndedListener(listener);
   }
 }

--- a/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.ts
+++ b/src/api-sessions/manager/ProxySpanSessionManager/ProxySpanSessionManager.ts
@@ -46,4 +46,12 @@ export class ProxySpanSessionManager implements SpanSessionManager {
   public startSessionSpan() {
     this.getDelegate().startSessionSpan();
   }
+
+  public addSessionStartedListener(listener: () => void): void {
+    this.getDelegate().addSessionStartedListener(listener);
+  }
+
+  public addSessionEndedListener(listener: () => void): void {
+    this.getDelegate().addSessionEndedListener(listener);
+  }
 }

--- a/src/api-sessions/manager/types.ts
+++ b/src/api-sessions/manager/types.ts
@@ -18,9 +18,9 @@ export interface SpanSessionManager {
   // todo move this to another class SpanSessionManagerInternal that is only accessible from within our code, but expose the external one without the method to the users.
   endSessionSpanInternal: (reason: ReasonSessionEnded) => void;
 
-  addSessionStartedListener: (listener: () => void) => void;
+  addSessionStartedListener: (listener: () => void) => () => void;
 
-  addSessionEndedListener: (listener: () => void) => void;
+  addSessionEndedListener: (listener: () => void) => () => void;
 }
 
 export type ReasonSessionEnded =

--- a/src/api-sessions/manager/types.ts
+++ b/src/api-sessions/manager/types.ts
@@ -17,6 +17,10 @@ export interface SpanSessionManager {
 
   // todo move this to another class SpanSessionManagerInternal that is only accessible from within our code, but expose the external one without the method to the users.
   endSessionSpanInternal: (reason: ReasonSessionEnded) => void;
+
+  addSessionStartedListener: (listener: () => void) => void;
+
+  addSessionEndedListener: (listener: () => void) => void;
 }
 
 export type ReasonSessionEnded =

--- a/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
+++ b/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
@@ -18,6 +18,8 @@ export class NavigationInstrumentation extends EmbraceInstrumentationBase {
   private _currentRoute: Route | null = null;
   private _currentRouteSpan: Span | null = null;
   private _instrumentationType: EMB_NAVIGATION_INSTRUMENTATIONS | null = null;
+  private _removeSessionStartedFn: (() => void) | null = null;
+  private _removeSessionEndedFn: (() => void) | null = null;
 
   public constructor({
     diag,
@@ -56,8 +58,49 @@ export class NavigationInstrumentation extends EmbraceInstrumentationBase {
     }
   };
 
+  private readonly _setupSessionListeners = () => {
+    if (!this._removeSessionStartedFn) {
+      this._removeSessionStartedFn =
+        this.sessionManager.addSessionStartedListener(() => {
+          if (this._currentRoute && !this._currentRouteSpan) {
+            this._diag.debug('Session started, starting route span.');
+
+            this._startRouteSpan(this._currentRoute);
+          }
+        });
+    }
+  };
+
+  private readonly _setupSessionEndedListeners = () => {
+    if (!this._removeSessionEndedFn) {
+      this._removeSessionEndedFn = this.sessionManager.addSessionEndedListener(
+        () => {
+          if (this._currentRouteSpan) {
+            this._diag.debug('Session ended, ending route span.');
+
+            this._endRouteSpan();
+          }
+        }
+      );
+    }
+  };
+
+  private readonly _cleanUpSessionListeners = () => {
+    if (this._removeSessionStartedFn) {
+      this._removeSessionStartedFn();
+      this._removeSessionStartedFn = null;
+    }
+
+    if (this._removeSessionEndedFn) {
+      this._removeSessionEndedFn();
+      this._removeSessionEndedFn = null;
+    }
+  };
+
   private readonly _startRouteSpan = (route: Route): Span => {
     this._diag.debug(`Starting route span for url: ${route.url}`);
+    this._setupSessionListeners();
+    this._setupSessionEndedListeners();
 
     const pathName = this._shouldCleanupPathOptionsFromRouteName
       ? route.path.replace(PATH_OPTIONS_RE, '')
@@ -94,6 +137,7 @@ export class NavigationInstrumentation extends EmbraceInstrumentationBase {
   };
 
   public disable = () => {
+    this._cleanUpSessionListeners();
     this.setConfig({
       enabled: false,
     });

--- a/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
+++ b/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
@@ -69,9 +69,7 @@ export class NavigationInstrumentation extends EmbraceInstrumentationBase {
           }
         });
     }
-  };
 
-  private readonly _setupSessionEndedListeners = () => {
     if (!this._removeSessionEndedFn) {
       this._removeSessionEndedFn = this.sessionManager.addSessionEndedListener(
         () => {
@@ -100,7 +98,6 @@ export class NavigationInstrumentation extends EmbraceInstrumentationBase {
   private readonly _startRouteSpan = (route: Route): Span => {
     this._diag.debug(`Starting route span for url: ${route.url}`);
     this._setupSessionListeners();
-    this._setupSessionEndedListeners();
 
     const pathName = this._shouldCleanupPathOptionsFromRouteName
       ? route.path.replace(PATH_OPTIONS_RE, '')

--- a/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
+++ b/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
@@ -1,6 +1,7 @@
 import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
 import { ATTR_SESSION_ID } from '@opentelemetry/semantic-conventions/incubating';
 import * as chai from 'chai';
+import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { KEY_EMB_SESSION_REASON_ENDED } from '../../constants/index.js';
 import {
@@ -189,5 +190,41 @@ describe('EmbraceSpanSessionManager', () => {
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
     expect(sessionSpan.attributes).to.have.property('emb.state', 'background');
+  });
+
+  it('should call the session start listener when starting a session', () => {
+    const listener = sinon.stub();
+    const manager = new EmbraceSpanSessionManager();
+    const removeListener = manager.addSessionStartedListener(listener);
+
+    void expect(listener).to.not.have.been.calledOnce;
+
+    manager.startSessionSpan();
+
+    void expect(listener).to.have.been.calledOnce;
+
+    removeListener();
+    manager.startSessionSpan();
+
+    void expect(listener).to.have.been.calledOnce;
+  });
+
+  it('should call the session ended listener when ending a session', () => {
+    const listener = sinon.stub();
+    const manager = new EmbraceSpanSessionManager();
+    const removeListener = manager.addSessionEndedListener(listener);
+
+    void expect(listener).to.not.have.been.calledOnce;
+
+    manager.startSessionSpan();
+    manager.endSessionSpan();
+
+    void expect(listener).to.have.been.calledOnce;
+
+    removeListener();
+    manager.startSessionSpan();
+    manager.endSessionSpan();
+
+    void expect(listener).to.have.been.calledOnce;
   });
 });

--- a/src/managers/EmbraceSpanSessionManager/types.ts
+++ b/src/managers/EmbraceSpanSessionManager/types.ts
@@ -12,3 +12,6 @@ export interface EmbraceSpanSessionManagerArgs {
 export interface SpanSessionManagerInternal extends SpanSessionManager {
   incrSessionCountForKey: (key: string) => void;
 }
+
+export type SessionStartedListener = () => void;
+export type SessionEndedListener = () => void;


### PR DESCRIPTION
## Goal

* Add addSessionStartedListener and addSessionEndedListener to hook into the session lifecycle from other instrumentations
* Use addSessionStartedListener and addSessionEndedListener in NavigationInstrumentation

## Testing

Unit tests and demo app