### PR TITLE
chore: add update-types for otel packages in dependabot.yml and move @opentelemetry/api and @opentelemetry/sdk-trace-web to peerDependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,20 @@ updates:
       eslint:
         patterns:
           - "*eslint*"
+      # All these packages are marked as experimental, so only apply patch updates
+      opentelemetry-experimental:
+        patterns:
+          - "@opentelemetry/instrumentation-*"
+          - "@opentelemetry/opentelemetry-browser-detector"
+          - "@opentelemetry/otlp-exporter-base"
+          - "@opentelemetry/web-common"
+        update-types:
+          - patch
       opentelemetry:
         patterns:
           - "@opentelemetry/*"
+        update-types:
+          - minor
       react:
         patterns:
           - "react*"

--- a/README.md
+++ b/README.md
@@ -39,14 +39,20 @@ Currently, only Spans and Logs are supported, but other signals will be added in
 npm:
 
 ```sh
-npm install @embrace-io/web-sdk
+npm install --save @embrace-io/web-sdk @opentelemetry/api@^1 @opentelemetry/sdk-trace-web@^1
+
 ```
 
 yarn:
 
 ```sh
-yarn add @embrace-io/web-sdk
+yarn add @embrace-io/web-sdk @opentelemetry/api@^1 @opentelemetry/sdk-trace-web@^1
 ```
+
+#### Why do I need to install `@opentelemetry/api` and `@opentelemetry/sdk-trace-web`?
+
+These packages are used internally to emit telemetry in the OpenTelemetry format. We list them as `peerDependencies` to 
+avoid bundling them and prevent version conflicts if you use the OpenTelemetry SDK directly in your application.
 
 > [!TIP]
 > For CDN installs, see [Including the SDK as a code snippet from CDN](#including-the-sdk-as-a-code-snippet-from-cdn).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,12 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api": "1.9.0",
         "@opentelemetry/instrumentation": "0.57.0",
         "@opentelemetry/instrumentation-document-load": "0.44.1",
         "@opentelemetry/instrumentation-fetch": "0.57.2",
         "@opentelemetry/instrumentation-xml-http-request": "0.57.2",
         "@opentelemetry/opentelemetry-browser-detector": "0.57.2",
         "@opentelemetry/otlp-exporter-base": "0.57.2",
-        "@opentelemetry/sdk-trace-web": "1.30.1",
         "@opentelemetry/web-common": "0.57.2",
         "hoist-non-react-statics": "3.3.2",
         "uuid": "11.1.0",
@@ -26,6 +24,8 @@
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-conventional": "19.8.1",
         "@eslint/js": "9.28.0",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/sdk-trace-web": "1.30.1",
         "@remcovaes/web-test-runner-vite-plugin": "1.2.2",
         "@rollup/plugin-commonjs": "28.0.3",
         "@rollup/plugin-node-resolve": "16.0.1",
@@ -59,6 +59,8 @@
         "typescript-eslint": "8.33.0"
       },
       "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <2.0.0",
+        "@opentelemetry/sdk-trace-web": ">=1.0.0 <2.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -110,14 +110,12 @@
     "telemetry"
   ],
   "dependencies": {
-    "@opentelemetry/api": "1.9.0",
     "@opentelemetry/instrumentation": "0.57.0",
     "@opentelemetry/instrumentation-document-load": "0.44.1",
     "@opentelemetry/instrumentation-fetch": "0.57.2",
     "@opentelemetry/instrumentation-xml-http-request": "0.57.2",
     "@opentelemetry/opentelemetry-browser-detector": "0.57.2",
     "@opentelemetry/otlp-exporter-base": "0.57.2",
-    "@opentelemetry/sdk-trace-web": "1.30.1",
     "@opentelemetry/web-common": "0.57.2",
     "hoist-non-react-statics": "3.3.2",
     "uuid": "11.1.0",
@@ -127,6 +125,8 @@
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
     "@eslint/js": "9.28.0",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/sdk-trace-web": "1.30.1",
     "@remcovaes/web-test-runner-vite-plugin": "1.2.2",
     "@rollup/plugin-commonjs": "28.0.3",
     "@rollup/plugin-node-resolve": "16.0.1",
@@ -160,6 +160,8 @@
     "typescript-eslint": "8.33.0"
   },
   "peerDependencies": {
+    "@opentelemetry/api": ">=1.0.0 <2.0.0",
+    "@opentelemetry/sdk-trace-web": ">=1.0.0 <2.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -160,8 +160,8 @@
     "typescript-eslint": "8.33.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <2.0.0",
-    "@opentelemetry/sdk-trace-web": ">=1.0.0 <2.0.0",
+    "@opentelemetry/api": ">=1.9.0 <2.0.0",
+    "@opentelemetry/sdk-trace-web": ">=1.30.1 <2.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Goal

* add update-types for otel packages in dependabot.yml 
* move @opentelemetry/api and @opentelemetry/sdk-trace-web to peerDependencies

## Testing

n/a