### PR TITLE
EMBR-7484 feat: option for attributing previous URLs for core web vitals

### DIFF
--- a/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -2,7 +2,10 @@ import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import type { MetricWithAttribution } from 'web-vitals/attribution';
+import type {
+  CLSMetricWithAttribution,
+  MetricWithAttribution,
+} from 'web-vitals/attribution';
 import {
   session,
   type SpanSessionManager,
@@ -504,5 +507,171 @@ describe('WebVitalsInstrumentation', () => {
 
     expect(clsEvent.time).to.deep.equal([5, 0]);
     expect(lcpEvent.time).to.deep.equal([5, 0]);
+  });
+
+  it('should attribute the correct URL for INP metrics', () => {
+    const testDocument: URLDocument = {
+      URL: 'https://first.com',
+    };
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      urlDocument: testDocument,
+      listeners: mockWebVitalListeners,
+      urlAttribution: true,
+    });
+
+    void expect(inpStub).to.have.been.callCount(2);
+    const inpFinalReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
+    const inpChangeReportFunc = inpStub.getCall(1).args[0] as WebVitalOnReport;
+
+    const inpMetric = {
+      name: 'INP',
+      value: 22,
+      rating: 'poor',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        interactionTarget: 'some-target',
+        interactionTime: 19000,
+        nextPaintTime: 18000,
+        interactionType: 'pointer',
+        processedEventEntries: [],
+        longAnimationFrameEntries: [],
+        inputDelay: 1000,
+        processingDuration: 2000,
+        presentationDelay: 3000,
+        loadState: 'complete',
+      },
+    } as MetricWithAttribution;
+
+    inpChangeReportFunc(inpMetric);
+    // should be attributed to this URL since that is when the last change to the metric occurred
+    testDocument.URL = 'https://second.com';
+    inpChangeReportFunc(inpMetric);
+    testDocument.URL = 'https://third.com';
+    inpFinalReportFunc(inpMetric);
+
+    spanSessionManager.endSessionSpan();
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(1);
+
+    const inpEvent = sessionSpan.events[0];
+
+    expect(inpEvent.name).to.be.equal('emb-web-vitals-report-INP');
+    expect(inpEvent.attributes).to.containSubset({
+      'url.full': 'https://second.com',
+    });
+  });
+
+  it('should attribute the correct URL for LCP metrics', () => {
+    const testDocument: URLDocument = {
+      URL: 'https://first.com',
+    };
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      urlDocument: testDocument,
+      listeners: mockWebVitalListeners,
+      urlAttribution: true,
+    });
+
+    void expect(lcpStub).to.have.been.callCount(2);
+    const lcpFinalReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
+    const lcpChangeReportFunc = lcpStub.getCall(1).args[0] as WebVitalOnReport;
+
+    const lcpMetric = {
+      name: 'LCP',
+      value: 22,
+      rating: 'poor',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        timeToFirstByte: 999,
+        resourceLoadDelay: 1000,
+        resourceLoadDuration: 2000,
+        elementRenderDelay: 3000,
+      },
+    } as MetricWithAttribution;
+
+    lcpChangeReportFunc(lcpMetric);
+    // should be attributed to this URL since that is when the last change to the metric occurred
+    testDocument.URL = 'https://second.com';
+    lcpChangeReportFunc(lcpMetric);
+    testDocument.URL = 'https://third.com';
+    lcpFinalReportFunc(lcpMetric);
+
+    spanSessionManager.endSessionSpan();
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(1);
+
+    const lcpEvent = sessionSpan.events[0];
+
+    expect(lcpEvent.name).to.be.equal('emb-web-vitals-report-LCP');
+    expect(lcpEvent.attributes).to.containSubset({
+      'url.full': 'https://second.com',
+    });
+  });
+
+  it('should attribute the correct URL for CLS metrics', () => {
+    const testDocument: URLDocument = {
+      URL: 'https://first.com',
+    };
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      urlDocument: testDocument,
+      listeners: mockWebVitalListeners,
+      urlAttribution: true,
+    });
+
+    void expect(clsStub).to.have.been.callCount(2);
+    const clsFinalReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+    const clsChangeReportFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
+
+    const clsMetric = {
+      name: 'CLS',
+      value: 22,
+      rating: 'poor',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        largestShiftTarget: 'some-target-1',
+      },
+    } as CLSMetricWithAttribution;
+
+    clsChangeReportFunc(clsMetric);
+    // should be attributed to this URL since that is when the last change to the metric occurred and largestShiftTarget
+    // was changed
+    clsMetric.attribution.largestShiftTarget = 'some-target-2';
+    testDocument.URL = 'https://second.com';
+    clsChangeReportFunc(clsMetric);
+    // should NOT be attributed to this URL since the largestShiftTarget didn't change
+    testDocument.URL = 'https://third.com';
+    clsChangeReportFunc(clsMetric);
+    clsFinalReportFunc(clsMetric);
+
+    spanSessionManager.endSessionSpan();
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(1);
+
+    const clsEvent = sessionSpan.events[0];
+
+    expect(clsEvent.name).to.be.equal('emb-web-vitals-report-CLS');
+    expect(clsEvent.attributes).to.containSubset({
+      'url.full': 'https://second.com',
+    });
   });
 });

--- a/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -1,11 +1,12 @@
 import type { Attributes } from '@opentelemetry/api';
 import type {
   CLSAttribution,
+  CLSMetricWithAttribution,
   INPAttribution,
   LCPAttribution,
   MetricWithAttribution,
+  Metric,
 } from 'web-vitals/attribution';
-import { type Metric } from 'web-vitals/attribution';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/index.js';
 import {
   ALL_WEB_VITALS,
@@ -101,6 +102,11 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
   private readonly _metricsToTrack: Metric['name'][];
   private readonly _listeners: WebVitalListeners;
   private readonly _urlDocument: URLDocument;
+  private readonly _urlAttribution: boolean;
+  private _attributedURLForINP: string | undefined;
+  private _attributedURLForLCP: string | undefined;
+  private _attributedURLForCLS: string | undefined;
+  private _largestShiftTargetForCLS: string | undefined;
 
   // instrumentation that adds an event to the session span for each web vital report
   public constructor({
@@ -109,6 +115,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     trackingLevel = 'core',
     listeners = WEB_VITALS_ID_TO_LISTENER,
     urlDocument = window.document,
+    urlAttribution = false,
   }: WebVitalsInstrumentationArgs = {}) {
     super({
       instrumentationName: 'WebVitalsInstrumentation',
@@ -121,6 +128,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     this._urlDocument = urlDocument;
     this._metricsToTrack =
       trackingLevel === 'core' ? [...CORE_WEB_VITALS] : [...ALL_WEB_VITALS];
+    this._urlAttribution = urlAttribution;
 
     if (this._config.enabled) {
       this.enable();
@@ -146,7 +154,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
 
         const attrs: Attributes = {
           [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
-          [ATTR_URL_FULL]: this._urlDocument.URL,
+          [ATTR_URL_FULL]: this._getAttributedURLForMetric(metric),
           'emb.web_vital.navigation_type': metric.navigationType,
           'emb.web_vital.name': metric.name,
           'emb.web_vital.rating': metric.rating,
@@ -163,6 +171,47 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
         );
       });
     });
+
+    if (this._urlAttribution) {
+      // When these web vitals make their final report (e.g. when the listeners w/ reportAllChanges=false trigger) the
+      // document's URL at that time may not match what it was at the time the scores were last updated. Instead, listen
+      // for updates to the scores and keep track of the URL to attribute for each
+      this._listeners.INP?.(
+        () => {
+          this._attributedURLForINP = this._urlDocument.URL;
+        },
+        {
+          reportAllChanges: true,
+        }
+      );
+      this._listeners.LCP?.(
+        () => {
+          this._attributedURLForLCP = this._urlDocument.URL;
+        },
+        {
+          reportAllChanges: true,
+        }
+      );
+      this._listeners.CLS?.(
+        (metric: MetricWithAttribution) => {
+          const clsMetric = metric as CLSMetricWithAttribution;
+          // A layout shift could cause CLS to change its rating but because the score is cumulative this might not
+          // correspond with an updated `largestShiftTarget`. Since we want to tie the attributed URL to the page that
+          // the `largestShiftTarget` was on we only update the attributed URL if that target has changed
+          if (
+            this._largestShiftTargetForCLS !==
+            clsMetric.attribution.largestShiftTarget
+          ) {
+            this._largestShiftTargetForCLS =
+              clsMetric.attribution.largestShiftTarget;
+            this._attributedURLForCLS = this._urlDocument.URL;
+          }
+        },
+        {
+          reportAllChanges: true,
+        }
+      );
+    }
   }
 
   private _getTimeForMetric(metric: MetricWithAttribution): number {
@@ -179,5 +228,25 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     }
 
     return this.perf.getNowMillis();
+  }
+
+  private _getAttributedURLForMetric(metric: MetricWithAttribution): string {
+    if (metric.name === 'INP' && this._attributedURLForINP) {
+      return this._attributedURLForINP;
+    }
+
+    if (metric.name === 'LCP' && this._attributedURLForLCP) {
+      return this._attributedURLForLCP;
+    }
+
+    if (
+      metric.name === 'CLS' &&
+      this._attributedURLForCLS &&
+      metric.attribution.largestShiftTarget === this._largestShiftTargetForCLS
+    ) {
+      return this._attributedURLForCLS;
+    }
+
+    return this._urlDocument.URL;
   }
 }

--- a/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -103,9 +103,14 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
   private readonly _listeners: WebVitalListeners;
   private readonly _urlDocument: URLDocument;
   private readonly _urlAttribution: boolean;
-  private _attributedURLForINP: string | undefined;
-  private _attributedURLForLCP: string | undefined;
-  private _attributedURLForCLS: string | undefined;
+  private readonly _attributedURL: Record<Metric['name'], string | undefined> =
+    {
+      INP: undefined,
+      LCP: undefined,
+      CLS: undefined,
+      FCP: undefined,
+      TTFB: undefined,
+    };
   private _largestShiftTargetForCLS: string | undefined;
 
   // instrumentation that adds an event to the session span for each web vital report
@@ -178,7 +183,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
       // for updates to the scores and keep track of the URL to attribute for each
       this._listeners.INP?.(
         () => {
-          this._attributedURLForINP = this._urlDocument.URL;
+          this._attributedURL.INP = this._urlDocument.URL;
         },
         {
           reportAllChanges: true,
@@ -186,7 +191,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
       );
       this._listeners.LCP?.(
         () => {
-          this._attributedURLForLCP = this._urlDocument.URL;
+          this._attributedURL.LCP = this._urlDocument.URL;
         },
         {
           reportAllChanges: true,
@@ -204,7 +209,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
           ) {
             this._largestShiftTargetForCLS =
               clsMetric.attribution.largestShiftTarget;
-            this._attributedURLForCLS = this._urlDocument.URL;
+            this._attributedURL.CLS = this._urlDocument.URL;
           }
         },
         {
@@ -231,20 +236,20 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
   }
 
   private _getAttributedURLForMetric(metric: MetricWithAttribution): string {
-    if (metric.name === 'INP' && this._attributedURLForINP) {
-      return this._attributedURLForINP;
+    if (metric.name === 'INP' && this._attributedURL.INP) {
+      return this._attributedURL.INP;
     }
 
-    if (metric.name === 'LCP' && this._attributedURLForLCP) {
-      return this._attributedURLForLCP;
+    if (metric.name === 'LCP' && this._attributedURL.LCP) {
+      return this._attributedURL.LCP;
     }
 
     if (
       metric.name === 'CLS' &&
-      this._attributedURLForCLS &&
+      this._attributedURL.CLS &&
       metric.attribution.largestShiftTarget === this._largestShiftTargetForCLS
     ) {
-      return this._attributedURLForCLS;
+      return this._attributedURL.CLS;
     }
 
     return this._urlDocument.URL;

--- a/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
+++ b/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
@@ -19,4 +19,5 @@ export type WebVitalsInstrumentationArgs = {
   trackingLevel?: TrackingLevel;
   listeners?: WebVitalListeners;
   urlDocument?: URLDocument;
+  urlAttribution?: boolean;
 } & Pick<EmbraceInstrumentationBaseArgs, 'diag' | 'perf'>;


### PR DESCRIPTION
## Goal

Wanted to propose this as a way to attribute URLs to the core web vitals we emit instead of always grabbing the current URL at the time of report. Wanted to first validate that this approach makes sense, and then if it did, do some more testing in real environments before we decide if we want it to be the default behaviour (currently the `urlAttribution` config controls this and defaults to false)