### PR TITLE
chore: suppress acceptable warnings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,6 +18,22 @@ const input = {
   'react-instrumentation': 'src/react/index.ts',
 };
 
+// Suppress irrelevant warnings to keep the build output clean
+const onwarn = (warning, warn) => {
+  const ignoredWarnings = [
+    'CIRCULAR_DEPENDENCY', // Circular dependencies are bundled, so no issue
+    'CYCLIC_CROSS_CHUNK_REEXPORT', // Barrel exports are intentional
+    'THIS_IS_UNDEFINED', // 'this' conversion to 'undefined' is preferred
+    'SOURCEMAP_ERROR', // Some node_modules have invalid sourcemaps
+  ];
+
+  if (ignoredWarnings.includes(warning.code)) {
+    return;
+  }
+
+  warn(warning);
+};
+
 export default defineConfig([
   // ESM Build
   {
@@ -37,6 +53,7 @@ export default defineConfig([
       preserveModulesRoot: 'src',
     },
     external: isExternal,
+    onwarn,
   },
 
   // ESNext build
@@ -57,6 +74,7 @@ export default defineConfig([
       preserveModulesRoot: 'src',
     },
     external: isExternal,
+    onwarn,
   },
 
   // CJS build
@@ -77,6 +95,7 @@ export default defineConfig([
       preserveModulesRoot: 'src',
     },
     external: isExternal,
+    onwarn,
   },
 
   // CDN Build, it only exports the core web sdk and not any additional instrumentation
@@ -102,5 +121,6 @@ export default defineConfig([
       sourcemap: true,
     },
     external: peerDeps,
+    onwarn,
   },
 ]);


### PR DESCRIPTION
## Goal

To suppress rollup warnings about circular dependencies, barrel files, and use of `this` so real errors are easier to spot.

## Testing

Build output is quieter:
```
> npm run sdk:compile:clean & npm run sdk:compile


> @embrace-io/web-sdk@1.3.0 sdk:compile
> rollup -c && npm run sdk:compile:types


> @embrace-io/web-sdk@1.3.0 sdk:compile:clean
> rimraf build


src/index.ts, src/react/index.ts → build/esm...
created build/esm in 2.1s

src/index.ts, src/react/index.ts → build/esnext...
created build/esnext in 1.5s

src/index.ts, src/react/index.ts → build/src...
created build/src in 1.6s

src/index.ts → build/iife/bundle.js...
created build/iife/bundle.js in 3.1s

> @embrace-io/web-sdk@1.3.0 sdk:compile:types
> tsc --build tsconfig.types.json
```