### PR TITLE
fix: support publishing web-cli with npm workspaces

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -601,7 +601,7 @@ jobs:
 
       - name: Install NPM dependencies
         run: |
-          npm ci --strict-peer-deps
+          npm ci --include-workspace-root --strict-peer-deps
 
       - name: Run 'npm publish'
         env:


### PR DESCRIPTION
## Goal

`npm ci` was failing since the move to npm packages

## Testing

<!-- Describe how this change has been tested -->