### PR TITLE
feat: explicitly export sdk to window

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -113,8 +113,13 @@ export default defineConfig([
     output: {
       file: 'build/iife/bundle.js',
       format: 'iife',
-      name: 'EmbraceWebSdk', // Global variable name for the SDK
+      // global variable name for the SDK
+      name: 'EmbraceWebSdk',
       sourcemap: true,
+      // TODO create a new entry file that sets the window variable explicitly and remove this line.
+      // This is a workaround to assign the SDK to the global window object so users can lazyload the SDK.
+      // By default, rollup creates the export with 'var' and assumes the SDK is being used in a script tag,
+      // which would normally be the window.
       footer: 'window.EmbraceWebSdk = EmbraceWebSdk;',
     },
     external: peerDeps,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -115,6 +115,7 @@ export default defineConfig([
       format: 'iife',
       name: 'EmbraceWebSdk', // Global variable name for the SDK
       sourcemap: true,
+      footer: 'window.EmbraceWebSdk = EmbraceWebSdk;',
     },
     external: peerDeps,
     onwarn,


### PR DESCRIPTION
## Goal

In addition to using a script tag to load the bundled IIFE version of the sdk, allow users to lazy load: `await import('https://cdn.jsdelivr.net/npm/@embrace-io/web-sdk@1')` 

## Testing

CDN demo is working.