### PR TITLE
fix: do not require token if cli is called with --no-upload

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -37,9 +37,10 @@ program
       .makeOptionMandatory()
   )
   .addOption(
-    new Option('-t, --token <token>', 'API token to authenticate with Embrace')
-      .env('EMB_SOURCE_UPLOAD_API_TOKEN')
-      .makeOptionMandatory()
+    new Option(
+      '-t, --token <token>',
+      'API token to authenticate with Embrace'
+    ).env('EMB_SOURCE_UPLOAD_API_TOKEN')
   )
   .addOption(
     new Option('-a, --app-id <appID>', 'Application ID')

--- a/cli/src/processSourceFiles.ts
+++ b/cli/src/processSourceFiles.ts
@@ -50,6 +50,7 @@ export const processSourceFiles = async ({
     appVersion,
     templateBundleID,
     templateAppVersion,
+    upload,
   });
   if (validationError) {
     console.error('Input Validation Error: ', validationError);

--- a/cli/src/uploadToApi.ts
+++ b/cli/src/uploadToApi.ts
@@ -27,6 +27,13 @@ export const uploadToApi = async ({
   dryRun,
   upload,
 }: UploadToApiArgs): Promise<void> => {
+  console.log(
+    upload && !dryRun ? 'Uploading to Embrace API' : 'Dry run, skipping upload'
+  );
+  if (dryRun || !upload) {
+    return;
+  }
+
   // prepare the body for the API request as a gzipped JSON object
   const body = new Blob([
     zlib.gzipSync(
@@ -42,12 +49,7 @@ export const uploadToApi = async ({
   formData.append('app', appID);
   formData.append('token', token);
   formData.append('file', body);
-  console.log(
-    upload && !dryRun ? 'Uploading to Embrace API' : 'Dry run, skipping upload'
-  );
-  if (dryRun || !upload) {
-    return;
-  }
+
   try {
     console.log(`Uploading to API bundle ID ${bundleID}, appID ${appID}`);
     const response = await fetch(host + pathForUpload + storeType, {

--- a/cli/src/validateInput.ts
+++ b/cli/src/validateInput.ts
@@ -14,6 +14,7 @@ interface ValidateInputArgs {
   cliVersion: string;
   templateBundleID: string;
   templateAppVersion: string;
+  upload: boolean;
 }
 
 export const validateInput = ({
@@ -28,6 +29,7 @@ export const validateInput = ({
   appVersion,
   templateBundleID,
   templateAppVersion,
+  upload,
 }: ValidateInputArgs): string | null => {
   if (!jsFilePath.trim()) {
     return 'JS file path cannot be empty.';
@@ -40,10 +42,10 @@ export const validateInput = ({
   if (!mapFilePath.trim()) {
     return 'Map file path cannot be empty.';
   }
-  if (!token.trim()) {
+  if (upload && !token.trim()) {
     return 'Token cannot be empty.';
   }
-  if (token.length !== 32) {
+  if (upload && token.length !== 32) {
     return 'Token must be 32 characters long.';
   }
   if (!appID.trim()) {


### PR DESCRIPTION
## Goal

Currently we are calling with `--no-upload` in our frontend demo: https://github.com/embrace-io/embrace-web-sdk/blob/main/demo/frontend/scripts/runDemo.sh#L25 and this is failing as we are not passing a token, which is not used so shouldn't be mandatory.

## Testing

<!-- Describe how this change has been tested -->