### PR TITLE
chore: enable linting of demo and tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,8 @@ export default tseslint.config([
     files: [
       './src/**/*.{js,mjs,cjs,ts,jsx,tsx}',
       './cli/src/**/*.{js,mjs,cjs,ts,jsx,tsx}',
+      './tests/**/*.{js,mjs,cjs,ts,jsx,tsx}',
+      './demo/**/*.{js,mjs,cjs,ts,jsx,tsx}',
     ],
     extends: [
       pluginJs.configs.recommended,
@@ -149,11 +151,7 @@ export default tseslint.config([
     languageOptions: {
       globals: globals.browser,
       parserOptions: {
-        project: [
-          './tsconfig.json',
-          './tsconfig.test.json',
-          './cli/tsconfig.json',
-        ],
+        projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "sdk:lint:eslint": "eslint --max-warnings=0 ./src ./cli/src",
     "sdk:lint:prettier": "prettier --write ./src ./cli/src",
     "sdk:lint": "npm run sdk:lint:eslint && npm run sdk:lint:prettier",
-    "sdk:tsc:check": "tsc --build --noEmit tsconfig.json tsconfig.test.json cli/tsconfig.json",
+    "sdk:tsc:check": "tsc --build --noEmit tsconfig.json cli/tsconfig.json",
     "sdk:lint:fix": "npm run sdk:lint:eslint:fix && npm run sdk:lint:prettier",
     "commitlint": "commitlint",
     "playwright": "playwright",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,9 @@
     "allowUnusedLabels": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
     "inlineSources": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "NodeNext",
     "moduleDetection": "force",
@@ -21,7 +22,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "pretty": true,
-    "rootDir": "src",
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
@@ -29,6 +29,5 @@
     "useDefineForClassFields": true,
     "verbatimModuleSyntax": true
   },
-  "include": ["./src/**/*.ts"],
-  "exclude": ["./src/**/*.test.ts"]
+  "exclude": ["tests/bundle", "demo"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "./tsconfig.json",
-  "include": ["./src/**/*.test.ts", "./tests/**/*.ts"],
-  "exclude": ["node_modules", "./tests/bundle"],
-  "compilerOptions": {
-    "rootDir": "."
-  }
-}

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -9,5 +9,6 @@
     "declarationDir": "build/types",
     "outDir": "build/types"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Goal

Set up eslint to provide feedback on demos and tests in our code editors. Passing lint checks is not yet enforced in CI. Some additional work is needed before all lint errors are resolved.

## Testing

CI passes. Editor highlights errors and warnings within files in the demo folder.