### PR TITLE
EMBR-7913 feat: add configuration options to clicks instrumentation for sensitive data

### DIFF
--- a/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
+++ b/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
@@ -258,4 +258,79 @@ describe('ClicksInstrumentation', () => {
       'view.name': '<button>button2</button>',
     });
   });
+
+  it('should allow tracking to be omitted for certain elements', () => {
+    instrumentation = new ClicksInstrumentation({
+      diag,
+      shouldTrack: element => !element.hasAttribute('data-is-sensitive'),
+    });
+    const target1 = document.createElement('div');
+    target1.setAttribute('data-is-sensitive', 'true');
+    target1.innerText = 'should not track';
+    testContainer.append(target1);
+
+    const target2 = document.createElement('div');
+    target2.innerText = 'should track';
+    testContainer.append(target2);
+
+    target1.click();
+    target2.click();
+    spanSessionManager.endSessionSpan();
+
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(1);
+
+    const clickEvent = sessionSpan.events[0];
+
+    void expect(clickEvent.name).to.be.equal('click');
+
+    void expect(clickEvent.attributes).to.deep.equal({
+      'emb.type': 'ux.tap',
+      'tap.coords': '0,0',
+      'view.name': '<div>should track</div>',
+    });
+  });
+
+  it('should allow the inner text parsing to be customized for certain elements', () => {
+    instrumentation = new ClicksInstrumentation({
+      diag,
+      innerTextForElement: element =>
+        element.hasAttribute('data-is-sensitive')
+          ? '[REDACTED]'
+          : element.innerText,
+    });
+    const target1 = document.createElement('div');
+    target1.setAttribute('data-is-sensitive', 'true');
+    target1.innerText = 'should not track';
+    testContainer.append(target1);
+
+    const target2 = document.createElement('div');
+    target2.innerText = 'should track';
+    testContainer.append(target2);
+
+    target1.click();
+    target2.click();
+    spanSessionManager.endSessionSpan();
+
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(2);
+
+    void expect(sessionSpan.events[0].name).to.be.equal('click');
+    void expect(sessionSpan.events[0].attributes).to.deep.equal({
+      'emb.type': 'ux.tap',
+      'tap.coords': '0,0',
+      'view.name': '<div>[REDACTED]</div>',
+    });
+
+    void expect(sessionSpan.events[1].name).to.be.equal('click');
+    void expect(sessionSpan.events[1].attributes).to.deep.equal({
+      'emb.type': 'ux.tap',
+      'tap.coords': '0,0',
+      'view.name': '<div>should track</div>',
+    });
+  });
 });

--- a/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
+++ b/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
@@ -19,7 +19,12 @@ import { getHTMLElementFriendlyName } from './utils.js';
 export class ClicksInstrumentation extends EmbraceInstrumentationBase {
   private readonly _onClickHandler: (event: MouseEvent) => void;
 
-  public constructor({ diag, perf }: ClicksInstrumentationArgs = {}) {
+  public constructor({
+    diag,
+    perf,
+    shouldTrack,
+    innerTextForElement,
+  }: ClicksInstrumentationArgs = {}) {
     super({
       instrumentationName: 'SpanSessionBrowserActivityInstrumentation',
       instrumentationVersion: '1.0.0',
@@ -38,6 +43,10 @@ export class ClicksInstrumentation extends EmbraceInstrumentationBase {
         return;
       }
 
+      if (shouldTrack && !shouldTrack(element)) {
+        return;
+      }
+
       try {
         const currentSessionSpan = this.sessionManager.getSessionSpan();
         if (currentSessionSpan) {
@@ -45,7 +54,12 @@ export class ClicksInstrumentation extends EmbraceInstrumentationBase {
             'click',
             {
               'emb.type': 'ux.tap',
-              'view.name': getHTMLElementFriendlyName(element),
+              'view.name': getHTMLElementFriendlyName(
+                element,
+                innerTextForElement
+                  ? innerTextForElement(element)
+                  : element.innerText
+              ),
               'tap.coords': `${event.x.toString()},${event.y.toString()}`,
             },
             this.perf.epochMillisFromOriginOffset(event.timeStamp)

--- a/src/instrumentations/clicks/ClicksInstrumentation/types.ts
+++ b/src/instrumentations/clicks/ClicksInstrumentation/types.ts
@@ -1,6 +1,6 @@
 import type { EmbraceInstrumentationBaseArgs } from '../../EmbraceInstrumentationBase/index.js';
 
-export type ClicksInstrumentationArgs = Pick<
-  EmbraceInstrumentationBaseArgs,
-  'diag' | 'perf'
->;
+export type ClicksInstrumentationArgs = {
+  shouldTrack?: (element: HTMLElement) => boolean;
+  innerTextForElement?: (element: HTMLElement) => string;
+} & Pick<EmbraceInstrumentationBaseArgs, 'diag' | 'perf'>;

--- a/src/instrumentations/clicks/ClicksInstrumentation/utils.ts
+++ b/src/instrumentations/clicks/ClicksInstrumentation/utils.ts
@@ -1,9 +1,12 @@
 const MAX_INNER_TEXT = 30;
 
-export const getHTMLElementFriendlyName = (element: HTMLElement) => {
+export const getHTMLElementFriendlyName = (
+  element: HTMLElement,
+  innerText: string
+) => {
   const nodeName = element.nodeName.toLowerCase();
-  const innerText = element.innerText.substring(0, MAX_INNER_TEXT);
-  const ellipsis = element.innerText.length > MAX_INNER_TEXT ? '...' : '';
+  const truncatedInnerText = innerText.substring(0, MAX_INNER_TEXT);
+  const ellipsis = innerText.length > MAX_INNER_TEXT ? '...' : '';
   const className = element.className ? ` class="${element.className}"` : '';
-  return `<${nodeName}${className}>${innerText}${ellipsis}</${nodeName}>`;
+  return `<${nodeName}${className}>${truncatedInnerText}${ellipsis}</${nodeName}>`;
 };


### PR DESCRIPTION
There's a couple sources of potentially sensitive information from the telemetry we gather automatically:
* Tracking of clicks
* Tracking of network requests
* Appending the current URL as an attribute

Splitting up between PRs, this one is addressing the clicks instrumentation. Adding an option where the user can supply a callback to tell us not to track a click altogether for a particular element. A bit more fine-grained adding a 2nd option to override the friendly representation we make for the clicked element in case its inner text contains something sensitive

Will plan to document in https://embrace.io/docs/web/best-practices/security-considerations/ once the rest of the work is implemented