### PR TITLE
EMBR-7913 feat: convenience option for ignoring urls from the network instrumentations

### DIFF
--- a/src/sdk/setupDefaultInstrumentations.ts
+++ b/src/sdk/setupDefaultInstrumentations.ts
@@ -50,15 +50,19 @@ export const setupDefaultInstrumentations = (
 
   if (!config.omit?.has('@opentelemetry/instrumentation-fetch')) {
     instrumentations.push(
-      new FetchInstrumentation(config['@opentelemetry/instrumentation-fetch'])
+      new FetchInstrumentation({
+        ...config['network'],
+        ...config['@opentelemetry/instrumentation-fetch'],
+      })
     );
   }
 
   if (!config.omit?.has('@opentelemetry/instrumentation-xml-http-request')) {
     instrumentations.push(
-      new XMLHttpRequestInstrumentation(
-        config['@opentelemetry/instrumentation-xml-http-request']
-      )
+      new XMLHttpRequestInstrumentation({
+        ...config['network'],
+        ...config['@opentelemetry/instrumentation-xml-http-request'],
+      })
     );
   }
 

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -210,6 +210,10 @@ type OptionalInstrumentations =
   | '@opentelemetry/instrumentation-fetch'
   | '@opentelemetry/instrumentation-xml-http-request';
 
+interface NetworkInstrumentationArgs {
+  ignoreUrls?: Array<string | RegExp>;
+}
+
 export interface DefaultInstrumenationConfig {
   omit?: Set<OptionalInstrumentations>;
   exception?: GlobalExceptionInstrumentationArgs;
@@ -219,6 +223,11 @@ export interface DefaultInstrumenationConfig {
   'session-visibility'?: SpanSessionVisibilityInstrumentationArgs;
   'session-activity'?: SpanSessionBrowserActivityInstrumentationArgs;
   'session-timeout'?: SpanSessionTimeoutInstrumentationArgs;
+
+  // Convenience to allow common config arguments for '@opentelemetry/instrumentation-fetch' and
+  // '@opentelemetry/instrumentation-xml-http-request' to just be specified once
+  network?: NetworkInstrumentationArgs;
+
   /*
     Remove 'enabled' from the accepted config for the @opentelemetry instrumentations. This parameter is misleading
     since we are going to call `registerInstrumentations` for every instrumentation we include here even if their


### PR DESCRIPTION
There's a couple sources of potentially sensitive information from the telemetry we gather automatically:
* Tracking of clicks
* Tracking of network requests
* Appending the current URL as an attribute

Splitting up between PRs, this one is addressing the network instrumentation. Both the OTel instrumentations for XHR and Fetch already support options for ignore particular URLs altogether. Here simply adding a convenience option that is passed to both so that the user just needs to specify it once

Will plan to document in https://embrace.io/docs/web/best-practices/security-considerations/ once the rest of the work is implemented