### PR TITLE
chore: add sourcemapDebugIds to rollup

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -71,6 +71,7 @@ export default defineConfig([
       sourcemap: true,
       preserveModules: true, // Keep module structure intact
       preserveModulesRoot: 'src',
+      sourcemapDebugIds: true,
     },
     external: isExternal,
     onwarn,
@@ -86,6 +87,7 @@ export default defineConfig([
       sourcemap: true,
       preserveModules: true,
       preserveModulesRoot: 'src',
+      sourcemapDebugIds: true,
     },
     external: isExternal,
     onwarn,
@@ -101,6 +103,7 @@ export default defineConfig([
       sourcemap: true,
       preserveModules: true,
       preserveModulesRoot: 'src',
+      sourcemapDebugIds: true,
     },
     external: isExternal,
     onwarn,
@@ -116,6 +119,7 @@ export default defineConfig([
       // global variable name for the SDK
       name: 'EmbraceWebSdk',
       sourcemap: true,
+      sourcemapDebugIds: true,
       // TODO create a new entry file that sets the window variable explicitly and remove this line.
       // This is a workaround to assign the SDK to the global window object so users can lazyload the SDK.
       // By default, rollup creates the export with 'var' and assumes the SDK is being used in a script tag,


### PR DESCRIPTION
## Goal

Prepare for new tooling that leverages debugIds. Read more: https://github.com/tc39/ecma426/blob/main/proposals/debug-id.md

## Testing

Look at the source of our exported code to see the new comment:
```js
import * as index from './sdk/index.js';
export { index as sdk };
export { session } from './api-sessions/sessionAPI.js';
export { log } from './api-logs/logAPI.js';
export { trace } from './api-traces/traceAPI.js';
export { user } from './api-users/userAPI.js';
//# debugId=9eb21e18-3292-461b-bbed-dadabdf91197
//# sourceMappingURL=index.js.map
```