### PR TITLE
chore: export getNavigationInstrumentation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { trace } from './api-traces/index.js';
 import type { ExtendedSpan } from './api-traces/index.js';
 import { user } from './api-users/index.js';
 import * as sdk from './sdk/index.js';
+import { getNavigationInstrumentation } from './instrumentations/index.js';
 
 export type { ExtendedSpan };
-export { sdk, session, log, trace, user };
+export { sdk, session, log, trace, user, getNavigationInstrumentation };

--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -23,3 +23,4 @@ export {
   type WebVitalsInstrumentationArgs,
 } from './web-vitals/index.js';
 export { EmbraceInstrumentationBase } from './EmbraceInstrumentationBase/index.js';
+export { getNavigationInstrumentation } from './navigation/index.js';

--- a/src/instrumentations/navigation/index.ts
+++ b/src/instrumentations/navigation/index.ts
@@ -1,1 +1,4 @@
-export { NavigationInstrumentation } from './NavigationInstrumentation/index.js';
+export {
+  NavigationInstrumentation,
+  getNavigationInstrumentation,
+} from './NavigationInstrumentation/index.js';


### PR DESCRIPTION
Added a code snippet here to show how custom navigation instrumentation can be added: https://github.com/embrace-io/embrace-docs/pull/378

Realized there isn't anything React specific in the helper though so wanted to also export `getNavigationInstrumentation` at the top-level so that we can also add a generic example for custom navigation