### PR TITLE
chore: repair webpack sonda import

### DIFF
--- a/demo/webpack-example/webpack.config.js
+++ b/demo/webpack-example/webpack.config.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const Sonda = require('sonda/webpack');
+const Sonda = require('sonda').SondaWebpackPlugin;
 
 const isProduction = process.env.NODE_ENV === 'production';
 


### PR DESCRIPTION
## Goal

Sonda 0.9.0 changed their export and the webpack demo was unable to build.

## Testing

`npm run build` in the webpack folder is successful.