### PR TITLE
EMBR-8211 chore: resolve CI test run error

### DIFF
--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -14,7 +14,13 @@ const removeGlobalExceptionTestError = ({ args }) =>
 export default {
   nodeResolve: true,
   files: ['src/**/*.test.ts'],
-  plugins: [vitePlugin()],
+  plugins: [
+    vitePlugin({
+      optimizeDeps: {
+        entries: []
+      }
+    })
+  ],
   browsers: [playwrightLauncher({ product: 'chromium', concurrency: 1 })],
   filterBrowserLogs: log =>
     removeViteLogging(log) && removeGlobalExceptionTestError(log),

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -17,9 +17,10 @@ export default {
   plugins: [
     vitePlugin({
       optimizeDeps: {
-        entries: []
-      }
-    })
+        // Will cause errors when it crawls the demo/ and tests/ directories for html files from other app builds
+        entries: [],
+      },
+    }),
   ],
   browsers: [playwrightLauncher({ product: 'chromium', concurrency: 1 })],
   filterBrowserLogs: log =>


### PR DESCRIPTION
## Goal

Resolve this error output in CI test runs:

```
Error:   Failed to scan for dependencies from entries:
  /home/runner/work/embrace-web-sdk/embrace-web-sdk/demo/frontend/index.html
/home/runner/work/embrace-web-sdk/embrace-web-sdk/demo/frontend-cdn/index.html
/home/runner/work/embrace-web-sdk/embrace-web-sdk/demo/webpack-example/index.html
/home/runner/work/embrace-web-sdk/embrace-web-sdk/tests/bundle/vite-7/index.html
/home/runner/work/embrace-web-sdk/embrace-web-sdk/tests/performance/public/lighthouse-test.html
/home/runner/work/embrace-web-sdk/embrace-web-sdk/tests/performance/public/performance-test.html
/home/runner/work/embrace-web-sdk/embrace-web-sdk/tests/bundle/webpack-5/public/index.html

  ✘ [ERROR] Failed to resolve entry for package "@embrace-io/web-sdk". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-scan]
```

After looking into it doesn't seem like an actual problem but updating here so that it doesn't add noise to the test output.

I could reproduce this locally but only on a fresh repo checkout, after npm install and running the tests it seems Vite does a one-time dependency optimization that ends up picking up all our .html files in demo/ + tests/ which cause the import errors. Vite must then be writing to some file to mark that it attempted this because on subsequent runs there's no error but I couldn't figure out where this was.

Resolution is to set `entries` to an empty array so that it doesn't attempt to crawl any of the html files which shouldn't be needed for the test runs: https://vite.dev/config/dep-optimization-options.html#optimizedeps-entries 