### PR TITLE
chore: restrict more otel libs in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,35 +1,42 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
     directories:
-      - "/"
-      - "/cli"
-      - "/demo/frontend"
+      - '/'
+      - '/cli'
+      - '/demo/frontend'
+      - '/demo/frontend-cdn'
+      - '/demo/webpack-example'
+      - '/tests/performance'
+      - '/tests/integration'
+
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     open-pull-requests-limit: 50
     groups:
       eslint:
         patterns:
-          - "*eslint*"
+          - '*eslint*'
       # All these packages are marked as experimental, so only apply patch updates
       opentelemetry-experimental:
         patterns:
-          - "@opentelemetry/instrumentation-*"
-          - "@opentelemetry/opentelemetry-browser-detector"
-          - "@opentelemetry/otlp-exporter-base"
-          - "@opentelemetry/web-common"
+          - '@opentelemetry/api-logs'
+          - '@opentelemetry/instrumentation*'
+          - '@opentelemetry/opentelemetry-browser-detector'
+          - '@opentelemetry/otlp-*'
+          - '@opentelemetry/sdk-logs'
+          - '@opentelemetry/web-common'
         update-types:
           - patch
       opentelemetry:
         patterns:
-          - "@opentelemetry/*"
+          - '@opentelemetry/*'
         update-types:
           - minor
       react:
         patterns:
-          - "react*"
+          - 'react*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
       eslint:
         patterns:
           - '*eslint*'
+      opentelemetry:
+        patterns:
+          - '@opentelemetry/*'
+        update-types:
+          - minor
       # All these packages are marked as experimental, so only apply patch updates
       opentelemetry-experimental:
         patterns:
@@ -32,11 +37,6 @@ updates:
           - '@opentelemetry/web-common'
         update-types:
           - patch
-      opentelemetry:
-        patterns:
-          - '@opentelemetry/*'
-        update-types:
-          - minor
       react:
         patterns:
           - 'react*'


### PR DESCRIPTION
## Goal

Set more experimental otel packages as patch-only in dependabot.

Moved `opentelemetry` group up in the file to test if the wildcard was overwriting the rule for the experimental package group. I suspect this is the case because of this behavior: https://github.com/embrace-io/embrace-web-sdk/pull/561

## Note

Prettier ran on the yaml file. It's still valid but I can add prettier rules to use double quotes if needed.
