### PR TITLE
chore: include user_agent.original resource attribute

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
       opentelemetry-experimental:
         patterns:
           - "@opentelemetry/instrumentation-*"
-          - "@opentelemetry/opentelemetry-browser-detector"
           - "@opentelemetry/otlp-exporter-base"
           - "@opentelemetry/web-common"
         update-types:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@opentelemetry/instrumentation-document-load": "0.44.1",
         "@opentelemetry/instrumentation-fetch": "0.57.2",
         "@opentelemetry/instrumentation-xml-http-request": "0.57.2",
-        "@opentelemetry/opentelemetry-browser-detector": "0.57.2",
         "@opentelemetry/otlp-exporter-base": "0.57.2",
         "@opentelemetry/otlp-transformer": "0.57.2",
         "@opentelemetry/resources": "1.30.1",
@@ -2465,21 +2464,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/opentelemetry-browser-detector": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/opentelemetry-browser-detector/-/opentelemetry-browser-detector-0.57.2.tgz",
-      "integrity": "sha512-J7lLU7DPpR6Ar7NAoi/qtbXRvT5pM1E0KMz4mt5HHvCZTZ2AFjSt1FzmrJR8tIv4G+MmmQNe7sPtRT6Qn+oKaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/resources": "1.30.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "@opentelemetry/instrumentation-document-load": "0.44.1",
     "@opentelemetry/instrumentation-fetch": "0.57.2",
     "@opentelemetry/instrumentation-xml-http-request": "0.57.2",
-    "@opentelemetry/opentelemetry-browser-detector": "0.57.2",
     "@opentelemetry/otlp-exporter-base": "0.57.2",
     "@opentelemetry/otlp-transformer": "0.57.2",
     "@opentelemetry/resources": "1.30.1",

--- a/src/resources/webSdkResource.test.ts
+++ b/src/resources/webSdkResource.test.ts
@@ -39,6 +39,7 @@ describe('webSdkResource', () => {
       'telemetry.sdk.language': 'webjs',
       'telemetry.sdk.name': 'embrace-web-sdk',
       'telemetry.sdk.version': SDK_VERSION,
+      'user_agent.original': window.navigator.userAgent,
     });
   });
 

--- a/src/resources/webSdkResource.ts
+++ b/src/resources/webSdkResource.ts
@@ -1,10 +1,10 @@
-import { browserDetector } from '@opentelemetry/opentelemetry-browser-detector';
-import { detectResourcesSync, Resource } from '@opentelemetry/resources';
+import { Resource } from '@opentelemetry/resources';
 import {
   ATTR_SERVICE_NAME,
   ATTR_TELEMETRY_SDK_LANGUAGE,
   ATTR_TELEMETRY_SDK_NAME,
   ATTR_TELEMETRY_SDK_VERSION,
+  ATTR_USER_AGENT_ORIGINAL,
 } from '@opentelemetry/semantic-conventions';
 import {
   EMBRACE_SERVICE_NAME,
@@ -38,7 +38,7 @@ export const getWebSDKResource = ({
   */
   const processedAppVersion = appVersion ?? TEMPLATE_APP_VERSION.trim();
 
-  let resource = new Resource({
+  return new Resource({
     [ATTR_SERVICE_NAME]: EMBRACE_SERVICE_NAME,
     [ATTR_TELEMETRY_SDK_NAME]: EMBRACE_SERVICE_NAME,
     app_version: processedAppVersion,
@@ -50,10 +50,6 @@ export const getWebSDKResource = ({
     sdk_platform: 'web',
     [ATTR_TELEMETRY_SDK_LANGUAGE]: 'webjs',
     [KEY_EMB_APP_INSTANCE_ID]: getAppInstanceId(pageSessionStorage, diagLogger),
+    [ATTR_USER_AGENT_ORIGINAL]: window.navigator.userAgent,
   });
-  const detectedResources = detectResourcesSync({
-    detectors: [browserDetector],
-  });
-  resource = resource.merge(detectedResources);
-  return resource;
 };

--- a/src/sdk/initSDK.test.ts
+++ b/src/sdk/initSDK.test.ts
@@ -371,8 +371,8 @@ describe('initSDK', () => {
           { key: 'sdk_simple_version', value: { intValue: 1 } },
           { key: 'sdk_platform', value: { stringValue: 'web' } },
           {
-            key: 'browser.language',
-            value: { stringValue: window.navigator.language },
+            key: 'user_agent.original',
+            value: { stringValue: window.navigator.userAgent },
           },
         ],
         droppedAttributesCount: 0,

--- a/tests/integration/tests/__golden__/next-latest-send-log.json
+++ b/tests/integration/tests/__golden__/next-latest-send-log.json
@@ -66,43 +66,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "D0731276D0514832A7ECD42AC940FFAC"
+              "stringValue": "34CBAA03361342C4B810B2762980523E"
             }
           },
           {
-            "key": "browser.platform",
+            "key": "user_agent.original",
             "value": {
-              "stringValue": "macOS"
-            }
-          },
-          {
-            "key": "browser.brands",
-            "value": {
-              "arrayValue": {
-                "values": [
-                  {
-                    "stringValue": "Not;A=Brand 99"
-                  },
-                  {
-                    "stringValue": "HeadlessChrome 139"
-                  },
-                  {
-                    "stringValue": "Chromium 139"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "key": "browser.mobile",
-            "value": {
-              "boolValue": false
-            }
-          },
-          {
-            "key": "browser.language",
-            "value": {
-              "stringValue": "en-US"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/139.0.7258.5 Safari/537.36"
             }
           }
         ],
@@ -115,8 +85,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1752519997215800049",
-              "observedTimeUnixNano": "1752519997215000000",
+              "timeUnixNano": "1752596060453899902",
+              "observedTimeUnixNano": "1752596060454000000",
               "severityNumber": 9,
               "severityText": "INFO",
               "body": {
@@ -132,13 +102,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "19599B97DC9D43699E1B29B8C6B7F0FE"
+                    "stringValue": "9BCDDEB2859C44729B71D3B30326112C"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "15A32265546B4C4DAE655B0D183F94A4"
+                    "stringValue": "D563E70D0644443C88D86C5E79F00117"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/next-latest-session.json
+++ b/tests/integration/tests/__golden__/next-latest-session.json
@@ -66,43 +66,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "6187D8265B3B4316A08DE920EF4C1552"
+              "stringValue": "F6CBA37F73A1457AA8E5DDA6F08C0BD0"
             }
           },
           {
-            "key": "browser.platform",
+            "key": "user_agent.original",
             "value": {
-              "stringValue": "macOS"
-            }
-          },
-          {
-            "key": "browser.brands",
-            "value": {
-              "arrayValue": {
-                "values": [
-                  {
-                    "stringValue": "Not;A=Brand 99"
-                  },
-                  {
-                    "stringValue": "HeadlessChrome 139"
-                  },
-                  {
-                    "stringValue": "Chromium 139"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "key": "browser.mobile",
-            "value": {
-              "boolValue": false
-            }
-          },
-          {
-            "key": "browser.language",
-            "value": {
-              "stringValue": "en-US"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/139.0.7258.5 Safari/537.36"
             }
           }
         ],
@@ -115,12 +85,12 @@
           },
           "spans": [
             {
-              "traceId": "b5e1969f3fbe637703ecfa0d575bd06c",
-              "spanId": "e6eead1434f4f39e",
+              "traceId": "72fb2bd0b644dd0d7e1271b43ae41a76",
+              "spanId": "1174b19bd6c1eefc",
               "name": "emb-session",
               "kind": 1,
-              "startTimeUnixNano": "1752519996738000000",
-              "endTimeUnixNano": "1752519996907300000",
+              "startTimeUnixNano": "1752596060059000000",
+              "endTimeUnixNano": "1752596060198900000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -137,7 +107,7 @@
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
                   }
                 },
                 {
@@ -161,7 +131,7 @@
                 {
                   "key": "emb.startup_duration",
                   "value": {
-                    "doubleValue": 7.699951171875
+                    "intValue": 4
                   }
                 }
               ],
@@ -183,17 +153,17 @@
           },
           "spans": [
             {
-              "traceId": "b17c4aae12150114e548563377aad2f6",
-              "spanId": "8f4a3fae44fd0146",
+              "traceId": "fb17d10db4f4bc65a1d1092b88f468c7",
+              "spanId": "7fb390729d476f44",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752519996646199951",
-              "endTimeUnixNano": "1752519996651299951",
+              "startTimeUnixNano": "1752596060021899903",
+              "endTimeUnixNano": "1752596060024399903",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
                   }
                 },
                 {
@@ -205,13 +175,13 @@
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 2285
+                    "intValue": 2281
                   }
                 },
                 {
                   "key": "http.response_content_length_uncompressed",
                   "value": {
-                    "intValue": 6974
+                    "intValue": 6971
                   }
                 }
               ],
@@ -220,49 +190,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996646199951",
+                  "timeUnixNano": "1752596060021899903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996648599951",
+                  "timeUnixNano": "1752596060022799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996648599951",
+                  "timeUnixNano": "1752596060022799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752519996648599951",
+                  "timeUnixNano": "1752596060022799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752519996648899951",
+                  "timeUnixNano": "1752596060022899903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752519996648999951",
+                  "timeUnixNano": "1752596060022999903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752519996650499951",
+                  "timeUnixNano": "1752596060024299903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752519996651299951",
+                  "timeUnixNano": "1752596060024399903",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -274,18 +244,18 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "7b2fc05abf5ee187",
-              "parentSpanId": "8cba152eca4ccc47",
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "051174b1085ba822",
+              "parentSpanId": "d0b774aaf4d6daf4",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752519996652700049",
-              "endTimeUnixNano": "1752519996657200049",
+              "startTimeUnixNano": "1752596060026099903",
+              "endTimeUnixNano": "1752596060029199903",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
                   }
                 },
                 {
@@ -306,49 +276,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996652700049",
+                  "timeUnixNano": "1752596060026099903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996652700049",
+                  "timeUnixNano": "1752596060026099903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996652700049",
+                  "timeUnixNano": "1752596060026099903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752519996652700049",
+                  "timeUnixNano": "1752596060026099903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752519996652700049",
+                  "timeUnixNano": "1752596060026099903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752519996655300049",
+                  "timeUnixNano": "1752596060027799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752519996657000049",
+                  "timeUnixNano": "1752596060028999903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752519996657200049",
+                  "timeUnixNano": "1752596060029199903",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -360,196 +330,18 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "9aa6e809fd1f8086",
-              "parentSpanId": "8cba152eca4ccc47",
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "b8b8dd3e7a4634c5",
+              "parentSpanId": "d0b774aaf4d6daf4",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752519996652699951",
-              "endTimeUnixNano": "1752519996658199951",
+              "startTimeUnixNano": "1752596060026100049",
+              "endTimeUnixNano": "1752596060029700049",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
-                  }
-                },
-                {
-                  "key": "http.url",
-                  "value": {
-                    "stringValue": "http://localhost:3000/_next/static/media/93f479601ee12b01-s.p.woff2"
-                  }
-                },
-                {
-                  "key": "http.response_content_length",
-                  "value": {
-                    "intValue": 31288
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1752519996652699951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996655299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996655299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectStart",
-                  "timeUnixNano": "1752519996655299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectEnd",
-                  "timeUnixNano": "1752519996655499951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "requestStart",
-                  "timeUnixNano": "1752519996655499951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseStart",
-                  "timeUnixNano": "1752519996657799951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseEnd",
-                  "timeUnixNano": "1752519996658199951",
-                  "droppedAttributesCount": 0
-                }
-              ],
-              "droppedEventsCount": 0,
-              "status": {
-                "code": 0
-              },
-              "links": [],
-              "droppedLinksCount": 0
-            },
-            {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "d54134d1b30be835",
-              "parentSpanId": "8cba152eca4ccc47",
-              "name": "resourceFetch",
-              "kind": 1,
-              "startTimeUnixNano": "1752519996652600000",
-              "endTimeUnixNano": "1752519996666700000",
-              "attributes": [
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
-                  }
-                },
-                {
-                  "key": "http.url",
-                  "value": {
-                    "stringValue": "http://localhost:3000/_next/static/css/9d7bd9b804957750.css"
-                  }
-                },
-                {
-                  "key": "http.response_content_length",
-                  "value": {
-                    "intValue": 934
-                  }
-                },
-                {
-                  "key": "http.response_content_length_uncompressed",
-                  "value": {
-                    "intValue": 2486
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1752519996652600000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996655900000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996655900000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectStart",
-                  "timeUnixNano": "1752519996655900000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectEnd",
-                  "timeUnixNano": "1752519996656000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "requestStart",
-                  "timeUnixNano": "1752519996656000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseStart",
-                  "timeUnixNano": "1752519996663200000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseEnd",
-                  "timeUnixNano": "1752519996666700000",
-                  "droppedAttributesCount": 0
-                }
-              ],
-              "droppedEventsCount": 0,
-              "status": {
-                "code": 0
-              },
-              "links": [],
-              "droppedLinksCount": 0
-            },
-            {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "23eb9dae2bbb0726",
-              "parentSpanId": "8cba152eca4ccc47",
-              "name": "resourceFetch",
-              "kind": 1,
-              "startTimeUnixNano": "1752519996652499902",
-              "endTimeUnixNano": "1752519996666699902",
-              "attributes": [
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
                   }
                 },
                 {
@@ -576,49 +368,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996652499902",
+                  "timeUnixNano": "1752596060026100049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996655499902",
+                  "timeUnixNano": "1752596060027700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996655499902",
+                  "timeUnixNano": "1752596060027700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752519996655499902",
+                  "timeUnixNano": "1752596060027700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752519996655699902",
+                  "timeUnixNano": "1752596060027800049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752519996655699902",
+                  "timeUnixNano": "1752596060027800049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752519996666199902",
+                  "timeUnixNano": "1752596060029300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752519996666699902",
+                  "timeUnixNano": "1752596060029700049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -630,18 +422,196 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "e62f82835c60121d",
-              "parentSpanId": "8cba152eca4ccc47",
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "61c35077867dcec7",
+              "parentSpanId": "d0b774aaf4d6daf4",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752519996652599902",
-              "endTimeUnixNano": "1752519996677899902",
+              "startTimeUnixNano": "1752596060025999952",
+              "endTimeUnixNano": "1752596060029599952",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://localhost:3000/_next/static/css/9d7bd9b804957750.css"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 934
+                  }
+                },
+                {
+                  "key": "http.response_content_length_uncompressed",
+                  "value": {
+                    "intValue": 2486
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1752596060025999952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1752596060027599952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1752596060027599952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1752596060027599952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1752596060027699952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1752596060027699952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1752596060029399952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1752596060029599952",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            },
+            {
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "f9d902f9ba076a69",
+              "parentSpanId": "d0b774aaf4d6daf4",
+              "name": "resourceFetch",
+              "kind": 1,
+              "startTimeUnixNano": "1752596060025999952",
+              "endTimeUnixNano": "1752596060029699952",
+              "attributes": [
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://localhost:3000/_next/static/media/93f479601ee12b01-s.p.woff2"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 31288
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1752596060025999952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1752596060027599952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1752596060027599952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1752596060027599952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1752596060027699952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1752596060027699952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1752596060029399952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1752596060029699952",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            },
+            {
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "e12e24a68e269ac6",
+              "parentSpanId": "d0b774aaf4d6daf4",
+              "name": "resourceFetch",
+              "kind": 1,
+              "startTimeUnixNano": "1752596060025900000",
+              "endTimeUnixNano": "1752596060033600000",
+              "attributes": [
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
                   }
                 },
                 {
@@ -668,49 +638,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996652599902",
+                  "timeUnixNano": "1752596060025900000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996652599902",
+                  "timeUnixNano": "1752596060025900000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996652599902",
+                  "timeUnixNano": "1752596060025900000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752519996652599902",
+                  "timeUnixNano": "1752596060025900000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752519996652599902",
+                  "timeUnixNano": "1752596060025900000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752519996668799902",
+                  "timeUnixNano": "1752596060031100000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752519996674199902",
+                  "timeUnixNano": "1752596060033400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752519996677899902",
+                  "timeUnixNano": "1752596060033600000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -722,24 +692,24 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "bc1bea732b15e37a",
-              "parentSpanId": "8cba152eca4ccc47",
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "ac50955ab4f33ae2",
+              "parentSpanId": "d0b774aaf4d6daf4",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752519996652500049",
-              "endTimeUnixNano": "1752519996680200049",
+              "startTimeUnixNano": "1752596060026000000",
+              "endTimeUnixNano": "1752596060034100000",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
                   }
                 },
                 {
                   "key": "http.url",
                   "value": {
-                    "stringValue": "http://localhost:3000/_next/static/chunks/main-app-c944f6eef2142bf1.js"
+                    "stringValue": "http://localhost:3000/_next/static/chunks/main-app-1d390a07189a4e47.js"
                   }
                 },
                 {
@@ -754,49 +724,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996652500049",
+                  "timeUnixNano": "1752596060026000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996652500049",
+                  "timeUnixNano": "1752596060026000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996652500049",
+                  "timeUnixNano": "1752596060026000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752519996652500049",
+                  "timeUnixNano": "1752596060026000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752519996652500049",
+                  "timeUnixNano": "1752596060026000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752519996672800049",
+                  "timeUnixNano": "1752596060032400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752519996679800049",
+                  "timeUnixNano": "1752596060034000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752519996680200049",
+                  "timeUnixNano": "1752596060034100000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -808,18 +778,466 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "09b4a30cf971d5e9",
-              "parentSpanId": "8cba152eca4ccc47",
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "860aa2ef1e90dc75",
+              "parentSpanId": "d0b774aaf4d6daf4",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752519996652399951",
-              "endTimeUnixNano": "1752519996702999951",
+              "startTimeUnixNano": "1752596060026000000",
+              "endTimeUnixNano": "1752596060035100000",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://localhost:3000/_next/static/chunks/582ccdcc-6283a40d63c7d7c8.js"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 187
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1752596060026000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1752596060033100000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1752596060033100000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1752596060033100000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1752596060033200000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1752596060033300000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1752596060035000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1752596060035100000",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            },
+            {
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "e06557745c1509e2",
+              "parentSpanId": "d0b774aaf4d6daf4",
+              "name": "resourceFetch",
+              "kind": 1,
+              "startTimeUnixNano": "1752596060025899903",
+              "endTimeUnixNano": "1752596060034999903",
+              "attributes": [
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://localhost:3000/_next/static/chunks/4f9414d9-fc8d40896e9338eb.js"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 313
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1752596060025899903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1752596060033099903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1752596060033099903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1752596060033099903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1752596060033199903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1752596060033299903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1752596060034899903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1752596060034999903",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            },
+            {
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "55390f2f0fc1ab04",
+              "parentSpanId": "d0b774aaf4d6daf4",
+              "name": "resourceFetch",
+              "kind": 1,
+              "startTimeUnixNano": "1752596060025800049",
+              "endTimeUnixNano": "1752596060036500049",
+              "attributes": [
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://localhost:3000/_next/static/chunks/app/page-2efecfe3324bb2e2.js"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 12001
+                  }
+                },
+                {
+                  "key": "http.response_content_length_uncompressed",
+                  "value": {
+                    "intValue": 42907
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1752596060025800049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1752596060025800049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1752596060025800049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1752596060025800049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1752596060025800049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1752596060034000049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1752596060036100049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1752596060036500049",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            },
+            {
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "a1e87390242d2877",
+              "parentSpanId": "d0b774aaf4d6daf4",
+              "name": "resourceFetch",
+              "kind": 1,
+              "startTimeUnixNano": "1752596060025800049",
+              "endTimeUnixNano": "1752596060038100049",
+              "attributes": [
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://localhost:3000/_next/static/chunks/684-52534655199975b3.js"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 46108
+                  }
+                },
+                {
+                  "key": "http.response_content_length_uncompressed",
+                  "value": {
+                    "intValue": 174869
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1752596060025800049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1752596060025800049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1752596060025800049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1752596060025800049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1752596060025800049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1752596060031700049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1752596060034600049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1752596060038100049",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            },
+            {
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "fa6e701f29d033ba",
+              "parentSpanId": "d0b774aaf4d6daf4",
+              "name": "resourceFetch",
+              "kind": 1,
+              "startTimeUnixNano": "1752596060025699952",
+              "endTimeUnixNano": "1752596060038499952",
+              "attributes": [
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://localhost:3000/_next/static/chunks/97-78040752f4def6d7.js"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 35654
+                  }
+                },
+                {
+                  "key": "http.response_content_length_uncompressed",
+                  "value": {
+                    "intValue": 144361
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1752596060025699952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1752596060025699952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1752596060025699952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1752596060025699952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1752596060025699952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1752596060033399952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1752596060035799952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1752596060038499952",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            },
+            {
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "be3f746664261c0c",
+              "parentSpanId": "d0b774aaf4d6daf4",
+              "name": "resourceFetch",
+              "kind": 1,
+              "startTimeUnixNano": "1752596060025699952",
+              "endTimeUnixNano": "1752596060038699952",
+              "attributes": [
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
                   }
                 },
                 {
@@ -846,49 +1264,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996652399951",
+                  "timeUnixNano": "1752596060025699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996652399951",
+                  "timeUnixNano": "1752596060025699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996652399951",
+                  "timeUnixNano": "1752596060025699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752519996652399951",
+                  "timeUnixNano": "1752596060025699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752519996652399951",
+                  "timeUnixNano": "1752596060025699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752519996670799951",
+                  "timeUnixNano": "1752596060031199952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752519996681399951",
+                  "timeUnixNano": "1752596060034599952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752519996702999951",
+                  "timeUnixNano": "1752596060038699952",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -900,465 +1318,17 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "066288dba3523182",
-              "parentSpanId": "8cba152eca4ccc47",
-              "name": "resourceFetch",
-              "kind": 1,
-              "startTimeUnixNano": "1752519996652300098",
-              "endTimeUnixNano": "1752519996704200098",
-              "attributes": [
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
-                  }
-                },
-                {
-                  "key": "http.url",
-                  "value": {
-                    "stringValue": "http://localhost:3000/_next/static/chunks/684-c616a1fe474f99d5.js"
-                  }
-                },
-                {
-                  "key": "http.response_content_length",
-                  "value": {
-                    "intValue": 46107
-                  }
-                },
-                {
-                  "key": "http.response_content_length_uncompressed",
-                  "value": {
-                    "intValue": 174869
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1752519996652300098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996652300098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996652300098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectStart",
-                  "timeUnixNano": "1752519996652300098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectEnd",
-                  "timeUnixNano": "1752519996652300098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "requestStart",
-                  "timeUnixNano": "1752519996672200098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseStart",
-                  "timeUnixNano": "1752519996682500098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseEnd",
-                  "timeUnixNano": "1752519996704200098",
-                  "droppedAttributesCount": 0
-                }
-              ],
-              "droppedEventsCount": 0,
-              "status": {
-                "code": 0
-              },
-              "links": [],
-              "droppedLinksCount": 0
-            },
-            {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "75d64c1e3fc014ec",
-              "parentSpanId": "8cba152eca4ccc47",
-              "name": "resourceFetch",
-              "kind": 1,
-              "startTimeUnixNano": "1752519996652400000",
-              "endTimeUnixNano": "1752519996678900000",
-              "attributes": [
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
-                  }
-                },
-                {
-                  "key": "http.url",
-                  "value": {
-                    "stringValue": "http://localhost:3000/_next/static/chunks/582ccdcc-6283a40d63c7d7c8.js"
-                  }
-                },
-                {
-                  "key": "http.response_content_length",
-                  "value": {
-                    "intValue": 187
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1752519996652400000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996670900000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996670900000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectStart",
-                  "timeUnixNano": "1752519996670900000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectEnd",
-                  "timeUnixNano": "1752519996672400000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "requestStart",
-                  "timeUnixNano": "1752519996672600000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseStart",
-                  "timeUnixNano": "1752519996678700000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseEnd",
-                  "timeUnixNano": "1752519996678900000",
-                  "droppedAttributesCount": 0
-                }
-              ],
-              "droppedEventsCount": 0,
-              "status": {
-                "code": 0
-              },
-              "links": [],
-              "droppedLinksCount": 0
-            },
-            {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "8ca016a33a18e593",
-              "parentSpanId": "8cba152eca4ccc47",
-              "name": "resourceFetch",
-              "kind": 1,
-              "startTimeUnixNano": "1752519996652699951",
-              "endTimeUnixNano": "1752519996679899951",
-              "attributes": [
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
-                  }
-                },
-                {
-                  "key": "http.url",
-                  "value": {
-                    "stringValue": "http://localhost:3000/_next/static/chunks/4f9414d9-fc8d40896e9338eb.js"
-                  }
-                },
-                {
-                  "key": "http.response_content_length",
-                  "value": {
-                    "intValue": 313
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1752519996652699951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996671299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996671299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectStart",
-                  "timeUnixNano": "1752519996671299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectEnd",
-                  "timeUnixNano": "1752519996672599951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "requestStart",
-                  "timeUnixNano": "1752519996673299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseStart",
-                  "timeUnixNano": "1752519996679299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseEnd",
-                  "timeUnixNano": "1752519996679899951",
-                  "droppedAttributesCount": 0
-                }
-              ],
-              "droppedEventsCount": 0,
-              "status": {
-                "code": 0
-              },
-              "links": [],
-              "droppedLinksCount": 0
-            },
-            {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "51c2ec82a3b3d1e2",
-              "parentSpanId": "8cba152eca4ccc47",
-              "name": "resourceFetch",
-              "kind": 1,
-              "startTimeUnixNano": "1752519996652600098",
-              "endTimeUnixNano": "1752519996696300098",
-              "attributes": [
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
-                  }
-                },
-                {
-                  "key": "http.url",
-                  "value": {
-                    "stringValue": "http://localhost:3000/_next/static/chunks/app/page-d4c6f9de84e9db24.js"
-                  }
-                },
-                {
-                  "key": "http.response_content_length",
-                  "value": {
-                    "intValue": 12022
-                  }
-                },
-                {
-                  "key": "http.response_content_length_uncompressed",
-                  "value": {
-                    "intValue": 42948
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1752519996652600098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996652600098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996652600098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectStart",
-                  "timeUnixNano": "1752519996652600098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectEnd",
-                  "timeUnixNano": "1752519996652600098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "requestStart",
-                  "timeUnixNano": "1752519996680200098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseStart",
-                  "timeUnixNano": "1752519996691700098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseEnd",
-                  "timeUnixNano": "1752519996696300098",
-                  "droppedAttributesCount": 0
-                }
-              ],
-              "droppedEventsCount": 0,
-              "status": {
-                "code": 0
-              },
-              "links": [],
-              "droppedLinksCount": 0
-            },
-            {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "d58931639085b647",
-              "parentSpanId": "8cba152eca4ccc47",
-              "name": "resourceFetch",
-              "kind": 1,
-              "startTimeUnixNano": "1752519996652600098",
-              "endTimeUnixNano": "1752519996704700098",
-              "attributes": [
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
-                  }
-                },
-                {
-                  "key": "http.url",
-                  "value": {
-                    "stringValue": "http://localhost:3000/_next/static/chunks/932-37119dcf59dc9e30.js"
-                  }
-                },
-                {
-                  "key": "http.response_content_length",
-                  "value": {
-                    "intValue": 36404
-                  }
-                },
-                {
-                  "key": "http.response_content_length_uncompressed",
-                  "value": {
-                    "intValue": 148864
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1752519996652600098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996652600098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996652600098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectStart",
-                  "timeUnixNano": "1752519996652600098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectEnd",
-                  "timeUnixNano": "1752519996652600098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "requestStart",
-                  "timeUnixNano": "1752519996678100098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseStart",
-                  "timeUnixNano": "1752519996689900098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseEnd",
-                  "timeUnixNano": "1752519996704700098",
-                  "droppedAttributesCount": 0
-                }
-              ],
-              "droppedEventsCount": 0,
-              "status": {
-                "code": 0
-              },
-              "links": [],
-              "droppedLinksCount": 0
-            },
-            {
-              "traceId": "7e30165af3f94c5d4ee41224448a7482",
-              "spanId": "8cba152eca4ccc47",
+              "traceId": "e3707d70c9114eb6e31987802c859c31",
+              "spanId": "d0b774aaf4d6daf4",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1752519996646199951",
-              "endTimeUnixNano": "1752519996744499951",
+              "startTimeUnixNano": "1752596060022000000",
+              "endTimeUnixNano": "1752596060062200000",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "920964828E3A4BB8A322B94F33E3291D"
+                    "stringValue": "C0806A7286F34705B584B10CEDAB6F78"
                   }
                 },
                 {
@@ -1379,67 +1349,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996646199951",
+                  "timeUnixNano": "1752596060022000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "unloadEventStart",
-                  "timeUnixNano": "1752519996646199951",
+                  "timeUnixNano": "1752596060022000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "unloadEventEnd",
-                  "timeUnixNano": "1752519996646199951",
+                  "timeUnixNano": "1752596060022000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1752519996675699951",
+                  "timeUnixNano": "1752596060030200000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1752519996675699951",
+                  "timeUnixNano": "1752596060030200000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1752519996675699951",
+                  "timeUnixNano": "1752596060030300000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1752519996744499951",
+                  "timeUnixNano": "1752596060062200000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1752519996744499951",
+                  "timeUnixNano": "1752596060062200000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1752519996744499951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "firstPaint",
-                  "timeUnixNano": "1752519996682199951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "firstContentfulPaint",
-                  "timeUnixNano": "1752519996682199951",
+                  "timeUnixNano": "1752596060062200000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/vite-7-es2015-send-log.json
@@ -66,43 +66,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "984470232ADF41808C59FF48FF6CE546"
+              "stringValue": "322DAD7B3D8E4A469725E8E0D585ACEB"
             }
           },
           {
-            "key": "browser.platform",
+            "key": "user_agent.original",
             "value": {
-              "stringValue": "macOS"
-            }
-          },
-          {
-            "key": "browser.brands",
-            "value": {
-              "arrayValue": {
-                "values": [
-                  {
-                    "stringValue": "Not;A=Brand 99"
-                  },
-                  {
-                    "stringValue": "HeadlessChrome 139"
-                  },
-                  {
-                    "stringValue": "Chromium 139"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "key": "browser.mobile",
-            "value": {
-              "boolValue": false
-            }
-          },
-          {
-            "key": "browser.language",
-            "value": {
-              "stringValue": "en-US"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/139.0.7258.5 Safari/537.36"
             }
           }
         ],
@@ -115,8 +85,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1752520002849599854",
-              "observedTimeUnixNano": "1752520002849000000",
+              "timeUnixNano": "1752596065749900146",
+              "observedTimeUnixNano": "1752596065749000000",
               "severityNumber": 9,
               "severityText": "INFO",
               "body": {
@@ -132,13 +102,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "C8EB04FEB98E4B6D8212E22DD1B24E63"
+                    "stringValue": "1ED12AF9CE6B4B7FA20D3F1B45AE84C7"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "6402C54D35804B5CA6521F4CBD37F4CE"
+                    "stringValue": "364F9C93CB6C4215988795D63AAB5E86"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/vite-7-es2015-session.json
@@ -66,43 +66,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "B01A3B11E9974A698A6A60448E4B3B1C"
+              "stringValue": "A84B263559414A2FBB1EDEF15E5F281B"
             }
           },
           {
-            "key": "browser.platform",
+            "key": "user_agent.original",
             "value": {
-              "stringValue": "macOS"
-            }
-          },
-          {
-            "key": "browser.brands",
-            "value": {
-              "arrayValue": {
-                "values": [
-                  {
-                    "stringValue": "Not;A=Brand 99"
-                  },
-                  {
-                    "stringValue": "HeadlessChrome 139"
-                  },
-                  {
-                    "stringValue": "Chromium 139"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "key": "browser.mobile",
-            "value": {
-              "boolValue": false
-            }
-          },
-          {
-            "key": "browser.language",
-            "value": {
-              "stringValue": "en-US"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/139.0.7258.5 Safari/537.36"
             }
           }
         ],
@@ -115,12 +85,12 @@
           },
           "spans": [
             {
-              "traceId": "09f2a0779febd1c3431fdef068778a58",
-              "spanId": "56cc376b881298ac",
+              "traceId": "dc997e49086333408629aec6feaed7d0",
+              "spanId": "31871663297132d2",
               "name": "emb-session",
               "kind": 1,
-              "startTimeUnixNano": "1752520002415000000",
-              "endTimeUnixNano": "1752520002565300000",
+              "startTimeUnixNano": "1752596065387000000",
+              "endTimeUnixNano": "1752596065532700000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -137,7 +107,7 @@
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "65937BEA19984FA484B069D3B85C0041"
+                    "stringValue": "22DE95575B9F454C95DD6AA8F08635BB"
                   }
                 },
                 {
@@ -161,7 +131,7 @@
                 {
                   "key": "emb.startup_duration",
                   "value": {
-                    "doubleValue": 6.10009765625
+                    "doubleValue": 4.5
                   }
                 }
               ],
@@ -183,17 +153,17 @@
           },
           "spans": [
             {
-              "traceId": "08978b5582cf51b5fb31fb46d9be6a0e",
-              "spanId": "9d430d80dced8098",
+              "traceId": "aeb2302ef8287c7917cc1ae7a095d5b5",
+              "spanId": "937a211a36e89d77",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752520002373500000",
-              "endTimeUnixNano": "1752520002375500000",
+              "startTimeUnixNano": "1752596065356600098",
+              "endTimeUnixNano": "1752596065357900098",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "65937BEA19984FA484B069D3B85C0041"
+                    "stringValue": "22DE95575B9F454C95DD6AA8F08635BB"
                   }
                 },
                 {
@@ -214,49 +184,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752520002373500000",
+                  "timeUnixNano": "1752596065356600098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752520002374700000",
+                  "timeUnixNano": "1752596065357200098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752520002374700000",
+                  "timeUnixNano": "1752596065357200098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752520002374700000",
+                  "timeUnixNano": "1752596065357200098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752520002374800000",
+                  "timeUnixNano": "1752596065357300098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752520002374900000",
+                  "timeUnixNano": "1752596065357400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752520002375300000",
+                  "timeUnixNano": "1752596065357800098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752520002375500000",
+                  "timeUnixNano": "1752596065357900098",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -268,104 +238,18 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "ce5c6697c46a3e718db805facfc54d0e",
-              "spanId": "641733058426b1fc",
-              "parentSpanId": "4d2627006a6179e2",
+              "traceId": "69824fe3678054fe4c0d83d5529505c6",
+              "spanId": "877684e52c0cf528",
+              "parentSpanId": "42d72d2f89c46165",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752520002377299951",
-              "endTimeUnixNano": "1752520002381699951",
+              "startTimeUnixNano": "1752596065359300000",
+              "endTimeUnixNano": "1752596065361100000",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "65937BEA19984FA484B069D3B85C0041"
-                  }
-                },
-                {
-                  "key": "http.url",
-                  "value": {
-                    "stringValue": "http://localhost:3001/public/vite-7/es2015/assets/index-DpSyqeF3.js"
-                  }
-                },
-                {
-                  "key": "http.response_content_length",
-                  "value": {
-                    "intValue": 379811
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1752520002377299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupStart",
-                  "timeUnixNano": "1752520002377299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupEnd",
-                  "timeUnixNano": "1752520002377299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectStart",
-                  "timeUnixNano": "1752520002377299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectEnd",
-                  "timeUnixNano": "1752520002377299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "requestStart",
-                  "timeUnixNano": "1752520002379299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseStart",
-                  "timeUnixNano": "1752520002380699951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseEnd",
-                  "timeUnixNano": "1752520002381699951",
-                  "droppedAttributesCount": 0
-                }
-              ],
-              "droppedEventsCount": 0,
-              "status": {
-                "code": 0
-              },
-              "links": [],
-              "droppedLinksCount": 0
-            },
-            {
-              "traceId": "ce5c6697c46a3e718db805facfc54d0e",
-              "spanId": "c0c32c7ae530ef26",
-              "parentSpanId": "4d2627006a6179e2",
-              "name": "resourceFetch",
-              "kind": 1,
-              "startTimeUnixNano": "1752520002377200000",
-              "endTimeUnixNano": "1752520002380700000",
-              "attributes": [
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "65937BEA19984FA484B069D3B85C0041"
+                    "stringValue": "22DE95575B9F454C95DD6AA8F08635BB"
                   }
                 },
                 {
@@ -386,49 +270,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752520002377200000",
+                  "timeUnixNano": "1752596065359300000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752520002378900000",
+                  "timeUnixNano": "1752596065360500000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752520002378900000",
+                  "timeUnixNano": "1752596065360500000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752520002378900000",
+                  "timeUnixNano": "1752596065360500000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752520002379200000",
+                  "timeUnixNano": "1752596065360800000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752520002379200000",
+                  "timeUnixNano": "1752596065360800000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752520002380000000",
+                  "timeUnixNano": "1752596065361100000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752520002380700000",
+                  "timeUnixNano": "1752596065361100000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -440,17 +324,103 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "ce5c6697c46a3e718db805facfc54d0e",
-              "spanId": "4d2627006a6179e2",
-              "name": "documentLoad",
+              "traceId": "69824fe3678054fe4c0d83d5529505c6",
+              "spanId": "54bc9fd94da42a03",
+              "parentSpanId": "42d72d2f89c46165",
+              "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752520002373600098",
-              "endTimeUnixNano": "1752520002418500098",
+              "startTimeUnixNano": "1752596065359199903",
+              "endTimeUnixNano": "1752596065361599903",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "65937BEA19984FA484B069D3B85C0041"
+                    "stringValue": "22DE95575B9F454C95DD6AA8F08635BB"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://localhost:3001/public/vite-7/es2015/assets/index-CGKnZD7u.js"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 375159
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1752596065359199903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1752596065359199903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1752596065359199903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1752596065359199903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1752596065359199903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1752596065360599903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1752596065361099903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1752596065361599903",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            },
+            {
+              "traceId": "69824fe3678054fe4c0d83d5529505c6",
+              "spanId": "42d72d2f89c46165",
+              "name": "documentLoad",
+              "kind": 1,
+              "startTimeUnixNano": "1752596065356699952",
+              "endTimeUnixNano": "1752596065388999952",
+              "attributes": [
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "22DE95575B9F454C95DD6AA8F08635BB"
                   }
                 },
                 {
@@ -471,55 +441,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752520002373600098",
+                  "timeUnixNano": "1752596065356699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "unloadEventStart",
-                  "timeUnixNano": "1752520002373600098",
+                  "timeUnixNano": "1752596065356699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "unloadEventEnd",
-                  "timeUnixNano": "1752520002373600098",
+                  "timeUnixNano": "1752596065356699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1752520002378900098",
+                  "timeUnixNano": "1752596065360299952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1752520002418200098",
+                  "timeUnixNano": "1752596065388699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1752520002418200098",
+                  "timeUnixNano": "1752596065388699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1752520002418400098",
+                  "timeUnixNano": "1752596065388899952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1752520002418400098",
+                  "timeUnixNano": "1752596065388899952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1752520002418500098",
+                  "timeUnixNano": "1752596065388999952",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/vite-7-esnext-send-log.json
+++ b/tests/integration/tests/__golden__/vite-7-esnext-send-log.json
@@ -66,43 +66,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "16CD34EE3DDC4509864ABA13EB8BF766"
+              "stringValue": "4FABB8E73AA24567AA119641B9071F5F"
             }
           },
           {
-            "key": "browser.platform",
+            "key": "user_agent.original",
             "value": {
-              "stringValue": "macOS"
-            }
-          },
-          {
-            "key": "browser.brands",
-            "value": {
-              "arrayValue": {
-                "values": [
-                  {
-                    "stringValue": "Not;A=Brand 99"
-                  },
-                  {
-                    "stringValue": "HeadlessChrome 139"
-                  },
-                  {
-                    "stringValue": "Chromium 139"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "key": "browser.mobile",
-            "value": {
-              "boolValue": false
-            }
-          },
-          {
-            "key": "browser.language",
-            "value": {
-              "stringValue": "en-US"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/139.0.7258.5 Safari/537.36"
             }
           }
         ],
@@ -115,8 +85,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1752519997037100098",
-              "observedTimeUnixNano": "1752519997037000000",
+              "timeUnixNano": "1752596060399699951",
+              "observedTimeUnixNano": "1752596060399000000",
               "severityNumber": 9,
               "severityText": "INFO",
               "body": {
@@ -132,13 +102,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "344585C879294CF09AA36E497962E8D7"
+                    "stringValue": "A4E65980859C474BA1C03CB62C10FEC4"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "84DCC9DFC4844304AB6C0F1AEFCDD8AB"
+                    "stringValue": "4A9CEB2BA8944D5C988762CC4299813B"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/vite-7-esnext-session.json
+++ b/tests/integration/tests/__golden__/vite-7-esnext-session.json
@@ -66,43 +66,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "B16B53D58FB7468892CB8D526E57C48D"
+              "stringValue": "F4F0F418FC864E2188384496CE3E5A6A"
             }
           },
           {
-            "key": "browser.platform",
+            "key": "user_agent.original",
             "value": {
-              "stringValue": "macOS"
-            }
-          },
-          {
-            "key": "browser.brands",
-            "value": {
-              "arrayValue": {
-                "values": [
-                  {
-                    "stringValue": "Not;A=Brand 99"
-                  },
-                  {
-                    "stringValue": "HeadlessChrome 139"
-                  },
-                  {
-                    "stringValue": "Chromium 139"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "key": "browser.mobile",
-            "value": {
-              "boolValue": false
-            }
-          },
-          {
-            "key": "browser.language",
-            "value": {
-              "stringValue": "en-US"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/139.0.7258.5 Safari/537.36"
             }
           }
         ],
@@ -115,12 +85,12 @@
           },
           "spans": [
             {
-              "traceId": "42a0d1785400ca5176517afb64d62803",
-              "spanId": "b809d221f11e6f82",
+              "traceId": "2e6cf3dad1526867b5a9330d56c45498",
+              "spanId": "ddd24832151f408e",
               "name": "emb-session",
               "kind": 1,
-              "startTimeUnixNano": "1752519996541000000",
-              "endTimeUnixNano": "1752519996719600000",
+              "startTimeUnixNano": "1752596060026000000",
+              "endTimeUnixNano": "1752596060183500000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -137,7 +107,7 @@
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EBBABD37AF17494BB7A17CD6C3C2DEBB"
+                    "stringValue": "CEA42A61909949A09830D87C15BFD658"
                   }
                 },
                 {
@@ -161,7 +131,7 @@
                 {
                   "key": "emb.startup_duration",
                   "value": {
-                    "doubleValue": 6.10009765625
+                    "doubleValue": 4.39990234375
                   }
                 }
               ],
@@ -183,17 +153,17 @@
           },
           "spans": [
             {
-              "traceId": "95f9e6dfcaa9dc231f7136053c9cddcd",
-              "spanId": "edf4f11180013ff7",
+              "traceId": "022dac9ff6a33ef4bf2dc88270c82ca4",
+              "spanId": "d6a3a771bdec5680",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752519996498000000",
-              "endTimeUnixNano": "1752519996502800000",
+              "startTimeUnixNano": "1752596059997100000",
+              "endTimeUnixNano": "1752596060005600000",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EBBABD37AF17494BB7A17CD6C3C2DEBB"
+                    "stringValue": "CEA42A61909949A09830D87C15BFD658"
                   }
                 },
                 {
@@ -214,49 +184,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996498000000",
+                  "timeUnixNano": "1752596059997100000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996500400000",
+                  "timeUnixNano": "1752596060004400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996500400000",
+                  "timeUnixNano": "1752596060004400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752519996500400000",
+                  "timeUnixNano": "1752596060004400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752519996500700000",
+                  "timeUnixNano": "1752596060004700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752519996500900000",
+                  "timeUnixNano": "1752596060004700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752519996502500000",
+                  "timeUnixNano": "1752596060005400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752519996502800000",
+                  "timeUnixNano": "1752596060005600000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -268,30 +238,30 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "92c90c2023af3541a78de86f5edda2cf",
-              "spanId": "3f7c2794c9b40a39",
-              "parentSpanId": "87df121b472b3796",
+              "traceId": "86da4a823591759e84a8cd1494286513",
+              "spanId": "7b6f38bb0b94cf2a",
+              "parentSpanId": "b64cf84efb45740b",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752519996504400098",
-              "endTimeUnixNano": "1752519996513600098",
+              "startTimeUnixNano": "1752596060007299903",
+              "endTimeUnixNano": "1752596060010299903",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EBBABD37AF17494BB7A17CD6C3C2DEBB"
+                    "stringValue": "CEA42A61909949A09830D87C15BFD658"
                   }
                 },
                 {
                   "key": "http.url",
                   "value": {
-                    "stringValue": "http://localhost:3001/public/vite-7/esnext/assets/index-Cuz5-d9Q.js"
+                    "stringValue": "http://localhost:3001/public/vite-7/esnext/assets/index-DPInB0lx.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 376635
+                    "intValue": 371992
                   }
                 }
               ],
@@ -300,49 +270,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996504400098",
+                  "timeUnixNano": "1752596060007299903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996504400098",
+                  "timeUnixNano": "1752596060007299903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996504400098",
+                  "timeUnixNano": "1752596060007299903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752519996504400098",
+                  "timeUnixNano": "1752596060007299903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752519996504400098",
+                  "timeUnixNano": "1752596060007299903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752519996506600098",
+                  "timeUnixNano": "1752596060008699903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752519996507500098",
+                  "timeUnixNano": "1752596060009399903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752519996513600098",
+                  "timeUnixNano": "1752596060010299903",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -354,18 +324,18 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "92c90c2023af3541a78de86f5edda2cf",
-              "spanId": "a7c2610b10ad3650",
-              "parentSpanId": "87df121b472b3796",
+              "traceId": "86da4a823591759e84a8cd1494286513",
+              "spanId": "b705dff3c3cb384d",
+              "parentSpanId": "b64cf84efb45740b",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752519996504299902",
-              "endTimeUnixNano": "1752519996508499902",
+              "startTimeUnixNano": "1752596060007300049",
+              "endTimeUnixNano": "1752596060009800049",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EBBABD37AF17494BB7A17CD6C3C2DEBB"
+                    "stringValue": "CEA42A61909949A09830D87C15BFD658"
                   }
                 },
                 {
@@ -386,49 +356,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996504299902",
+                  "timeUnixNano": "1752596060007300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996506699902",
+                  "timeUnixNano": "1752596060008800049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996506699902",
+                  "timeUnixNano": "1752596060008800049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752519996506699902",
+                  "timeUnixNano": "1752596060008800049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752519996506799902",
+                  "timeUnixNano": "1752596060008900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752519996506899902",
+                  "timeUnixNano": "1752596060008900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752519996507399902",
+                  "timeUnixNano": "1752596060009700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752519996508499902",
+                  "timeUnixNano": "1752596060009800049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -440,17 +410,17 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "92c90c2023af3541a78de86f5edda2cf",
-              "spanId": "87df121b472b3796",
+              "traceId": "86da4a823591759e84a8cd1494286513",
+              "spanId": "b64cf84efb45740b",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1752519996498100098",
-              "endTimeUnixNano": "1752519996544100098",
+              "startTimeUnixNano": "1752596059997200098",
+              "endTimeUnixNano": "1752596060028100098",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EBBABD37AF17494BB7A17CD6C3C2DEBB"
+                    "stringValue": "CEA42A61909949A09830D87C15BFD658"
                   }
                 },
                 {
@@ -471,55 +441,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996498100098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "unloadEventStart",
-                  "timeUnixNano": "1752519996498100098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "unloadEventEnd",
-                  "timeUnixNano": "1752519996498100098",
+                  "timeUnixNano": "1752596059997200098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1752519996506400098",
+                  "timeUnixNano": "1752596060008400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1752519996543800098",
+                  "timeUnixNano": "1752596060028100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1752519996543800098",
+                  "timeUnixNano": "1752596060028100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1752519996544000098",
+                  "timeUnixNano": "1752596060028100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1752519996544000098",
+                  "timeUnixNano": "1752596060028100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1752519996544100098",
+                  "timeUnixNano": "1752596060028100098",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/webpack-5-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/webpack-5-es2015-send-log.json
@@ -66,43 +66,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "4C52311613C64E20A99980B9B93D8FDB"
+              "stringValue": "5307BD21DE724C5F8212924E06E193FA"
             }
           },
           {
-            "key": "browser.platform",
+            "key": "user_agent.original",
             "value": {
-              "stringValue": "macOS"
-            }
-          },
-          {
-            "key": "browser.brands",
-            "value": {
-              "arrayValue": {
-                "values": [
-                  {
-                    "stringValue": "Not;A=Brand 99"
-                  },
-                  {
-                    "stringValue": "HeadlessChrome 139"
-                  },
-                  {
-                    "stringValue": "Chromium 139"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "key": "browser.mobile",
-            "value": {
-              "boolValue": false
-            }
-          },
-          {
-            "key": "browser.language",
-            "value": {
-              "stringValue": "en-US"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/139.0.7258.5 Safari/537.36"
             }
           }
         ],
@@ -115,8 +85,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1752520002949300049",
-              "observedTimeUnixNano": "1752520002949000000",
+              "timeUnixNano": "1752596065782199951",
+              "observedTimeUnixNano": "1752596065782000000",
               "severityNumber": 9,
               "severityText": "INFO",
               "body": {
@@ -132,13 +102,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "EB88F81392F54E558BA4669EE7A06247"
+                    "stringValue": "DCFA81C5EB074C43A9F67CE44E2BA076"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "9E5CECF64C014EB9A235855A7D1FD69D"
+                    "stringValue": "BB662E9DFA824DFC9476230A5DCC6243"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webpack-5-es2015-session.json
+++ b/tests/integration/tests/__golden__/webpack-5-es2015-session.json
@@ -66,43 +66,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "92797057F5F6459EA7B6EFA01D0E2648"
+              "stringValue": "915AA2DCB2CA4924B91312992AFFCF01"
             }
           },
           {
-            "key": "browser.platform",
+            "key": "user_agent.original",
             "value": {
-              "stringValue": "macOS"
-            }
-          },
-          {
-            "key": "browser.brands",
-            "value": {
-              "arrayValue": {
-                "values": [
-                  {
-                    "stringValue": "Not;A=Brand 99"
-                  },
-                  {
-                    "stringValue": "HeadlessChrome 139"
-                  },
-                  {
-                    "stringValue": "Chromium 139"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "key": "browser.mobile",
-            "value": {
-              "boolValue": false
-            }
-          },
-          {
-            "key": "browser.language",
-            "value": {
-              "stringValue": "en-US"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/139.0.7258.5 Safari/537.36"
             }
           }
         ],
@@ -115,12 +85,12 @@
           },
           "spans": [
             {
-              "traceId": "3118f3263528d8147d77fb5968d72687",
-              "spanId": "cc7c87d151252a92",
+              "traceId": "9a582245c0fd6c5ca45a0508416a164f",
+              "spanId": "18038f46c2bfdc30",
               "name": "emb-session",
               "kind": 1,
-              "startTimeUnixNano": "1752520002513000000",
-              "endTimeUnixNano": "1752520002682600000",
+              "startTimeUnixNano": "1752596065419000000",
+              "endTimeUnixNano": "1752596065565500000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -137,7 +107,7 @@
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "3E7A76B02FC0497BA178DC4B21E37F69"
+                    "stringValue": "CEAF21669C924D699AAA9FC701DC96EB"
                   }
                 },
                 {
@@ -161,7 +131,7 @@
                 {
                   "key": "emb.startup_duration",
                   "value": {
-                    "doubleValue": 7.300048828125
+                    "doubleValue": 4.599853515625
                   }
                 }
               ],
@@ -183,17 +153,17 @@
           },
           "spans": [
             {
-              "traceId": "ed7dda6bddbf30429b37ee5f17a18441",
-              "spanId": "58c1e94fa4bba60c",
+              "traceId": "5ba8abb75eaae673722d3e2ce45592b7",
+              "spanId": "a47a59d11dbebeb8",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752520002474600098",
-              "endTimeUnixNano": "1752520002477300098",
+              "startTimeUnixNano": "1752596065393300049",
+              "endTimeUnixNano": "1752596065394600049",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "3E7A76B02FC0497BA178DC4B21E37F69"
+                    "stringValue": "CEAF21669C924D699AAA9FC701DC96EB"
                   }
                 },
                 {
@@ -214,49 +184,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752520002474600098",
+                  "timeUnixNano": "1752596065393300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752520002476000098",
+                  "timeUnixNano": "1752596065393900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752520002476000098",
+                  "timeUnixNano": "1752596065393900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752520002476000098",
+                  "timeUnixNano": "1752596065393900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752520002476300098",
+                  "timeUnixNano": "1752596065394100049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752520002476400098",
+                  "timeUnixNano": "1752596065394100049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752520002477100098",
+                  "timeUnixNano": "1752596065394500049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752520002477300098",
+                  "timeUnixNano": "1752596065394600049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -268,18 +238,18 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "184a061925301cdb372e1192ddcced41",
-              "spanId": "8aa8ac91b1776ec9",
-              "parentSpanId": "06bd0f2421b57411",
+              "traceId": "d48363469ed3850cead5911562ebf446",
+              "spanId": "45184c0bb63d30fd",
+              "parentSpanId": "a8467572774fe984",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752520002478999952",
-              "endTimeUnixNano": "1752520002483499952",
+              "startTimeUnixNano": "1752596065396099951",
+              "endTimeUnixNano": "1752596065397999951",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "3E7A76B02FC0497BA178DC4B21E37F69"
+                    "stringValue": "CEAF21669C924D699AAA9FC701DC96EB"
                   }
                 },
                 {
@@ -291,7 +261,7 @@
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 455806
+                    "intValue": 451441
                   }
                 }
               ],
@@ -300,49 +270,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752520002478999952",
+                  "timeUnixNano": "1752596065396099951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752520002478999952",
+                  "timeUnixNano": "1752596065396099951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752520002478999952",
+                  "timeUnixNano": "1752596065396099951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752520002478999952",
+                  "timeUnixNano": "1752596065396099951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752520002478999952",
+                  "timeUnixNano": "1752596065396099951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752520002480799952",
+                  "timeUnixNano": "1752596065397199951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752520002481699952",
+                  "timeUnixNano": "1752596065397499951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752520002483499952",
+                  "timeUnixNano": "1752596065397999951",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -354,17 +324,17 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "184a061925301cdb372e1192ddcced41",
-              "spanId": "06bd0f2421b57411",
+              "traceId": "d48363469ed3850cead5911562ebf446",
+              "spanId": "a8467572774fe984",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1752520002474699952",
-              "endTimeUnixNano": "1752520002516299952",
+              "startTimeUnixNano": "1752596065393399902",
+              "endTimeUnixNano": "1752596065421099902",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "3E7A76B02FC0497BA178DC4B21E37F69"
+                    "stringValue": "CEAF21669C924D699AAA9FC701DC96EB"
                   }
                 },
                 {
@@ -385,55 +355,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752520002474699952",
+                  "timeUnixNano": "1752596065393399902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "unloadEventStart",
-                  "timeUnixNano": "1752520002474699952",
+                  "timeUnixNano": "1752596065393399902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "unloadEventEnd",
-                  "timeUnixNano": "1752520002474699952",
+                  "timeUnixNano": "1752596065393399902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1752520002480499952",
+                  "timeUnixNano": "1752596065396899902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1752520002516099951",
+                  "timeUnixNano": "1752596065420899902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1752520002516099951",
+                  "timeUnixNano": "1752596065420899902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1752520002516199952",
+                  "timeUnixNano": "1752596065420999902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1752520002516199952",
+                  "timeUnixNano": "1752596065420999902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1752520002516299952",
+                  "timeUnixNano": "1752596065421099902",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/webpack-5-esnext-send-log.json
+++ b/tests/integration/tests/__golden__/webpack-5-esnext-send-log.json
@@ -66,43 +66,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "E087D4BD5F5F4D93869443CA67B01789"
+              "stringValue": "28654B81F3B140B6B913BE0B8C8670EA"
             }
           },
           {
-            "key": "browser.platform",
+            "key": "user_agent.original",
             "value": {
-              "stringValue": "macOS"
-            }
-          },
-          {
-            "key": "browser.brands",
-            "value": {
-              "arrayValue": {
-                "values": [
-                  {
-                    "stringValue": "Not;A=Brand 99"
-                  },
-                  {
-                    "stringValue": "HeadlessChrome 139"
-                  },
-                  {
-                    "stringValue": "Chromium 139"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "key": "browser.mobile",
-            "value": {
-              "boolValue": false
-            }
-          },
-          {
-            "key": "browser.language",
-            "value": {
-              "stringValue": "en-US"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/139.0.7258.5 Safari/537.36"
             }
           }
         ],
@@ -115,8 +85,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1752519997083000000",
-              "observedTimeUnixNano": "1752519997083000000",
+              "timeUnixNano": "1752596060418199951",
+              "observedTimeUnixNano": "1752596060418000000",
               "severityNumber": 9,
               "severityText": "INFO",
               "body": {
@@ -132,13 +102,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "EE7C0630C3FB44FAA573A2D1F737CDF9"
+                    "stringValue": "E719DA7A0BB64377BFAFDBE17379F014"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "48BA6C833D46497993ED402EDBCEFAA4"
+                    "stringValue": "D9CA8857EA564318B54268F1CAB29BFC"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webpack-5-esnext-session.json
+++ b/tests/integration/tests/__golden__/webpack-5-esnext-session.json
@@ -66,43 +66,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "3BACFE19828043AA948EBA6A5848BA40"
+              "stringValue": "16F48328A6294897BD2F3FC67F75006A"
             }
           },
           {
-            "key": "browser.platform",
+            "key": "user_agent.original",
             "value": {
-              "stringValue": "macOS"
-            }
-          },
-          {
-            "key": "browser.brands",
-            "value": {
-              "arrayValue": {
-                "values": [
-                  {
-                    "stringValue": "Not;A=Brand 99"
-                  },
-                  {
-                    "stringValue": "HeadlessChrome 139"
-                  },
-                  {
-                    "stringValue": "Chromium 139"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "key": "browser.mobile",
-            "value": {
-              "boolValue": false
-            }
-          },
-          {
-            "key": "browser.language",
-            "value": {
-              "stringValue": "en-US"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/139.0.7258.5 Safari/537.36"
             }
           }
         ],
@@ -115,12 +85,12 @@
           },
           "spans": [
             {
-              "traceId": "5aa2e5ffb9fa96b8981ff7a498beb734",
-              "spanId": "55d220e4a4ff865b",
+              "traceId": "58700b72874d805a5ecef0b40199125f",
+              "spanId": "6163ede9eec54ddb",
               "name": "emb-session",
               "kind": 1,
-              "startTimeUnixNano": "1752519996565000000",
-              "endTimeUnixNano": "1752519996745700000",
+              "startTimeUnixNano": "1752596060033000000",
+              "endTimeUnixNano": "1752596060183300000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -137,7 +107,7 @@
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "4630A7F9F67C41DAADB8255679D59F5F"
+                    "stringValue": "7AA4B9216D6B4C09A9CE5E29F1949012"
                   }
                 },
                 {
@@ -161,7 +131,7 @@
                 {
                   "key": "emb.startup_duration",
                   "value": {
-                    "doubleValue": 9.10009765625
+                    "doubleValue": 4.900146484375
                   }
                 }
               ],
@@ -183,17 +153,17 @@
           },
           "spans": [
             {
-              "traceId": "c631e4f635ef0275ad6a58c825bc4569",
-              "spanId": "8ad9a9ca9baae967",
+              "traceId": "c7df7f4c3f6751438b73debd6d6c04c9",
+              "spanId": "31f28e764eb27de3",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752519996502600097",
-              "endTimeUnixNano": "1752519996508400097",
+              "startTimeUnixNano": "1752596059997799951",
+              "endTimeUnixNano": "1752596060005899951",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "4630A7F9F67C41DAADB8255679D59F5F"
+                    "stringValue": "7AA4B9216D6B4C09A9CE5E29F1949012"
                   }
                 },
                 {
@@ -214,49 +184,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996502600097",
+                  "timeUnixNano": "1752596059997799951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996505500097",
+                  "timeUnixNano": "1752596060004899951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996505500097",
+                  "timeUnixNano": "1752596060004899951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752519996505500097",
+                  "timeUnixNano": "1752596060004899951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752519996505700097",
+                  "timeUnixNano": "1752596060005099951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752519996505800097",
+                  "timeUnixNano": "1752596060005099951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752519996507900097",
+                  "timeUnixNano": "1752596060005799951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752519996508400097",
+                  "timeUnixNano": "1752596060005899951",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -268,18 +238,18 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "d4b77424fc9b5c73cd5c2ab5dd6383b2",
-              "spanId": "6632a7128255a103",
-              "parentSpanId": "8a7efa192c0acba1",
+              "traceId": "a71eff28eb9f318425df4af9e16a62aa",
+              "spanId": "151d5225c241e5ca",
+              "parentSpanId": "5d405df531d5254a",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1752519996510399902",
-              "endTimeUnixNano": "1752519996530099902",
+              "startTimeUnixNano": "1752596060006700000",
+              "endTimeUnixNano": "1752596060009400000",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "4630A7F9F67C41DAADB8255679D59F5F"
+                    "stringValue": "7AA4B9216D6B4C09A9CE5E29F1949012"
                   }
                 },
                 {
@@ -291,7 +261,7 @@
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 383441
+                    "intValue": 379086
                   }
                 }
               ],
@@ -300,49 +270,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996510399902",
+                  "timeUnixNano": "1752596060006700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1752519996510399902",
+                  "timeUnixNano": "1752596060006700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1752519996510399902",
+                  "timeUnixNano": "1752596060006700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1752519996510399902",
+                  "timeUnixNano": "1752596060006700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1752519996510399902",
+                  "timeUnixNano": "1752596060006700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1752519996524499902",
+                  "timeUnixNano": "1752596060008100000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1752519996526199902",
+                  "timeUnixNano": "1752596060008700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1752519996530099902",
+                  "timeUnixNano": "1752596060009400000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -354,17 +324,17 @@
               "droppedLinksCount": 0
             },
             {
-              "traceId": "d4b77424fc9b5c73cd5c2ab5dd6383b2",
-              "spanId": "8a7efa192c0acba1",
+              "traceId": "a71eff28eb9f318425df4af9e16a62aa",
+              "spanId": "5d405df531d5254a",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1752519996502699951",
-              "endTimeUnixNano": "1752519996569399951",
+              "startTimeUnixNano": "1752596059997799951",
+              "endTimeUnixNano": "1752596060035999951",
               "attributes": [
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "4630A7F9F67C41DAADB8255679D59F5F"
+                    "stringValue": "7AA4B9216D6B4C09A9CE5E29F1949012"
                   }
                 },
                 {
@@ -385,55 +355,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1752519996502699951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "unloadEventStart",
-                  "timeUnixNano": "1752519996502699951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "unloadEventEnd",
-                  "timeUnixNano": "1752519996502699951",
+                  "timeUnixNano": "1752596059997799951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1752519996512999951",
+                  "timeUnixNano": "1752596060008699951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1752519996569199951",
+                  "timeUnixNano": "1752596060035999951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1752519996569299951",
+                  "timeUnixNano": "1752596060035999951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1752519996569299951",
+                  "timeUnixNano": "1752596060035999951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1752519996569299951",
+                  "timeUnixNano": "1752596060035999951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1752519996569399951",
+                  "timeUnixNano": "1752596060035999951",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -52,8 +52,8 @@ const IGNORED_ATTRIBUTES_LIST = [
   'log.record.uid',
   'emb.startup_duration',
   'emb.app_instance_id',
-  // CI runs on Linux, devs might use different OS
-  'browser.platform',
+  // CI runs on Linux, devs might use different OS, thus different user agent
+  'user_agent.original',
 ];
 
 const testWithMockApi = base.extend<TestWithMockApi>({


### PR DESCRIPTION
## Goal

Include the stable user_agent.original attribute as described in https://opentelemetry.io/docs/specs/semconv/registry/attributes/user-agent/

## Testing

<!-- Describe how this change has been tested -->