### PR TITLE
chore: relax rule restrict-template-expressions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,6 +88,7 @@ export default tseslint.config([
         },
       ],
       'no-restricted-syntax': ['error', 'ExportAllDeclaration'],
+      '@typescript-eslint/restrict-template-expressions': 'off',
       'prefer-arrow-functions/prefer-arrow-functions': [
         'error',
         {


### PR DESCRIPTION
## Goal

Do not require values in template literals to be strings. Decided here: https://github.com/embrace-io/embrace-web-sdk/pull/585/files#r2208315426

## Testing

Spot checked Pablo's code in my IDE with `toString()` removed.