### PR TITLE
chore: fix commitlint command

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,0 +1,3 @@
+export default {
+  '{src,cli/src}/**/*': _stagedFiles => ['npm run sdk:lint:fix'],
+};

--- a/package.json
+++ b/package.json
@@ -49,16 +49,6 @@
     "playwright": "playwright",
     "prepare": "husky"
   },
-  "lint-staged": {
-    "./src/**/*": [
-      "npm run sdk:lint:eslint:fix",
-      "npm run sdk:lint:prettier"
-    ],
-    "./cli/src/**/*": [
-      "npm run sdk:lint:eslint:fix",
-      "npm run sdk:lint:prettier"
-    ]
-  },
   "files": [
     "build/esm/**/*.js",
     "build/esm/**/*.js.map",


### PR DESCRIPTION
## Goal

Currently, we are running global commands (sometimes twice if cli/src and src/ are changed in the same commit) with staged file names tacked onto the end. The lint commands already include every file in the src folders so there is some unnecessary redundancy.

## Testing

1. Made a commit outside the src folder - fast.
2. Made a commit inside the src folder - slow. 
3. Made a commit inside the src folder with bad formatting - slow but fixed in the actual commit.