### PR TITLE
chore: version bump job should also update goldens

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,22 +42,25 @@ jobs:
             echo 'Version is empty. Exiting'
             exit 1
           fi
-          # bump the version
+          PREVIOUS_VERSION=$(jq '.version' package.json)
+
           echo 'Updating package.json version to $version'
+
           # update sdk version
           jq --arg version "$version" '.version = $version' package.json > tmp.json && mv tmp.json package.json
-          npm i
+
           # update cli version
-          cd cli
-          jq --arg version "$version" '.version = $version' package.json > tmp.json && mv tmp.json package.json
+          jq --arg version "$version" '.version = $version' cli/package.json > tmp.json && mv tmp.json cli/package.json
+
+          # update the golden files
+          pushd tests/integration/tests/__golden__
+          ack $PREVIOUS_VERSION -l | xargs -I@ sed -i "" "s/$PREVIOUS_VERSION/\"$version\"/g" @
+          popd
+
+          # update package-lock.json
           npm i
-          # update demo versions
-          cd ../demo/frontend
-          npm i
-          cd ../frontend-cdn
-          npm i
-          # run the linter to update the version hardcoded in code
-          cd ../..
+
+          # update constants files
           npm run sdk:lint:fix
       - name: commit and create PR with the next release
         env:


### PR DESCRIPTION
Adding an update of the golden files sdk version to the version bump job. Ran the commands locally and the output looked good, not sure the best way to test short of merging and then trying to trigger the version bump again