### PR TITLE
chore: replace opentelemetry/sdk-trace-base with opentelemetry/sdk-trace-web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@opentelemetry/otlp-transformer": "0.57.2",
         "@opentelemetry/resources": "1.30.1",
         "@opentelemetry/sdk-logs": "0.57.2",
-        "@opentelemetry/sdk-trace-base": "1.30.1",
         "@opentelemetry/sdk-trace-web": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.34.0",
         "@opentelemetry/web-common": "0.57.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "@opentelemetry/otlp-transformer": "0.57.2",
     "@opentelemetry/resources": "1.30.1",
     "@opentelemetry/sdk-logs": "0.57.2",
-    "@opentelemetry/sdk-trace-base": "1.30.1",
     "@opentelemetry/sdk-trace-web": "1.30.1",
     "@opentelemetry/semantic-conventions": "1.34.0",
     "@opentelemetry/web-common": "0.57.2",

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -10,9 +10,8 @@ import type {
   LogRecordExporter,
   LogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
-import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
+import type { SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-web';
 import type { SpanSessionManager } from '../api-sessions/index.js';
-import type { SpanExporter } from '@opentelemetry/sdk-trace-base';
 import type {
   ClicksInstrumentationArgs,
   GlobalExceptionInstrumentationArgs,

--- a/tests/integration/platforms/vite-7/src/otel.ts
+++ b/tests/integration/platforms/vite-7/src/otel.ts
@@ -1,6 +1,6 @@
 import { sdk, session } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
-import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-web';
 
 const sdkControl = sdk.initSDK({
   appID: '11111',

--- a/tests/integration/platforms/vite-otel-latest/README.md
+++ b/tests/integration/platforms/vite-otel-latest/README.md
@@ -19,7 +19,6 @@ This test uses the latest versions of:
 - `@opentelemetry/instrumentation`
 - `@opentelemetry/instrumentation-document-load`
 - `@opentelemetry/sdk-logs`
-- `@opentelemetry/sdk-trace-base`
 - `@opentelemetry/sdk-trace-web`
 
 Compare with the SDK's [supported versions](../../../README.md#compatibility-with-otel-packages):

--- a/tests/integration/platforms/vite-otel-latest/package-lock.json
+++ b/tests/integration/platforms/vite-otel-latest/package-lock.json
@@ -13,7 +13,6 @@
         "@opentelemetry/instrumentation": "latest",
         "@opentelemetry/instrumentation-document-load": "latest",
         "@opentelemetry/sdk-logs": "latest",
-        "@opentelemetry/sdk-trace-base": "latest",
         "@opentelemetry/sdk-trace-web": "latest"
       },
       "devDependencies": {

--- a/tests/integration/platforms/vite-otel-latest/package.json
+++ b/tests/integration/platforms/vite-otel-latest/package.json
@@ -15,7 +15,6 @@
     "@opentelemetry/instrumentation": "latest",
     "@opentelemetry/instrumentation-document-load": "latest",
     "@opentelemetry/sdk-logs": "latest",
-    "@opentelemetry/sdk-trace-base": "latest",
     "@opentelemetry/sdk-trace-web": "latest"
   },
   "devDependencies": {

--- a/tests/integration/platforms/vite-otel-latest/src/main.ts
+++ b/tests/integration/platforms/vite-otel-latest/src/main.ts
@@ -3,7 +3,7 @@ import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
-import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-web';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 
 const provider = new WebTracerProvider();

--- a/tests/integration/platforms/webpack-5/src/otel.ts
+++ b/tests/integration/platforms/webpack-5/src/otel.ts
@@ -1,6 +1,6 @@
 import { sdk, session } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
-import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-web';
 
 const sdkControl = sdk.initSDK({
   appID: '11111',


### PR DESCRIPTION
## Goal

Simplify our code by relying directly on `@opentelemetry/sdk-trace-web` package.
Functionally nothing changes because the base package is still a peer dependency.

## Testing

Compilation succeeds.
