### PR TITLE
chore: optimize tsconfigs for bundlers

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,10 @@
     "inlineSources": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
-    "module": "NodeNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ES2022",
     "moduleDetection": "force",
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "bundler",
     "newLine": "LF",
     "noEmit": true,
     "noEmitOnError": true,
@@ -25,9 +25,9 @@
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
-    "target": "ESNext",
+    "target": "ES2022",
     "useDefineForClassFields": true,
     "verbatimModuleSyntax": true
   },
-  "exclude": ["demo", "tests/integration"]
+  "exclude": ["build", "demo", "dist", "node_modules", "tests/integration"]
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -6,8 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
-    "declarationDir": "build/types",
-    "outDir": "build/types"
+    "declarationDir": "build/types"
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts"]


### PR DESCRIPTION
We should be less strict about module resolution and more strict about authoring code with ES features newer than 2022, until we actually need them.

Additionally, outDir was redundant because the types file does not export js files.