### PR TITLE
EMBR-7274 chore: update example for custom export

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,9 +273,10 @@ sdk.initSDK({
 
 ## Custom exporters
 
-If you wish to export your data to another backend in addition to Embrace you can set up your own custom log and trace
-exporters and pass them in when initializing the SDK. For example to send telemetry to Grafana cloud using OTLP you
-could do the following:
+You can set up your own custom log and trace exporters and pass them in when initializing the SDK. The exporters should
+be configured to point to an OTLP compatible endpoint and include any headers required for that endpoint, such as
+authorization. Since these export requests will be made from a browser it is also required that the endpoint return
+appropriate CORS headers in its responses:
 
 ```typescript
 import { OTLPLogExporter }   from '@opentelemetry/exporter-logs-otlp-http';
@@ -286,22 +287,35 @@ sdk.initSDK({
   appVersion: "YOUR_APP_VERSION",
   spanExporters: [
     new OTLPTraceExporter({
-      url: `GRANAFA_ENDPOINT/v1/traces`,
+      url: 'https://example.com/endpoint/for/traces',
       headers: {
-        'Authorization': 'Basic YOUR_GRAFANA_CLOUD_TOKEN'
+        'Authorization': 'Basic TOKEN'
       }
     }),
   ],
   logExporters: [
     new OTLPLogExporter({
-      url: `GRANAFA_ENDPOINT/v1/logs`,
+      url: 'https://example.com/endpoint/for/logs',
       headers: {
-        'Authorization': 'Basic YOUR_GRAFANA_CLOUD_TOKEN'
+        'Authorization': 'Basic TOKEN'
       }
     }),
-  ]
+  ],
+  defaultInstrumentationConfig: {
+    network: {
+      ignoreUrls: ['https://example.com/endpoint/for/traces', 'https://example.com/endpoint/for/logs'],
+    },
+  },
 });
 ```
+
+> [!WARNING]
+> Embrace automatically creates spans for network requests, however because the OTLP export itself makes a network
+> request this can produce a cycle where the export's network request creates a span which is then exported which the
+> creates another span, etc. 
+> 
+> To avoid this you can configure the network instrumentation to ignore the URLs to which you are exporting as shown in
+> the above snippet.
 
 ## Including the SDK as a code snippet from CDN
 

--- a/demo/frontend-cdn/scripts/runDemo.sh
+++ b/demo/frontend-cdn/scripts/runDemo.sh
@@ -16,8 +16,7 @@ node -v
 rm -rf node_modules
 npm ci
 rm -rf build
-npm run sdk:compile:esm
-npm run sdk:compile:esm:bundle
+npm run compile
 #build demo locally
 cd ./demo/frontend-cdn || exit
 


### PR DESCRIPTION
We were using Grafana Cloud for our data export example on web, however this endpoint does not include CORS headers in its response so requires going through a proxy when hitting from the browser. Instead update the example to clarify that the export needs to hit an OTLP endpoint that includes CORS headers. Also updating this in the docs: https://github.com/embrace-io/embrace-docs/pull/405