### PR TITLE
chore: use prefix in cdn demos

### DIFF
--- a/demo/frontend-cdn/scripts/runDemo.sh
+++ b/demo/frontend-cdn/scripts/runDemo.sh
@@ -8,17 +8,13 @@ for arg in "$@"; do
   fi
 done
 
-# move to sdk directory (root)
-cd ../..
-#print current node version
-node -v
-#build sdk locally
-rm -rf node_modules
-npm ci
-rm -rf build
-npm run compile
-#build demo locally
-cd ./demo/frontend-cdn || exit
+# clean workspaces
+npm run clean --prefix ../..
+
+# compile sdk and build demo
+npm ci --prefix ../..
+npm run compile --prefix ../..
+npm install
 
 # create .env file if it doesn't exist
 if [ ! -f .env ]; then

--- a/demo/frontend/scripts/runDemo.sh
+++ b/demo/frontend/scripts/runDemo.sh
@@ -30,7 +30,7 @@ fi
 npm run clean --prefix ../..
 
 # compile sdk and build demo
-npm install
+npm ci --prefix ../..
 npm run build
 
 # add env vars from .env file to the current environment


### PR DESCRIPTION
1. Fix a husky error when installing from the demo workspace.
2. Use helpers commands in the cdn demo.