### PR TITLE
chore: publish all markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "build/types/**/*.d.ts",
     "build/types/**/*.d.ts.map",
     "LICENSE",
-    "README.md"
+    "*.md"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
There is a 404 when you follow relative links like REACT.md on jsdelivr.
https://www.jsdelivr.com/package/npm/@embrace-io/web-sdk