### PR TITLE
EMBR-6747 chore: tag cancelled network requests

### DIFF
--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -136,6 +136,41 @@ const App = () => {
     req.send();
   };
 
+  const handleCancelFetchNetworkRequest = () => {
+    const controller = new AbortController();
+    void fetch(POKEMON_URL, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+
+    controller.abort();
+  };
+
+  const handleCancelXMLNetworkRequest = () => {
+    const req = new XMLHttpRequest();
+    req.open('GET', POKEMON_URL, true);
+    req.send();
+    req.abort();
+  };
+
+  const handleThrowDOMException = () => {
+    window.atob('!@#$');
+  };
+
+  const handleThrowString = () => {
+    throw 'my error as a string';
+  };
+
+  const handleThrowUndefined = () => {
+    throw undefined;
+  };
+
+  const handleFailedResourceLoad = () => {
+    var img = document.createElement('img');
+    img.src = '/something/that/doesnotexist.png';
+    document.getElementById('root')?.appendChild(img);
+  };
+
   // handleThrowError Throws an error by going through a set of nested functions to validate stacktraces
   const handleThrowError = () => {
     handleThrowErrorA(true);
@@ -314,6 +349,34 @@ const App = () => {
           </button>
         </div>
 
+        {/* Weird Exceptions: */}
+        <div className={styles.actions}>
+          <button
+            onClick={handleThrowDOMException}
+            disabled={sessionProvider.getSessionSpan() === null}
+          >
+            Throw DOM Exception
+          </button>
+          <button
+            onClick={handleThrowString}
+            disabled={sessionProvider.getSessionSpan() === null}
+          >
+            Throw String
+          </button>
+          <button
+            onClick={handleThrowUndefined}
+            disabled={sessionProvider.getSessionSpan() === null}
+          >
+            Throw Undefined
+          </button>
+          <button
+            onClick={handleFailedResourceLoad}
+            disabled={sessionProvider.getSessionSpan() === null}
+          >
+            Trigger Failed Resource Load
+          </button>
+        </div>
+
         {/* Network: */}
         <div className={styles.actions}>
           <button onClick={handleSendFetchNetworkRequest}>
@@ -324,6 +387,16 @@ const App = () => {
           </button>
           <button onClick={handleSendXMLNetworkRequest}>
             Send a XML Network Request
+          </button>
+        </div>
+
+        {/* Cancelled Network: */}
+        <div className={styles.actions}>
+          <button onClick={handleCancelFetchNetworkRequest}>
+            Cancel a Fetch Network Request
+          </button>
+          <button onClick={handleCancelXMLNetworkRequest}>
+            Cancel a XML Network Request
           </button>
         </div>
 
@@ -342,12 +415,8 @@ const App = () => {
 
         {/* Navigation: */}
         <div className={styles.actions}>
-          <a href="https://google.com">
-            Navigate to google.com
-          </a>
-          <a href="/">
-            Open demo in same tab
-          </a>
+          <a href="https://google.com">Navigate to google.com</a>
+          <a href="/">Open demo in same tab</a>
           <a href="/" target="_blank">
             Open demo in new tab
           </a>

--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -168,7 +168,7 @@ const App = () => {
   const handleFailedResourceLoad = () => {
     var img = document.createElement('img');
     img.src = '/something/that/doesnotexist.png';
-    document.getElementById('root')?.appendChild(img);
+    document.body.appendChild(img);
   };
 
   // handleThrowError Throws an error by going through a set of nested functions to validate stacktraces

--- a/src/processors/EmbraceNetworkSpanProcessor/EmbraceNetworkSpanProcessor.test.ts
+++ b/src/processors/EmbraceNetworkSpanProcessor/EmbraceNetworkSpanProcessor.test.ts
@@ -120,4 +120,30 @@ describe('EmbraceNetworkSpanProcessor', () => {
       'url.full': '/some/path',
     });
   });
+
+  it('should add emb.type for network requests with a 0 response code', () => {
+    tracer
+      .startSpan('network-request', {
+        attributes: {
+          'http.request.method': 'GET',
+          'http.response.status_code': 0,
+          'http.response.body.size': 10,
+          'http.request.body.size': 20,
+          'url.full': 'https://example.com',
+        },
+      })
+      .end();
+
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const networkRequest = finishedSpans[0];
+    expect(networkRequest.attributes).to.be.deep.equal({
+      'emb.type': 'perf.network_request',
+      'http.request.method': 'GET',
+      'http.response.status_code': 0,
+      'http.response.body.size': 10,
+      'http.request.body.size': 20,
+      'url.full': 'https://example.com',
+    });
+  });
 });

--- a/src/processors/EmbraceNetworkSpanProcessor/types.ts
+++ b/src/processors/EmbraceNetworkSpanProcessor/types.ts
@@ -37,8 +37,8 @@ export const isNetworkSpan = (
   if (
     (span.attributes[ATTR_HTTP_REQUEST_METHOD] || // eslint-disable-next-line @typescript-eslint/no-deprecated
       span.attributes[SEMATTRS_HTTP_METHOD]) &&
-    (span.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE] || // eslint-disable-next-line @typescript-eslint/no-deprecated
-      span.attributes[SEMATTRS_HTTP_STATUS_CODE])
+    (typeof span.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE] === 'number' || // eslint-disable-next-line @typescript-eslint/no-deprecated
+      typeof span.attributes[SEMATTRS_HTTP_STATUS_CODE] === 'number')
   ) {
     const url = // eslint-disable-next-line @typescript-eslint/no-deprecated
       span.attributes[ATTR_URL_FULL] ?? span.attributes[SEMATTRS_HTTP_URL];


### PR DESCRIPTION
## Goal

When network requests are cancelled, or fail due to some other connection error like CORS, the response code is 0:
<img width="427" height="67" alt="image" src="https://github.com/user-attachments/assets/988767c1-cf9c-4fc4-863d-888c2c73fe57" />

Our logic for adding `'emb.type': 'perf.network_request'` to network spans was just checking that status code was truthy so was missing this case and we end up treating these as generic root spans in the dashboard