### PR TITLE
EMBR-8057 chore: wrap all storage access in error handling

### DIFF
--- a/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
+++ b/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
@@ -10,6 +10,7 @@ import {
   KEY_PREFIX_EMB_PROPERTIES,
 } from '../../constants/attributes.js';
 import {
+  FailingStorage,
   InMemoryDiagLogger,
   InMemoryStorage,
   setupTestTraceExporter,
@@ -652,5 +653,26 @@ describe('EmbraceSpanSessionManager', () => {
       KEY_EMB_SESSION_REASON_STARTED,
       'start reason'
     );
+  });
+
+  it('should default to session number 1 when storage is failing', () => {
+    manager = new EmbraceSpanSessionManager({
+      diag,
+      limitManager,
+      storage: new FailingStorage(),
+    });
+
+    manager.startSessionSpan();
+    manager.endSessionSpan();
+
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.attributes).to.have.property('emb.session_number', 1);
+
+    const warningLogs = diag.getWarnLogs();
+    expect(warningLogs).to.deep.equal([
+      'Failed to retrieve session number from storage',
+    ]);
   });
 });

--- a/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
+++ b/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
@@ -89,14 +89,19 @@ export class EmbraceSpanSessionManager implements SpanSessionManagerInternal {
   // This is not perfect in the sense that there may be a race condition between tabs.
   // Eventually a lock could be implemented, but for now this solution should work fine.
   public _getSessionNumber(): number {
-    const value = this._storage.getItem(EMBRACE_SESSION_NUMBER_STORAGE_KEY);
-    let number = value ? parseInt(value, 10) : 0;
-    number++;
-    this._storage.setItem(
-      EMBRACE_SESSION_NUMBER_STORAGE_KEY,
-      number.toString()
-    );
-    return number;
+    try {
+      const value = this._storage.getItem(EMBRACE_SESSION_NUMBER_STORAGE_KEY);
+      let number = value ? parseInt(value, 10) : 0;
+      number++;
+      this._storage.setItem(
+        EMBRACE_SESSION_NUMBER_STORAGE_KEY,
+        number.toString()
+      );
+      return number;
+    } catch (e) {
+      this._diag.warn('Failed to retrieve session number from storage', e);
+      return 1;
+    }
   }
 
   public addBreadcrumb(name: string) {

--- a/src/managers/EmbraceUserManager/EmbraceUserManager.test.ts
+++ b/src/managers/EmbraceUserManager/EmbraceUserManager.test.ts
@@ -152,4 +152,49 @@ describe('EmbraceUserManager', () => {
     void expect(storage.getItem(EMBRACE_EXTERNAL_USER_ID_KEY)).to.be.undefined;
     void expect(manager.getUserId()).to.be.undefined;
   });
+
+  it('should handle getting an external user id when storage is failing', () => {
+    const manager = new EmbraceUserManager({
+      diag,
+      storage: new FailingStorage(),
+    });
+    diag.clear();
+
+    expect(manager.getUserId()).to.equal(null);
+
+    const warningLogs = diag.getWarnLogs();
+    expect(warningLogs).to.deep.equal([
+      'Failed to retrieve user id from storage',
+    ]);
+  });
+
+  it('should handle setting an external user id when storage is failing', () => {
+    const manager = new EmbraceUserManager({
+      diag,
+      storage: new FailingStorage(),
+    });
+    diag.clear();
+
+    expect(() => {
+      manager.setUserId('my-id');
+    }).not.to.throw();
+
+    const warningLogs = diag.getWarnLogs();
+    expect(warningLogs).to.deep.equal(['Failed to store user id']);
+  });
+
+  it('should handle clearing an external user id when storage is failing', () => {
+    const manager = new EmbraceUserManager({
+      diag,
+      storage: new FailingStorage(),
+    });
+    diag.clear();
+
+    expect(() => {
+      manager.clearUserId();
+    }).not.to.throw();
+
+    const warningLogs = diag.getWarnLogs();
+    expect(warningLogs).to.deep.equal(['Failed to clear user id']);
+  });
 });

--- a/src/managers/EmbraceUserManager/EmbraceUserManager.ts
+++ b/src/managers/EmbraceUserManager/EmbraceUserManager.ts
@@ -123,15 +123,28 @@ export class EmbraceUserManager implements UserManagerInternal {
 
   // This is the external user id that can be set by the user
   public getUserId(): string | null {
-    return this._storage.getItem(EMBRACE_EXTERNAL_USER_ID_KEY);
+    try {
+      return this._storage.getItem(EMBRACE_EXTERNAL_USER_ID_KEY);
+    } catch (e) {
+      this._diag.warn('Failed to retrieve user id from storage', e);
+      return null;
+    }
   }
 
   // Use storage as source of truth so multiple tabs can share the same user id
   public setUserId(userId: string): void {
-    this._storage.setItem(EMBRACE_EXTERNAL_USER_ID_KEY, userId);
+    try {
+      this._storage.setItem(EMBRACE_EXTERNAL_USER_ID_KEY, userId);
+    } catch (e) {
+      this._diag.warn('Failed to store user id', e);
+    }
   }
 
   public clearUserId(): void {
-    this._storage.removeItem(EMBRACE_EXTERNAL_USER_ID_KEY);
+    try {
+      this._storage.removeItem(EMBRACE_EXTERNAL_USER_ID_KEY);
+    } catch (e) {
+      this._diag.warn('Failed to clear user id', e);
+    }
   }
 }

--- a/src/testUtils/InMemoryDiagLogger/InMemoryDiagLogger.ts
+++ b/src/testUtils/InMemoryDiagLogger/InMemoryDiagLogger.ts
@@ -2,11 +2,11 @@ import type { DiagLogger } from '@opentelemetry/api';
 
 // TODO this helper could be contributed back to the OpenTelemetry community
 export class InMemoryDiagLogger implements DiagLogger {
-  private readonly _errorLogs: string[] = [];
-  private readonly _warnLogs: string[] = [];
-  private readonly _infoLogs: string[] = [];
-  private readonly _debugLogs: string[] = [];
-  private readonly _verboseLogs: string[] = [];
+  private _errorLogs: string[] = [];
+  private _warnLogs: string[] = [];
+  private _infoLogs: string[] = [];
+  private _debugLogs: string[] = [];
+  private _verboseLogs: string[] = [];
 
   public debug(message: string): void {
     this._debugLogs.push(message);
@@ -46,5 +46,13 @@ export class InMemoryDiagLogger implements DiagLogger {
 
   public getVerboseLogs(): string[] {
     return this._verboseLogs;
+  }
+
+  public clear(): void {
+    this._errorLogs = [];
+    this._warnLogs = [];
+    this._infoLogs = [];
+    this._debugLogs = [];
+    this._verboseLogs = [];
   }
 }


### PR DESCRIPTION
## Goal

Had some second thoughts around this ticket as defined:
https://www.notion.so/embraceio/Consistently-invoke-storage-methods-defensively-from-the-SDK-21c7e3c9985280638f93f5c7844671dc?source=copy_link

One issue with a generic helper for safe storage access is we have a few spots where we're accessing storage functions in a loop, in those cases it seems cleaner to just have a single try/except wrapping the whole block rather than each `key` or `getItem` call needing its own error handling. We can also be a bit more flexible with each spot accessing storage deciding how it wants to deal with the error cases.

We were pretty close to each storage access being wrapped in error handling already so just doing the remaining couple spots here. I can keep the above ticket open if we still think there's value in those helpers, otherwise going forward we can just keep an eye out in PRs to make sure any new uses of storage we introduce are wrapped