### PR TITLE
chore: fix type conversion eslint error

### DIFF
--- a/src/managers/EmbraceLogManager/EmbraceLogManager.ts
+++ b/src/managers/EmbraceLogManager/EmbraceLogManager.ts
@@ -214,7 +214,7 @@ export class EmbraceLogManager implements LogManager {
 
     if (typeof error === 'string') {
       return {
-        message: String(error).trim(),
+        message: error.trim(),
         type: 'String',
         name: 'String',
         stack: userCallStack,


### PR DESCRIPTION
## Goal

Fixes the error:
```
/home/runner/work/embrace-web-sdk/embrace-web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.ts
Error:   217:18  error  Passing a string to String() does not change the type or value of the string  @typescript-eslint/no-unnecessary-type-conversion
```

The conversion is not really needed as we are already checking by doing `if (typeof error === 'string') {`

## Testing

<!-- Describe how this change has been tested -->