### PR TITLE
chore: remove vite plugin fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@commitlint/cli": "19.8.1",
         "@commitlint/config-conventional": "19.8.1",
         "@eslint/js": "9.33.0",
-        "@remcovaes/web-test-runner-vite-plugin": "github:overbalance/web-test-runner-vite-plugin#patch-1",
+        "@remcovaes/web-test-runner-vite-plugin": "1.3.0",
         "@rollup/plugin-commonjs": "28.0.6",
         "@rollup/plugin-node-resolve": "16.0.1",
         "@rollup/plugin-swc": "0.4.0",
@@ -3021,8 +3021,9 @@
       }
     },
     "node_modules/@remcovaes/web-test-runner-vite-plugin": {
-      "version": "1.2.2",
-      "resolved": "git+ssh://git@github.com/overbalance/web-test-runner-vite-plugin.git#05c56e54c122e7d4a1a32e8da1387f07c175a287",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@remcovaes/web-test-runner-vite-plugin/-/web-test-runner-vite-plugin-1.3.0.tgz",
+      "integrity": "sha512-f0ytdBQAWyvKTRI4Q49rsN13hCiQyhP+kQxcCD1Nt1pTVVPs76Tk1elX29mTptOQj++PgJEQ6/UkeGcrQlzmnQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
     "@eslint/js": "9.33.0",
-    "@remcovaes/web-test-runner-vite-plugin": "github:overbalance/web-test-runner-vite-plugin#patch-1",
+    "@remcovaes/web-test-runner-vite-plugin": "1.3.0",
     "@rollup/plugin-commonjs": "28.0.6",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@rollup/plugin-swc": "0.4.0",


### PR DESCRIPTION
Our upstream change was merged. Reverting back to the real npm module.