### PR TITLE
chore: turn on web vital url attribution by default

### DIFF
--- a/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -120,7 +120,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     trackingLevel = 'core',
     listeners = WEB_VITALS_ID_TO_LISTENER,
     urlDocument = window.document,
-    urlAttribution = false,
+    urlAttribution = true,
   }: WebVitalsInstrumentationArgs = {}) {
     super({
       instrumentationName: 'WebVitalsInstrumentation',


### PR DESCRIPTION
## Goal

Enable url attribution by default. I'm keeping the config in case someone wants to disable this manually.

## Testing

<!-- Describe how this change has been tested -->