### PR TITLE
feat: add browser and default fields to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Embrace Web SDK",
   "type": "module",
   "jsdelivr": "build/iife/bundle.js",
-  "main": "build/src/index.js",
+  "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
-  "esnext": "build/esnext/index.js",
+  "browser": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "publishConfig": {
     "access": "public"
@@ -51,41 +51,31 @@
     "prepare": "if [ -d .git ]; then husky; fi"
   },
   "files": [
-    "build/esm/**/*.js",
-    "build/esm/**/*.js.map",
-    "build/esnext/**/*.js",
-    "build/esnext/**/*.js.map",
-    "build/src/**/*.js",
-    "build/src/**/*.js.map",
-    "build/iife/**/*.js",
-    "build/iife/**/*.js.map",
-    "build/types/**/*.d.ts",
-    "build/types/**/*.d.ts.map",
+    "build",
     "LICENSE",
     "*.md"
   ],
   "exports": {
     ".": {
-      "esnext": "./build/esnext/index.js",
-      "module": "./build/esm/index.js",
       "types": "./build/types/index.d.ts",
+      "browser": "./build/esm/index.js",
       "import": "./build/esm/index.js",
-      "require": "./build/src/index.js",
-      "default": "./build/src/index.js"
+      "require": "./build/cjs/index.js",
+      "default": "./build/esm/index.js"
     },
     "./react-instrumentation": {
-      "esnext": "./build/esnext/react-instrumentation.js",
-      "module": "./build/esm/react-instrumentation.js",
-      "types": "./build/types/react/index.d.ts",
+      "types": "./build/types/react-instrumentation/index.d.ts",
+      "browser": "./build/esm/react-instrumentation.js",
       "import": "./build/esm/react-instrumentation.js",
-      "require": "./build/src/react-instrumentation.js",
-      "default": "./build/src/react-instrumentation.js"
-    }
+      "require": "./build/cjs/react-instrumentation.js",
+      "default": "./build/esm/react-instrumentation.js"
+    },
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {
       "react-instrumentation": [
-        "build/types/react/index.d.ts"
+        "build/types/react-instrumentation/index.d.ts"
       ],
       "*": [
         "build/types/index.d.ts"
@@ -112,6 +102,9 @@
     "instrumentation",
     "telemetry"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "dependencies": {
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/api-logs": "0.203.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,7 @@ const isExternal = id =>
 
 const input = {
   index: 'src/index.ts',
-  'react-instrumentation': 'src/react/index.ts',
+  'react-instrumentation': 'src/react-instrumentation/index.ts',
 };
 
 // Suppress irrelevant warnings to keep the build output clean
@@ -47,14 +47,14 @@ const plugins = ({ target }) => [
   }),
   resolve({
     mainFields: ['esnext', 'browser', 'module', 'main'], // Resolve priority for entry points, prefer esnext
-    extensions: ['.js', '.ts', '.jsx', '.tsx'], // Required because we import .ts files with .js extension
+    extensions: ['.js', '.ts', '.jsx', '.tsx'], // Required because we import .ts files as .js
   }),
   commonjs(), // Convert CommonJS modules to ES modules
   swc({
     swc: {
       sourceMaps: true, // Generate source maps
       jsc: {
-        target, // Set JavaScript target version
+        target, // Set JavaScript output version
       },
     },
   }),
@@ -76,27 +76,12 @@ export default defineConfig([
     onwarn,
   },
 
-  // ESNext Build: No language coercion applied
-  {
-    input,
-    plugins: plugins({ target: 'esnext' }),
-    output: {
-      dir: 'build/esnext',
-      format: 'esm',
-      sourcemap: true,
-      preserveModules: true,
-      preserveModulesRoot: 'src',
-    },
-    external: isExternal,
-    onwarn,
-  },
-
   // CJS Build: CommonJS modules for older bundlers
   {
     input,
     plugins: plugins({ target: 'es2022' }),
     output: {
-      dir: 'build/src',
+      dir: 'build/cjs',
       format: 'cjs',
       sourcemap: true,
       preserveModules: true,

--- a/scripts/measureSize.ts
+++ b/scripts/measureSize.ts
@@ -1,13 +1,12 @@
-import { readdirSync, statSync, createReadStream } from 'fs';
-import { join } from 'path';
-import { pipeline } from 'stream';
-import { createGzip } from 'zlib';
+import { readdirSync, statSync, createReadStream } from 'node:fs';
+import { join } from 'node:path';
+import { pipeline } from 'node:stream';
+import { createGzip } from 'node:zlib';
 
 const TARGET_DIRS = [
   { name: 'ESM', path: 'build/esm' },
-  { name: 'ESNext', path: 'build/esnext' },
-  { name: 'CJS (src)', path: 'build/src' },
-  { name: 'CDN script (iife)', path: 'build/iife' },
+  { name: 'CJS', path: 'build/cjs' },
+  { name: 'CDN bundle', path: 'build/iife' },
 ];
 
 const walkDir = (dir: string, ext = '.js'): string[] => {
@@ -46,7 +45,7 @@ const analyzeFolder = async (name: string, path: string) => {
     let totalRaw = 0;
     let totalGzip = 0;
 
-    console.log(`📂 ${name} — ${files.length} JS files`);
+    console.log(`📂 ${name} — ${files.length} js files`);
 
     for (const file of files) {
       const rawSize = getSize(file);

--- a/src/react-instrumentation/index.ts
+++ b/src/react-instrumentation/index.ts
@@ -1,5 +1,5 @@
-// Exposes all react specific instrumentation in a way that it is easy to tree-shake. Eventually this should be replaced by its own package.
-// That's why this rule don't apply here, and it will get fixed once we move this to its own package
+// Exposes all React-specific instrumentation in a way that is easy to tree-shake. Eventually this should be replaced by its own package.
+// That's why this rule doesn't apply here, and it will get fixed once we move this to its own package
 /* eslint-disable regex/invalid */
 import { withEmbraceRoutingLegacy } from '../instrumentations/navigation/NavigationInstrumentation/react/reactRouterV5/index.js';
 import { withEmbraceRouting } from '../instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Declarative/index.js';


### PR DESCRIPTION
## Goal

- Add browser field and export condition for better bundler compatibility
- Add engines field requiring Node.js 18+
- Add default export condition as fallback
- Move React instrumentation from src/react to src/react-instrumentation
- Update build to output CJS files to build/cjs/ instead of build/src/
- Remove esnext build target to simplify build pipeline
- Update measureSize script to work with new build structure

## Testing

