### PR TITLE
EMBR-7318 feat: rewrite network instrumentation

### DIFF
--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -136,6 +136,12 @@ const App = () => {
     req.send();
   };
 
+  const handleSendXMLNetworkRequest404 = () => {
+    const req = new XMLHttpRequest();
+    req.open('GET', 'https://example.com/sdk/auto/interception', true);
+    req.send();
+  };
+
   const handleCancelFetchNetworkRequest = () => {
     const controller = new AbortController();
     void fetch(POKEMON_URL, {
@@ -387,6 +393,9 @@ const App = () => {
           </button>
           <button onClick={handleSendXMLNetworkRequest}>
             Send a XML Network Request
+          </button>
+          <button onClick={handleSendXMLNetworkRequest404}>
+            Send a XML Network Request (404)
           </button>
         </div>
 

--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -18,6 +18,10 @@ export {
   type ClicksInstrumentationArgs,
 } from './clicks/index.js';
 export {
+  NetworkInstrumentation,
+  type NetworkInstrumentationArgs,
+} from './network/index.js';
+export {
   WebVitalsInstrumentation,
   type WebVitalOnReport,
   type WebVitalsInstrumentationArgs,

--- a/src/instrumentations/network/NetworkInstrumentation/NetworkInstrumentation.test.ts
+++ b/src/instrumentations/network/NetworkInstrumentation/NetworkInstrumentation.test.ts
@@ -1,0 +1,201 @@
+import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { session } from '../../../api-sessions/index.js';
+import type { SpanSessionManager } from '../../../api-sessions/index.js';
+import {
+  DEFAULT_LIMITS,
+  EmbraceLimitManager,
+  EmbraceSpanSessionManager,
+} from '../../../managers/index.js';
+import {
+  InMemoryDiagLogger,
+  setupTestTraceExporter,
+  setupPerformanceObserverTester,
+} from '../../../testUtils/index.js';
+import { NetworkInstrumentation } from './NetworkInstrumentation.js';
+
+chai.use(sinonChai);
+const { expect } = chai;
+
+const FETCH_SUCCESS_ENTRY = {
+  name: 'https://pokeapi.co/api/v2/pokemon/1/',
+  entryType: 'resource',
+  startTime: 1182839.5,
+  duration: 20030,
+  initiatorType: 'fetch',
+  deliveryType: '',
+  nextHopProtocol: 'http/1.1',
+  renderBlockingStatus: 'non-blocking',
+  workerStart: 0,
+  redirectStart: 0,
+  redirectEnd: 0,
+  fetchStart: 1182839.5,
+  domainLookupStart: 1202844.8000000007,
+  domainLookupEnd: 1202844.8000000007,
+  connectStart: 1202844.8000000007,
+  secureConnectionStart: 0,
+  connectEnd: 1202844.8000000007,
+  requestStart: 1202844.9000000004,
+  responseStart: 1202853.5,
+  firstInterimResponseStart: 0,
+  finalResponseHeadersStart: 1202853.5,
+  responseEnd: 1202869.5,
+  transferSize: 139681,
+  encodedBodySize: 139381,
+  decodedBodySize: 453190,
+  responseStatus: 200,
+  serverTiming: [],
+  toJSON: sinon.stub(),
+};
+
+const XML_HTTP_REQUEST_SUCCESS_ENTRY = {
+  name: 'https://pokeapi.co/api/v2/pokemon/1/',
+  entryType: 'resource',
+  startTime: 1182839.5,
+  duration: 20030,
+  initiatorType: 'xmlhttprequest',
+  deliveryType: '',
+  nextHopProtocol: 'http/1.1',
+  renderBlockingStatus: 'non-blocking',
+  workerStart: 0,
+  redirectStart: 0,
+  redirectEnd: 0,
+  fetchStart: 1182839.5,
+  domainLookupStart: 1202844.8000000007,
+  domainLookupEnd: 1202844.8000000007,
+  connectStart: 1202844.8000000007,
+  secureConnectionStart: 0,
+  connectEnd: 1202844.8000000007,
+  requestStart: 1202844.9000000004,
+  responseStart: 1202853.5,
+  firstInterimResponseStart: 0,
+  finalResponseHeadersStart: 1202853.5,
+  responseEnd: 1202869.5,
+  transferSize: 139681,
+  encodedBodySize: 139381,
+  decodedBodySize: 453190,
+  responseStatus: 200,
+  serverTiming: [],
+  toJSON: sinon.stub(),
+};
+
+const FETCH_404_ENTRY = {
+  name: 'https://pokeapi.co/api/v2/pokemon/foo/',
+  entryType: 'resource',
+  startTime: 1649386.3999999985,
+  duration: 11.300000000745058,
+  initiatorType: 'fetch',
+  deliveryType: '',
+  nextHopProtocol: 'http/1.0',
+  renderBlockingStatus: 'non-blocking',
+  workerStart: 0,
+  redirectStart: 0,
+  redirectEnd: 0,
+  fetchStart: 1649386.3999999985,
+  domainLookupStart: 1649388.1999999993,
+  domainLookupEnd: 1649388.1999999993,
+  connectStart: 1649388.1999999993,
+  secureConnectionStart: 0,
+  connectEnd: 1649388.5,
+  requestStart: 1649388.5,
+  responseStart: 1649396.8999999985,
+  firstInterimResponseStart: 0,
+  finalResponseHeadersStart: 1649396.8999999985,
+  responseEnd: 1649397.6999999993,
+  transferSize: 635,
+  encodedBodySize: 335,
+  decodedBodySize: 335,
+  responseStatus: 404,
+  serverTiming: [],
+  toJSON: sinon.stub(),
+};
+
+describe('NetworkInstrumentation', () => {
+  let memoryExporter: InMemorySpanExporter;
+  let instrumentation: NetworkInstrumentation;
+  let diag: InMemoryDiagLogger;
+  let spanSessionManager: SpanSessionManager;
+
+  before(() => {
+    memoryExporter = setupTestTraceExporter();
+  });
+
+  beforeEach(() => {
+    memoryExporter.reset();
+    diag = new InMemoryDiagLogger();
+    spanSessionManager = new EmbraceSpanSessionManager({
+      limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+    });
+    session.setGlobalSessionManager(spanSessionManager);
+    spanSessionManager.startSessionSpan();
+  });
+
+  afterEach(() => {
+    instrumentation.disable();
+  });
+
+  it('should observe resource entries', () => {
+    const performanceObserverTester = setupPerformanceObserverTester();
+    instrumentation = new NetworkInstrumentation({
+      diag,
+      performanceObserverBuilder: performanceObserverTester.builder,
+    });
+
+    void expect(
+      performanceObserverTester.observerStub.observe.calledWith({
+        type: 'resource',
+        buffered: true,
+      })
+    ).to.be.true;
+  });
+
+  it('should add spans for observed performance resource timing entries', () => {
+    const performanceObserverTester = setupPerformanceObserverTester();
+
+    instrumentation = new NetworkInstrumentation({
+      diag,
+      performanceObserverBuilder: performanceObserverTester.builder,
+    });
+
+    expect(
+      performanceObserverTester.invokeCallback([
+        FETCH_SUCCESS_ENTRY,
+        XML_HTTP_REQUEST_SUCCESS_ENTRY,
+        FETCH_404_ENTRY,
+      ])
+    ).to.equal(true);
+
+    spanSessionManager.endSessionSpan();
+
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(4);
+
+    expect(finishedSpans[0].attributes).to.deep.equal({
+      'http.request.body.size': 0,
+      'http.request.method': 'GET',
+      'http.response.body.size': 453190,
+      'http.response.status_code': 200,
+      'url.full': 'https://pokeapi.co/api/v2/pokemon/1/',
+    });
+
+    expect(finishedSpans[1].attributes).to.deep.equal({
+      'http.request.body.size': 0,
+      'http.request.method': 'GET',
+      'http.response.body.size': 453190,
+      'http.response.status_code': 200,
+      'url.full': 'https://pokeapi.co/api/v2/pokemon/1/',
+    });
+
+    expect(finishedSpans[2].attributes).to.deep.equal({
+      'error.message': 'not found',
+      'error.type': 'not found',
+      'http.request.body.size': 0,
+      'http.request.method': 'GET',
+      'http.response.body.size': 335,
+      'http.response.status_code': 404,
+      'url.full': 'https://pokeapi.co/api/v2/pokemon/foo/',
+    });
+  });
+});

--- a/src/instrumentations/network/NetworkInstrumentation/NetworkInstrumentation.ts
+++ b/src/instrumentations/network/NetworkInstrumentation/NetworkInstrumentation.ts
@@ -1,0 +1,120 @@
+/*
+  This instrumentation is taking code from here as a starting point:
+    https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+ */
+
+import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.js';
+import type {
+  NetworkInstrumentationArgs,
+  PerformanceObserverCallbackWithOptions,
+} from './types.js';
+
+import {
+  ATTR_ERROR_TYPE,
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_URL_FULL,
+} from '@opentelemetry/semantic-conventions';
+
+import {
+  ATTR_HTTP_REQUEST_BODY_SIZE,
+  ATTR_HTTP_RESPONSE_BODY_SIZE,
+  ATTR_ERROR_MESSAGE,
+} from '@opentelemetry/semantic-conventions/incubating';
+
+const DEFAULT_PERFORMANCE_OBSERVER_CREATOR = (
+  callback: PerformanceObserverCallbackWithOptions
+) => {
+  if (typeof PerformanceObserver !== 'function') {
+    return undefined;
+  }
+
+  return new PerformanceObserver(callback);
+};
+
+export class NetworkInstrumentation extends EmbraceInstrumentationBase {
+  private readonly _performanceObserver: PerformanceObserver | undefined;
+
+  public constructor({
+    diag,
+    perf,
+    // TODO use ignoreURLS
+    ignoreUrls: _ignoreUrls,
+    performanceObserverBuilder = DEFAULT_PERFORMANCE_OBSERVER_CREATOR,
+  }: NetworkInstrumentationArgs = {}) {
+    super({
+      instrumentationName: 'NetworkInstrumentation',
+      instrumentationVersion: '1.0.0',
+      diag,
+      perf,
+      config: {},
+    });
+
+    this._performanceObserver = performanceObserverBuilder(
+      (
+        list: PerformanceObserverEntryList,
+        _observer: PerformanceObserver,
+        options?: { droppedEntriesCount: number }
+      ) => {
+        list.getEntriesByType('resource').forEach(entry => {
+          if (entry.entryType !== 'resource') {
+            return;
+          }
+
+          const resourceTimingEntry = entry as PerformanceResourceTiming;
+
+          if (
+            resourceTimingEntry.initiatorType !== 'fetch' &&
+            resourceTimingEntry.initiatorType !== 'xmlhttprequest'
+          ) {
+            return;
+          }
+
+          const networkSpan = this.tracer.startSpan(resourceTimingEntry.name, {
+            startTime: this.perf.epochMillisFromOriginOffset(
+              resourceTimingEntry.fetchStart
+            ),
+            attributes: {
+              [ATTR_URL_FULL]: resourceTimingEntry.name,
+              [ATTR_HTTP_REQUEST_METHOD]: 'unknown', // TODO no way to retrieve this
+              [ATTR_HTTP_RESPONSE_STATUS_CODE]:
+                resourceTimingEntry.responseStatus,
+              [ATTR_HTTP_REQUEST_BODY_SIZE]: 0, // TODO no way to retrieve this
+              [ATTR_HTTP_RESPONSE_BODY_SIZE]:
+                resourceTimingEntry.decodedBodySize,
+            },
+          });
+
+          if (resourceTimingEntry.responseStatus >= 400) {
+            networkSpan.setAttributes({
+              [ATTR_ERROR_MESSAGE]: 'unknown', // TODO no way to retrieve this
+              [ATTR_ERROR_TYPE]: 'unknown',
+            });
+          }
+
+          networkSpan.end(resourceTimingEntry.responseEnd);
+        });
+        if (options && options.droppedEntriesCount > 0) {
+          // TODO handle this? Emit a warning and include an attribute on session?
+        }
+      }
+    );
+
+    if (!this._performanceObserver) {
+      // TODO handle this? Emit a warning and include an attribute on session?
+      return;
+    }
+
+    if (this._config.enabled) {
+      this.enable();
+    }
+  }
+
+  public disable(): void {
+    this._performanceObserver?.disconnect();
+  }
+
+  public enable(): void {
+    this._performanceObserver?.observe({ type: 'resource', buffered: true });
+  }
+}

--- a/src/instrumentations/network/NetworkInstrumentation/index.ts
+++ b/src/instrumentations/network/NetworkInstrumentation/index.ts
@@ -1,0 +1,1 @@
+export { NetworkInstrumentation } from './NetworkInstrumentation.js';

--- a/src/instrumentations/network/NetworkInstrumentation/types.ts
+++ b/src/instrumentations/network/NetworkInstrumentation/types.ts
@@ -1,0 +1,21 @@
+import type { EmbraceInstrumentationBaseArgs } from '../../EmbraceInstrumentationBase/index.js';
+
+// PerformanceObserverCallback typing does not include the 3rd options argument but this should
+// be available as per https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/PerformanceObserver#dropped_buffer_entries
+export type PerformanceObserverCallbackOptions = {
+  droppedEntriesCount: number;
+};
+export type PerformanceObserverCallbackWithOptions = (
+  entries: PerformanceObserverEntryList,
+  observer: PerformanceObserver,
+  options?: PerformanceObserverCallbackOptions
+) => void;
+
+export type NetworkInstrumentationArgs = {
+  ignoreUrls?: Array<string | RegExp>;
+  // Useful for testing so that we can construct a PerformanceObserver where the entries surfaced are controlled by
+  // the test spec
+  performanceObserverBuilder?: (
+    callback: PerformanceObserverCallbackWithOptions
+  ) => PerformanceObserver | undefined;
+} & Pick<EmbraceInstrumentationBaseArgs, 'diag' | 'perf'>;

--- a/src/instrumentations/network/index.ts
+++ b/src/instrumentations/network/index.ts
@@ -1,0 +1,2 @@
+export { NetworkInstrumentation } from './NetworkInstrumentation/index.js';
+export type { NetworkInstrumentationArgs } from './NetworkInstrumentation/types.js';

--- a/src/sdk/initSDK.ts
+++ b/src/sdk/initSDK.ts
@@ -210,6 +210,7 @@ export const initSDK = (
         loggerProvider,
         instrumentations: [
           setupDefaultInstrumentations(defaultInstrumentationConfig, {
+            diagLogger,
             logManager: embraceLogManager,
             spanSessionManager,
           }),
@@ -219,7 +220,9 @@ export const initSDK = (
     } else {
       registerInstrumentations({
         instrumentations: [
-          setupDefaultInstrumentations(defaultInstrumentationConfig),
+          setupDefaultInstrumentations(defaultInstrumentationConfig, {
+            diagLogger,
+          }),
           ...instrumentations,
         ],
       });

--- a/src/sdk/setupDefaultInstrumentations.ts
+++ b/src/sdk/setupDefaultInstrumentations.ts
@@ -7,19 +7,29 @@ import {
   SpanSessionVisibilityInstrumentation,
   WebVitalsInstrumentation,
   ClicksInstrumentation,
+  NetworkInstrumentation,
   EmbraceInstrumentationBase,
 } from '../instrumentations/index.js';
 import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
-import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
-import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import type {
   DefaultInstrumentationConfig,
   SetupDefaultInstrumentationsArgs,
 } from './types.js';
+import { diag } from '@opentelemetry/api';
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
+import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 
 export const setupDefaultInstrumentations = (
   config: DefaultInstrumentationConfig = {},
-  { logManager, spanSessionManager }: SetupDefaultInstrumentationsArgs = {}
+  {
+    diagLogger,
+    logManager,
+    spanSessionManager,
+  }: SetupDefaultInstrumentationsArgs = {
+    diagLogger: diag.createComponentLogger({
+      namespace: 'embrace-sdk',
+    }),
+  }
 ): Instrumentation[] => {
   /*
     These instrumentations are core to managing the session lifecycle and so are not optional
@@ -53,20 +63,35 @@ export const setupDefaultInstrumentations = (
     );
   }
 
-  if (!config.omit?.has('@opentelemetry/instrumentation-fetch')) {
-    instrumentations.push(
-      new FetchInstrumentation({
-        ...config['network'],
-        ...config['@opentelemetry/instrumentation-fetch'],
-      })
+  if (
+    config['@opentelemetry/instrumentation-fetch'] ||
+    config['@opentelemetry/instrumentation-xml-http-request'] ||
+    config.omit?.has('@opentelemetry/instrumentation-fetch') ||
+    config.omit?.has('@opentelemetry/instrumentation-xml-http-request')
+  ) {
+    diagLogger.warn(
+      'configuration for "@opentelemetry/instrumentation-fetch" and "@opentelemetry/instrumentation-xml-http-request" are deprecated, please use "network" instead '
     );
   }
 
-  if (!config.omit?.has('@opentelemetry/instrumentation-xml-http-request')) {
+  if (
+    !config.omit?.has('@opentelemetry/instrumentation-fetch') &&
+    !config.omit?.has('@opentelemetry/instrumentation-xml-http-request') &&
+    !config.omit?.has('network')
+  ) {
+    instrumentations.push(
+      new NetworkInstrumentation({
+        ...config['network'],
+      })
+    );
+    instrumentations.push(
+      new FetchInstrumentation({
+        ...config['network'],
+      })
+    );
     instrumentations.push(
       new XMLHttpRequestInstrumentation({
         ...config['network'],
-        ...config['@opentelemetry/instrumentation-xml-http-request'],
       })
     );
   }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -15,6 +15,7 @@ import type { SpanSessionManager } from '../api-sessions/index.js';
 import type {
   ClicksInstrumentationArgs,
   GlobalExceptionInstrumentationArgs,
+  NetworkInstrumentationArgs,
   SpanSessionBrowserActivityInstrumentationArgs,
   SpanSessionOnLoadInstrumentationArgs,
   SpanSessionTimeoutInstrumentationArgs,
@@ -303,15 +304,13 @@ type OptionalInstrumentations =
   | 'exception'
   | 'click'
   | 'web-vital'
+  | 'network'
   | '@opentelemetry/instrumentation-document-load'
   | '@opentelemetry/instrumentation-fetch'
   | '@opentelemetry/instrumentation-xml-http-request';
 
-interface NetworkInstrumentationArgs {
-  ignoreUrls?: Array<string | RegExp>;
-}
-
 export interface SetupDefaultInstrumentationsArgs {
+  diagLogger: DiagLogger;
   logManager?: LogManager;
   spanSessionManager?: SpanSessionManager;
 }
@@ -325,9 +324,6 @@ export interface DefaultInstrumentationConfig {
   'session-visibility'?: SpanSessionVisibilityInstrumentationArgs;
   'session-activity'?: SpanSessionBrowserActivityInstrumentationArgs;
   'session-timeout'?: SpanSessionTimeoutInstrumentationArgs;
-
-  // Convenience to allow common config arguments for '@opentelemetry/instrumentation-fetch' and
-  // '@opentelemetry/instrumentation-xml-http-request' to just be specified once
   network?: NetworkInstrumentationArgs;
 
   /*
@@ -339,10 +335,18 @@ export interface DefaultInstrumentationConfig {
     DocumentLoadInstrumentationConfig,
     'enabled'
   >;
+
+  /*
+   * @deprecated 'network' instead
+   */
   '@opentelemetry/instrumentation-fetch'?: Omit<
     FetchInstrumentationConfig,
     'enabled'
   >;
+
+  /*
+   * @deprecated 'network' instead
+   */
   '@opentelemetry/instrumentation-xml-http-request'?: Omit<
     XMLHttpRequestInstrumentationConfig,
     'enabled'

--- a/src/testUtils/index.ts
+++ b/src/testUtils/index.ts
@@ -22,3 +22,4 @@ export { mockSpan } from './mockEntities/index.js';
 export { InMemoryStorage } from './InMemoryStorage/index.js';
 export { FailingStorage } from './FailingStorage/index.js';
 export { SAMPLED_UUID, NOT_SAMPLED_UUID } from './constants.js';
+export { setupPerformanceObserverTester } from './setupPerformanceObserverTester/index.js';

--- a/src/testUtils/setupPerformanceObserverTester/index.ts
+++ b/src/testUtils/setupPerformanceObserverTester/index.ts
@@ -1,0 +1,1 @@
+export { setupPerformanceObserverTester } from './setupPerformanceObserverTester.js';

--- a/src/testUtils/setupPerformanceObserverTester/setupPerformanceObserverTester.ts
+++ b/src/testUtils/setupPerformanceObserverTester/setupPerformanceObserverTester.ts
@@ -1,0 +1,35 @@
+import * as sinon from 'sinon';
+import type {
+  PerformanceObserverCallbackOptions,
+  PerformanceObserverCallbackWithOptions,
+} from '../../instrumentations/network/NetworkInstrumentation/types.js';
+
+export const setupPerformanceObserverTester = () => {
+  const observerStub = sinon.createStubInstance(PerformanceObserver);
+  let instrumentationCallback:
+    | PerformanceObserverCallbackWithOptions
+    | undefined = undefined;
+
+  return {
+    observerStub,
+    builder: (callback: PerformanceObserverCallbackWithOptions) => {
+      instrumentationCallback = callback;
+      return observerStub;
+    },
+    invokeCallback: (
+      entries: PerformanceEntry[],
+      options?: PerformanceObserverCallbackOptions
+    ) => {
+      if (!instrumentationCallback) {
+        return false;
+      }
+
+      const entryList = sinon.createStubInstance(PerformanceObserverEntryList, {
+        getEntriesByType: entries,
+      });
+
+      instrumentationCallback(entryList, observerStub, options);
+      return true;
+    },
+  };
+};


### PR DESCRIPTION
Putting this up for reference but doesn't seem like we can move forward with this as replacement for the existing network instrumentations:
* HTTP request method used is unavailable from PerformanceResourceTiming
* Request size is unavailable (current instrumentation doesn't report this by default but can be enabled)
* In the case of errors response status text is unavailable
* Status code is currently unavailable in Safari (https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus)
* Response size is unavailable if the request is CORS and `Timing-Allow-Origin` is not present