### PR TITLE
feat: add browser and default fields to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Embrace Web SDK",
   "type": "module",
   "jsdelivr": "build/iife/bundle.js",
-  "main": "build/src/index.js",
+  "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
-  "esnext": "build/esnext/index.js",
+  "browser": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "publishConfig": {
     "access": "public"
@@ -44,48 +44,38 @@
     "sdk:lint:prettier": "prettier --check .",
     "sdk:lint:prettier:fix": "prettier --write .",
     "sdk:lint:eslint": "eslint --max-warnings=0",
-    "sdk:lint:eslint:fix": "eslint --fix --max-warnings=0",
+    "sdk:lint:eslint:fix": "eslint --fix --max-warnings=0 --no-warn-ignored",
     "sdk:tsc:check": "tsc --build --noEmit tsconfig.json cli/tsconfig.json",
     "commitlint": "commitlint",
     "playwright": "playwright",
     "prepare": "if [ -d .git ]; then husky; fi"
   },
   "files": [
-    "build/esm/**/*.js",
-    "build/esm/**/*.js.map",
-    "build/esnext/**/*.js",
-    "build/esnext/**/*.js.map",
-    "build/src/**/*.js",
-    "build/src/**/*.js.map",
-    "build/iife/**/*.js",
-    "build/iife/**/*.js.map",
-    "build/types/**/*.d.ts",
-    "build/types/**/*.d.ts.map",
+    "build",
     "LICENSE",
     "*.md"
   ],
   "exports": {
     ".": {
-      "esnext": "./build/esnext/index.js",
-      "module": "./build/esm/index.js",
       "types": "./build/types/index.d.ts",
+      "browser": "./build/esm/index.js",
       "import": "./build/esm/index.js",
-      "require": "./build/src/index.js",
-      "default": "./build/src/index.js"
+      "require": "./build/cjs/index.js",
+      "default": "./build/esm/index.js"
     },
     "./react-instrumentation": {
-      "esnext": "./build/esnext/react-instrumentation.js",
-      "module": "./build/esm/react-instrumentation.js",
-      "types": "./build/types/react/index.d.ts",
+      "types": "./build/types/react-instrumentation/index.d.ts",
+      "browser": "./build/esm/react-instrumentation.js",
       "import": "./build/esm/react-instrumentation.js",
-      "require": "./build/src/react-instrumentation.js",
-      "default": "./build/src/react-instrumentation.js"
-    }
+      "require": "./build/cjs/react-instrumentation.js",
+      "default": "./build/esm/react-instrumentation.js"
+    },
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {
       "react-instrumentation": [
-        "build/types/react/index.d.ts"
+        "build/types/react-instrumentation/index.d.ts"
       ],
       "*": [
         "build/types/index.d.ts"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,7 @@ const isExternal = id =>
 
 const input = {
   index: 'src/index.ts',
-  'react-instrumentation': 'src/react/index.ts',
+  'react-instrumentation': 'src/react-instrumentation/index.ts',
 };
 
 // Suppress irrelevant warnings to keep the build output clean
@@ -54,7 +54,7 @@ const plugins = ({ target }) => [
     swc: {
       sourceMaps: true, // Generate source maps
       jsc: {
-        target, // Set JavaScript target version
+        target, // Set JavaScript output version
       },
     },
   }),
@@ -76,27 +76,12 @@ export default defineConfig([
     onwarn,
   },
 
-  // ESNext Build: No language coercion applied
-  {
-    input,
-    plugins: plugins({ target: 'esnext' }),
-    output: {
-      dir: 'build/esnext',
-      format: 'esm',
-      sourcemap: true,
-      preserveModules: true,
-      preserveModulesRoot: 'src',
-    },
-    external: isExternal,
-    onwarn,
-  },
-
   // CJS Build: CommonJS modules for older bundlers
   {
     input,
     plugins: plugins({ target: 'es2022' }),
     output: {
-      dir: 'build/src',
+      dir: 'build/cjs',
       format: 'cjs',
       sourcemap: true,
       preserveModules: true,

--- a/scripts/measureSize.ts
+++ b/scripts/measureSize.ts
@@ -6,9 +6,8 @@ import { createGzip } from 'node:zlib';
 
 const TARGET_DIRS = [
   { name: 'ESM', path: 'build/esm' },
-  { name: 'ESNext', path: 'build/esnext' },
-  { name: 'CJS (src)', path: 'build/src' },
-  { name: 'CDN script (iife)', path: 'build/iife' },
+  { name: 'CJS', path: 'build/cjs' },
+  { name: 'CDN bundle', path: 'build/iife' },
 ];
 
 const walkDir = (dir: string, ext = '.js'): string[] => {
@@ -49,7 +48,7 @@ const analyzeFolder = async (name: string, path: string) => {
     let totalRaw = 0;
     let totalGzip = 0;
 
-    console.log(`📂 ${name} — ${files.length} JS files`);
+    console.log(`📂 ${name} — ${files.length} js files`);
 
     for (const file of files) {
       const rawSize = getSize(file);

--- a/src/react-instrumentation/index.ts
+++ b/src/react-instrumentation/index.ts
@@ -1,5 +1,5 @@
-// Exposes all react specific instrumentation in a way that it is easy to tree-shake. Eventually this should be replaced by its own package.
-// That's why this rule don't apply here, and it will get fixed once we move this to its own package
+// Exposes all React-specific instrumentation in a way that is easy to tree-shake. Eventually this should be replaced by its own package.
+// That's why this rule doesn't apply here, and it will get fixed once we move this to its own package
 /* eslint-disable regex/invalid */
 import { withEmbraceRoutingLegacy } from '../instrumentations/navigation/NavigationInstrumentation/react/reactRouterV5/index.js';
 import { withEmbraceRouting } from '../instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Declarative/index.js';

--- a/tests/utils/json-to-markdown-table.ts
+++ b/tests/utils/json-to-markdown-table.ts
@@ -35,7 +35,7 @@ const resultsToMarkdownTable = (data: Record<string, Metric[]>): string => {
 
   // Make sure empty rows are handled correctly
   const bodyRows = rows
-    .map((row) => `| ${headers.map(header => row[header] ?? '').join(' | ')} |\n`)
+    .map(row => `| ${headers.map(header => row[header] ?? '').join(' | ')} |\n`)
     .join('');
 
   return `${headerRow}${separatorRow}${bodyRows}`;


### PR DESCRIPTION
## Goal

- Add browser field and export condition for better bundler compatibility
- Add engines field requiring Node.js 18+
- Add default export condition as fallback
- Move React instrumentation from src/react to src/react-instrumentation
- Update build to output CJS files to build/cjs/ instead of build/src/
- Remove esnext build target to simplify build pipeline
- Update measureSize script to work with new build structure

## Testing