### PR TITLE
chore(exports): add browser cjs export, use cjs extension in output

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Embrace Web SDK",
   "type": "module",
   "jsdelivr": "build/iife/bundle.js",
-  "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "browser": "build/esm/index.js",
+  "main": "build/cjs/index.cjs",
   "types": "build/types/index.d.ts",
   "publishConfig": {
     "access": "public"
@@ -60,15 +60,13 @@
       "types": "./build/types/index.d.ts",
       "browser": "./build/esm/index.js",
       "import": "./build/esm/index.js",
-      "require": "./build/cjs/index.js",
-      "default": "./build/esm/index.js"
+      "require": "./build/cjs/index.cjs"
     },
     "./react-instrumentation": {
       "types": "./build/types/react-instrumentation/index.d.ts",
       "browser": "./build/esm/react-instrumentation.js",
       "import": "./build/esm/react-instrumentation.js",
-      "require": "./build/cjs/react-instrumentation.js",
-      "default": "./build/esm/react-instrumentation.js"
+      "require": "./build/cjs/react-instrumentation.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Embrace Web SDK",
   "type": "module",
   "jsdelivr": "build/iife/bundle.js",
-  "module": "build/esm/index.js",
-  "browser": "build/esm/index.js",
-  "main": "build/cjs/index.cjs",
   "types": "build/types/index.d.ts",
+  "browser": "build/esm/index.js",
+  "module": "build/esm/index.js",
+  "main": "build/cjs/index.cjs",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -58,13 +58,19 @@
   "exports": {
     ".": {
       "types": "./build/types/index.d.ts",
-      "browser": "./build/esm/index.js",
+      "browser": {
+        "import": "./build/esm/index.js",
+        "require": "./build/cjs/index.cjs"
+      },
       "import": "./build/esm/index.js",
       "require": "./build/cjs/index.cjs"
     },
     "./react-instrumentation": {
       "types": "./build/types/react-instrumentation/index.d.ts",
-      "browser": "./build/esm/react-instrumentation.js",
+      "browser": {
+        "import": "./build/esm/react-instrumentation.js",
+        "require": "./build/cjs/react-instrumentation.cjs"
+      },
       "import": "./build/esm/react-instrumentation.js",
       "require": "./build/cjs/react-instrumentation.cjs"
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -76,7 +76,7 @@ export default defineConfig([
     onwarn,
   },
 
-  // CJS Build: CommonJS modules for older bundlers
+  // CJS Build: CommonJS modules for Next.js and webpack < 5
   {
     input,
     plugins: plugins({ target: 'es2022' }),
@@ -86,6 +86,8 @@ export default defineConfig([
       sourcemap: true,
       preserveModules: true,
       preserveModulesRoot: 'src',
+      entryFileNames: '[name].cjs',
+      chunkFileNames: '[name]-[hash].cjs',
     },
     external: isExternal,
     onwarn,


### PR DESCRIPTION
## Goal

1. Using .cjs extension is recommended for commonjs files in module packages. Bundlers are smart but this is a best practice.
2. Accommodate "browser" consumers that still use require()

## Testing

I recommend we merge this PR after https://github.com/embrace-io/embrace-web-sdk/pull/731 