### PR TITLE
chore: update sdk version in integration test goldens

### DIFF
--- a/tests/integration/tests/__golden__/chromium-next-latest-send-log.json
+++ b/tests/integration/tests/__golden__/chromium-next-latest-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/chromium-next-latest-session.json
+++ b/tests/integration/tests/__golden__/chromium-next-latest-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
@@ -787,7 +787,7 @@
             },
             {
               "traceId": "b2c0e277e6971085864dd2e919f3f0c2",
-              "spanId": "3ec0ebce168e20e5",
+              "spanId": "3ec0ebce2.0.00e5",
               "parentSpanId": "5384425937e7c22c",
               "name": "resourceFetch",
               "kind": 1,

--- a/tests/integration/tests/__golden__/chromium-vite-7-esnext-send-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-esnext-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/chromium-vite-7-esnext-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-esnext-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/chromium-webpack-5-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/chromium-webpack-5-es2015-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/chromium-webpack-5-es2015-session.json
+++ b/tests/integration/tests/__golden__/chromium-webpack-5-es2015-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/chromium-webpack-5-esnext-send-log.json
+++ b/tests/integration/tests/__golden__/chromium-webpack-5-esnext-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/chromium-webpack-5-esnext-session.json
+++ b/tests/integration/tests/__golden__/chromium-webpack-5-esnext-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/firefox-next-latest-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-next-latest-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/firefox-next-latest-session.json
+++ b/tests/integration/tests/__golden__/firefox-next-latest-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/firefox-vite-7-esnext-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-esnext-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/firefox-vite-7-esnext-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-esnext-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/firefox-webpack-5-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-webpack-5-es2015-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/firefox-webpack-5-es2015-session.json
+++ b/tests/integration/tests/__golden__/firefox-webpack-5-es2015-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/firefox-webpack-5-esnext-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-webpack-5-esnext-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/firefox-webpack-5-esnext-session.json
+++ b/tests/integration/tests/__golden__/firefox-webpack-5-esnext-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/webkit-next-latest-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-next-latest-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/webkit-next-latest-session.json
+++ b/tests/integration/tests/__golden__/webkit-next-latest-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/webkit-vite-7-esnext-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-esnext-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/webkit-vite-7-esnext-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-esnext-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/webkit-webpack-5-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-webpack-5-es2015-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/webkit-webpack-5-es2015-session.json
+++ b/tests/integration/tests/__golden__/webkit-webpack-5-es2015-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/webkit-webpack-5-esnext-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-webpack-5-esnext-send-log.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {

--- a/tests/integration/tests/__golden__/webkit-webpack-5-esnext-session.json
+++ b/tests/integration/tests/__golden__/webkit-webpack-5-esnext-session.json
@@ -30,13 +30,13 @@
           {
             "key": "sdk_version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {
             "key": "telemetry.sdk.version",
             "value": {
-              "stringValue": "1.8.2"
+              "stringValue": "2.0.0"
             }
           },
           {


### PR DESCRIPTION
Will revisit why the GHA for this isn't working, I ran the same line from it in order to generate this diff so the command itself seems fine: https://github.com/embrace-io/embrace-web-sdk/blob/56eded29c13851007b31df982502d8efeee857de/.github/workflows/release.yaml#L61