### PR TITLE
chore(test): ensure storage methods return null instead of undefined

### DIFF
--- a/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
+++ b/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
@@ -469,7 +469,7 @@ describe('EmbraceSpanSessionManager', () => {
     manager.addProperty(propertyKey, value);
 
     const storedValue = storage.getItem(attributeKey);
-    void expect(storedValue).to.be.undefined;
+    void expect(storedValue).to.be.null;
   });
 
   it('should not store permanent properties in localStorage that have been removed', () => {
@@ -488,11 +488,11 @@ describe('EmbraceSpanSessionManager', () => {
     manager.startSessionSpan();
     manager.removeProperty(propertyKey);
     const storedAttribute2 = storage.getItem(attributeKey);
-    void expect(storedAttribute2).to.be.undefined;
+    void expect(storedAttribute2).to.be.null;
     manager.endSessionSpan();
 
     const storedAttribute3 = storage.getItem(attributeKey);
-    void expect(storedAttribute3).to.be.undefined;
+    void expect(storedAttribute3).to.be.null;
   });
 
   it('should not persist session properties after session end', () => {

--- a/src/managers/EmbraceUserManager/EmbraceUserManager.test.ts
+++ b/src/managers/EmbraceUserManager/EmbraceUserManager.test.ts
@@ -55,7 +55,7 @@ describe('EmbraceUserManager', () => {
     expect(manager.getEmbraceUserId()).to.be.equal(VALID_UUID);
 
     manager.clearEmbraceUserId();
-    void expect(storage.getItem(EMBRACE_USER_ID_STORAGE_KEY)).to.be.undefined;
+    void expect(storage.getItem(EMBRACE_USER_ID_STORAGE_KEY)).to.be.null;
 
     // Since the user was cleared from storage a new ID should be generated for the next manager
     const nextManager = new EmbraceUserManager({ diag, storage });
@@ -117,7 +117,7 @@ describe('EmbraceUserManager', () => {
     );
     expect(manager.getEmbraceUserId()).to.equal(VALID_UUID);
     void expect(storage.getItem(EMBRACE_USER_STORAGE_KEY_DEPRECATED)).to.be
-      .undefined;
+      .null;
   });
 
   it('should get an external user id', () => {
@@ -149,8 +149,8 @@ describe('EmbraceUserManager', () => {
     );
 
     manager.clearUserId();
-    void expect(storage.getItem(EMBRACE_EXTERNAL_USER_ID_KEY)).to.be.undefined;
-    void expect(manager.getUserId()).to.be.undefined;
+    void expect(storage.getItem(EMBRACE_EXTERNAL_USER_ID_KEY)).to.be.null;
+    void expect(manager.getUserId()).to.be.null;
   });
 
   it('should handle getting an external user id when storage is failing', () => {

--- a/src/processors/EmbraceSessionBatchedSpanProcessor/EmbraceSessionBatchedSpanProcessor.test.ts
+++ b/src/processors/EmbraceSessionBatchedSpanProcessor/EmbraceSessionBatchedSpanProcessor.test.ts
@@ -352,7 +352,7 @@ describe('EmbraceSessionBatchedSpanProcessor', () => {
         expect(inMemoryStorage.length).to.equal(2);
         expect(
           inMemoryStorage.getItem('embrace_pending_session1_1000')
-        ).to.equal(undefined);
+        ).to.equal(null);
         expect(
           inMemoryStorage.getItem('embrace_pending_session2_1000')
         ).to.not.equal(null);
@@ -411,7 +411,7 @@ describe('EmbraceSessionBatchedSpanProcessor', () => {
         expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(2);
         expect(
           inMemoryStorage.getItem(`embrace_pending_expired_${pastTime}`)
-        ).to.equal(undefined);
+        ).to.equal(null);
       });
 
       it('should not export non-expired spans', () => {

--- a/src/testUtils/InMemoryStorage/InMemoryStorage.ts
+++ b/src/testUtils/InMemoryStorage/InMemoryStorage.ts
@@ -11,11 +11,11 @@ export class InMemoryStorage implements Storage {
   }
 
   public getItem(key: string): string | null {
-    return this._items[key];
+    return this._items[key] ?? null;
   }
 
   public key(index: number): string | null {
-    return Object.keys(this._items)[index];
+    return Object.keys(this._items)[index] ?? null;
   }
 
   public removeItem(key: string): void {


### PR DESCRIPTION
### Summary
Fix InMemoryStorage test utility to return `null` instead of `undefined`, matching the Web Storage API spec.

#### Changes
- Updated `InMemoryStorage.getItem()` and `key()` to return `null` for missing values
- Fixed test assertions expecting `undefined` to expect `null`

#### Impact
Test-only change. Ensures test environment accurately simulates browser Storage API behavior.