### PR TITLE
chore: lower node version requirement to v20 for cli

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -72,6 +72,6 @@
     "typescript-eslint": "8.41.0"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "typescript-eslint": "8.41.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=20.0.0"
       }
     },
     "demo/frontend": {


### PR DESCRIPTION
## Goal

Support older versions of node in cli

## Testing

```bash
❯ npm run demo:frontend:upload:sourcemaps:dry -- -p dist -a abcde -t c668afaf44f9090819df6d8690e1ecc7

> embrace-web-sdk-react-demo@0.0.1 demo:frontend:upload:sourcemaps:dry
> embrace-web-cli upload -d --app-version 0.0.1 -p dist -a abcde -t c668afaf44f9090819df6d8690e1ecc7

Found 4 JavaScript files in directory tree: dist
Processing dist/assets/index-hzLTV2wD.js and dist/assets/index-hzLTV2wD.js.map...
Using debugID 6ea96afb-962c-4470-90f4-21c7f87108d0 from sourceMap for dist/assets/index-hzLTV2wD.js
Dry run mode, not replacing the contents for dist/assets/index-hzLTV2wD.js and dist/assets/index-hzLTV2wD.js.map
Dry run, skipping upload
Uploaded dist/assets/index-hzLTV2wD.js and dist/assets/index-hzLTV2wD.js.map
Processing dist/assets/opentelemetry-BnU_jIoQ.js and dist/assets/opentelemetry-BnU_jIoQ.js.map...
Template App version not found in dist/assets/opentelemetry-BnU_jIoQ.js
Using debugID 4d25bb28-e398-4f96-9fb4-92ab05134d62 from sourceMap for dist/assets/opentelemetry-BnU_jIoQ.js
Dry run mode, not replacing the contents for dist/assets/opentelemetry-BnU_jIoQ.js and dist/assets/opentelemetry-BnU_jIoQ.js.map
Dry run, skipping upload
Uploaded dist/assets/opentelemetry-BnU_jIoQ.js and dist/assets/opentelemetry-BnU_jIoQ.js.map
Processing dist/assets/react-Ctiv0JXW.js and dist/assets/react-Ctiv0JXW.js.map...
Template App version not found in dist/assets/react-Ctiv0JXW.js
Using debugID 34600849-cff8-4abb-afc0-576a531218ad from sourceMap for dist/assets/react-Ctiv0JXW.js
Dry run mode, not replacing the contents for dist/assets/react-Ctiv0JXW.js and dist/assets/react-Ctiv0JXW.js.map
Dry run, skipping upload
Uploaded dist/assets/react-Ctiv0JXW.js and dist/assets/react-Ctiv0JXW.js.map
Processing dist/assets/vendor-BDFMIPNC.js and dist/assets/vendor-BDFMIPNC.js.map...
Template App version not found in dist/assets/vendor-BDFMIPNC.js
Using debugID 9711f358-e0d8-4ff7-9cac-9aceb797d83 from sourceMap for dist/assets/vendor-BDFMIPNC.js
Dry run mode, not replacing the contents for dist/assets/vendor-BDFMIPNC.js and dist/assets/vendor-BDFMIPNC.js.map
Dry run, skipping upload
Uploaded dist/assets/vendor-BDFMIPNC.js and dist/assets/vendor-BDFMIPNC.js.map
❯ node -v
v20.19.5
```
