### PR TITLE
fix: setup a StackContextManager on init by default

### DIFF
--- a/src/sdk/initSDK.test.ts
+++ b/src/sdk/initSDK.test.ts
@@ -111,6 +111,7 @@ describe('initSDK', () => {
     trace.disable();
     logs.disable();
     diag.disable();
+    context.disable();
     registry.clear();
   });
 
@@ -323,6 +324,40 @@ describe('initSDK', () => {
         })
       ).to.be.true;
     }
+  });
+
+  it('should setup a default context manager when none is provided', async () => {
+    const result = initSDK({
+      spanExporters: [spanExporter],
+    });
+    void expect(result).not.to.be.false;
+
+    trace.getTracer('test').startActiveSpan('my active span', active => {
+      trace.getTracer('test').startSpan('my child span').end();
+      trace
+        .getSpan(context.active())
+        ?.setAttribute('active-span-attribute', 'foo');
+      active.end();
+    });
+
+    if (result) {
+      await result.flush();
+    }
+
+    const finishedSpans = spanExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(2);
+    const active = finishedSpans[1];
+    const child = finishedSpans[0];
+
+    expect(active.name).to.be.equal('my active span');
+    expect(active.attributes['active-span-attribute']).to.be.equal('foo');
+    expect(child.name).to.be.equal('my child span');
+    expect(child.parentSpanContext?.traceId).to.be.equal(
+      active.spanContext().traceId
+    );
+    expect(child.parentSpanContext?.spanId).to.be.equal(
+      active.spanContext().spanId
+    );
   });
 
   describe('communication with Embrace', () => {

--- a/src/sdk/initSDK.ts
+++ b/src/sdk/initSDK.ts
@@ -7,11 +7,12 @@ import {
   BatchLogRecordProcessor,
   LoggerProvider,
 } from '@opentelemetry/sdk-logs';
-import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
 import {
+  StackContextManager,
   BatchSpanProcessor,
   WebTracerProvider,
 } from '@opentelemetry/sdk-trace-web';
+import type { SpanProcessor } from '@opentelemetry/sdk-trace-web';
 import { session } from '../api-sessions/index.js';
 import { user } from '../api-users/index.js';
 import {
@@ -343,7 +344,11 @@ const setupTraces = ({
   if (registerGlobally) {
     trace.setGlobalTraceManager(embraceTraceManager);
     tracerProvider.register({
-      contextManager,
+      // WebTracerProvider.register has different fallback behaviours depending on whether null or undefined is passed,
+      // be more explicit here and always supply a StackContextManager if the config did not specify one. If a user really
+      // wants to turn off context management they can pass a no-op manager explicitly:
+      // https://github.com/open-telemetry/opentelemetry-js/blob/4f0b6285af24b71a9fa022755aaa3b6a63ae5033/packages/opentelemetry-sdk-trace-web/src/WebTracerProvider.ts#L39
+      contextManager: contextManager || new StackContextManager(),
       propagator,
     });
   }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -85,7 +85,7 @@ type BaseSDKInitConfig = {
   /**
    * contextManager defines a custom context manager that will be attached to the TracerProvider setup by the SDK
    *
-   * **default**: null
+   * **default**: StackContextManager
    */
   contextManager?: ContextManager | null;
 


### PR DESCRIPTION
## Goal

Originally when a context manager was not specified in `initSDK` we were passing `undefined` to `WebTracerProvider.register`, this changed to `null` here: https://github.com/embrace-io/embrace-web-sdk/commit/b702d8d7#diff-9008c3bb87939b875b09be1754c1c62bd39282b15b15b359bb82df538a6db253L220

This had the effect of setting up a NoopContextManager instead of a StackContextManager. Changing our behaviour to setup a StackContextManager by default when nothing custom is passed to `initSDK` and adding a test that would have failed with the old logic