### PR TITLE
chore: force npm i to include linux entries

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 lockfile-version=3
+include=optional


### PR DESCRIPTION
## Goal

When updating node_modules, sometimes the linux entries are dropped.

## Testing

`npm run clean`
`rm package-lock.json`
`npm i` <-- without `--include=optional`

Lockfile includes linux entries.