### PR TITLE
chore: update testing otel version

### DIFF
--- a/src/sdk/initSDK.test.ts
+++ b/src/sdk/initSDK.test.ts
@@ -1503,7 +1503,7 @@ describe('initSDK', () => {
               test.networkType === 'fetch'
                 ? '@opentelemetry/instrumentation-fetch'
                 : '@opentelemetry/instrumentation-xml-http-request',
-            version: '0.204.0',
+            version: '0.205.0',
           }
         );
         expect(exportedSpans).to.have.lengthOf(1);


### PR DESCRIPTION
After the last OTel version bump, initSDK tests needed an update.