### PR TITLE
chore: remove dependabot wildcard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,9 @@ updates:
       - '/demo/frontend-cdn'
       - '/demo/webpack-example'
       - '/tests/integration'
-      - '/tests/integration/platforms/*'
+      - '/tests/integration/platforms/next-latest'
+      - '/tests/integration/platforms/vite-7'
+      - '/tests/integration/platforms/webpack-5'
       - '/tests/performance'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
Repair the dependabot config by removing the `*` and using explicit paths.