### PR TITLE
EMBR-8655 chore: avoid running under restricted protocols

### DIFF
--- a/src/sdk/initSDK.test.ts
+++ b/src/sdk/initSDK.test.ts
@@ -384,6 +384,35 @@ describe('initSDK', () => {
     );
   });
 
+  it('should not initialize on restricted protocols', () => {
+    const diagLogger = new InMemoryDiagLogger();
+    const result = initSDK({
+      appID: 'app12',
+      diagLogger,
+      // we can't easily override window.location.protocol for this test, instead
+      // leverage the fact we know it will run under http:
+      restrictedProtocols: new Set(['http:']),
+    });
+    void expect(result).to.be.false;
+
+    expect(diagLogger.getErrorLogs()).to.have.lengthOf(1);
+    expect(diagLogger.getErrorLogs()[0]).to.equal(
+      'failed to initialize the SDK: not initializing due to restricted protocol: http:'
+    );
+  });
+
+  it('should not initialize on file protocol by default', () => {
+    const spy = sinon.spy(Set.prototype, 'has').withArgs('http:');
+    const diagLogger = new InMemoryDiagLogger();
+    const result = initSDK({ appID: 'app12', diagLogger });
+
+    // ideally we would fake the protocol to be 'file:' but since we can't easily override window.location.protocol then
+    // just verify that the protocol was checked against the right default set
+    expect(spy.getCall(0).thisValue).to.deep.equal(new Set(['file:']));
+    void expect(result).not.to.be.false;
+    expect(diagLogger.getErrorLogs()).to.have.lengthOf(0);
+  });
+
   describe('communication with Embrace', () => {
     beforeEach(() => {
       fakeFetchInstall();

--- a/src/sdk/initSDK.ts
+++ b/src/sdk/initSDK.ts
@@ -90,6 +90,7 @@ export const initSDK = (
     dynamicSDKConfig,
     registerGlobally = true,
     blockNetworkSpanForwarding = false,
+    restrictedProtocols = new Set(['file:']),
   }: SDKInitConfig = { appID: '' }
 ): SDKControl | false => {
   try {
@@ -115,6 +116,12 @@ export const initSDK = (
     if (!sendingToEmbrace && !logExporters.length && !spanExporters.length) {
       throw new Error(
         'when the embrace appID is omitted then at least one logExporter or spanExporter must be set'
+      );
+    }
+
+    if (restrictedProtocols.has(window.location.protocol)) {
+      throw new Error(
+        `not initializing due to restricted protocol: ${window.location.protocol}`
       );
     }
 

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -204,6 +204,15 @@ type BaseSDKInitConfig = {
    * **default**: false
    */
   blockNetworkSpanForwarding?: boolean;
+
+  /**
+   * restrictedProtocols defines a set of protocols where the SDK should not operate. In `initSDK` if the current
+   * `window.location` is on one of these protocols the SDK will stop initialization. Note that when adding protocols
+   * the final ":" should be included as per https://developer.mozilla.org/en-US/docs/Web/API/URL/protocol
+   *
+   * **default**: new Set(['file:'])
+   */
+  restrictedProtocols?: Set<string>;
 };
 
 /*


### PR DESCRIPTION
## Goal

Adding a check to avoid running when the protocol is "file:", making this configurable in case anyone wants to override the default