### PR TITLE
fix: fallback to TEMPLATE_APP_VERSION when fetching remote config

### DIFF
--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,3 +1,3 @@
 export { getAppInstanceId } from './appInstanceId.js';
-export { SDK_VERSION } from './constants/index.js';
+export { SDK_VERSION, TEMPLATE_APP_VERSION } from './constants/index.js';
 export { getWebSDKResource } from './webSdkResource.js';

--- a/src/sdk/initSDK.test.ts
+++ b/src/sdk/initSDK.test.ts
@@ -1078,6 +1078,32 @@ describe('initSDK', () => {
       );
     });
 
+    it('should refresh the remote config using the template app version if one is not provided', () => {
+      fakeFetchRespondWith(
+        JSON.stringify({
+          threshold: 90,
+        })
+      );
+
+      const result = initSDK({
+        appID: 'abc12',
+        defaultInstrumentationConfig: {
+          omit: new Set([
+            // This instrumentation does its own patching of Fetch which interferes with our test stub
+            '@opentelemetry/instrumentation-fetch',
+            // Document load instrumentation generates a bunch of spans in this test environment
+            'document-load',
+          ]),
+        },
+      });
+      void expect(result).not.to.be.false;
+
+      void expect(fakeFetchWasCalled()).to.be.true;
+      expect(fakeFetchGetUrl()).to.contain(
+        'https://a-abc12.config.emb-api.com/v2/config?appId=abc12&osVersion=1&appVersion=EmbIOAppVersionX.X.X&deviceId='
+      );
+    });
+
     it('should disable the SDK', () => {
       const noOpLogManager = new NoOpLogManager();
       const noOpTraceManager = new NoOpTraceManager();

--- a/src/sdk/initSDK.ts
+++ b/src/sdk/initSDK.ts
@@ -39,7 +39,7 @@ import {
   UserLogRecordProcessor,
   UserSpanProcessor,
 } from '../processors/index.js';
-import { getWebSDKResource } from '../resources/index.js';
+import { getWebSDKResource, TEMPLATE_APP_VERSION } from '../resources/index.js';
 import { isValidAppID } from './utils.js';
 import { setupDefaultInstrumentations } from './setupDefaultInstrumentations.js';
 import { createSessionSpanProcessor } from '@opentelemetry/web-common';
@@ -144,7 +144,8 @@ export const initSDK = (
       providedDynamicSDKConfigManager ??
       new EmbraceDynamicConfigManager({
         appID,
-        appVersion,
+        appVersion:
+          appVersion || TEMPLATE_APP_VERSION.trim() || 'no-app-version',
         embraceConfigURL,
         defaultConfig: dynamicSDKConfig,
         deviceId: enduserPseudoID,


### PR DESCRIPTION
## Goal

We use the app version when constructing the URL for fetching remote config, however this can be omitted in `initSDK` and injected by the CLI instead. To cover this case fallback to `TEMPLATE_APP_VERSION.trim()` which is what we do in https://github.com/embrace-io/embrace-web-sdk/blob/ce9186df04617802137cb28e79808721cde24ba9/src/resources/webSdkResource.ts#L38