### PR TITLE
chore(cli): move validate script

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -13,7 +13,7 @@
     "prepublishOnly": "npm run compile && npm run validate",
     "clean": "npx rimraf dist",
     "compile": "tsc && tsup-node src/index.ts --no-config --format esm --clean",
-    "validate": "bash ../scripts/validate-cli.sh"
+    "validate": "bash scripts/validate-cli.sh"
   },
   "files": [
     "dist",

--- a/cli/scripts/validate-cli.sh
+++ b/cli/scripts/validate-cli.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-CLI_FILE="cli/dist/index.js"
+CLI_FILE="dist/index.js"
 
 SIZE=$(wc -c < "$CLI_FILE" | tr -d ' ')
 SIZE_KB=$((SIZE / 1024))
@@ -11,9 +11,8 @@ echo "🔍 Validating CLI build output..."
 
 # Run quick checks first (es-check and publint)
 echo "Running es-check and publint..."
-# Always run from root
 npx es-check es2022 "$CLI_FILE" --module --allow-hash-bang
-(cd cli && npx publint)
+npx publint
 echo "  ✅ ES compatibility and package checks passed"
 
 # 2. Verify CLI is executable
@@ -36,8 +35,8 @@ ORIG_DIR=$(pwd)
 cd $TEMP_DIR
 npm init -y --quiet > /dev/null 2>&1
 
-# Link the CLI locally from root/cli directory
-npm install "$ORIG_DIR/cli" --quiet 2>&1
+# Link the CLI locally
+npm install $ORIG_DIR --quiet 2>&1
 
 # 4. Check that CLI has required commands
 echo "Checking CLI commands..."
@@ -50,7 +49,5 @@ else
   echo "  X  No commands found in CLI help"
   exit 1
 fi
-
-cd "$ORIG_DIR"
 
 echo "✅ All CLI validations passed!"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "sdk:lint:eslint:fix": "eslint --fix --max-warnings=0 --no-warn-ignored",
     "sdk:tsc:check": "tsc --build --noEmit tsconfig.json cli/tsconfig.json",
     "sdk:validate": "bash scripts/validate-build.sh",
-    "cli:validate": "bash scripts/validate-cli.sh",
+    "cli:validate": "npm run validate --prefix cli",
     "commitlint": "commitlint",
     "playwright": "playwright",
     "prepare": "if [ -d .git ]; then husky; fi"


### PR DESCRIPTION
Move the validate cli script into the cli folder to make sure there are no path issues when run from root.