### PR TITLE
fix: try and address js/polynomial-redos warning

### DIFF
--- a/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
+++ b/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
@@ -101,7 +101,7 @@ describe('NavigationInstrumentation', () => {
   it('should clean up the path options from the route name if configured', () => {
     navigationInstrumentation = new NavigationInstrumentation({ diag });
     navigationInstrumentation.setCurrentRoute({
-      path: '/test/:time(hourly|daily|weekly|monthly)',
+      path: '/test/:time(hourly|daily|weekly|monthly)/:type(typeA|typeB)',
       url: '/test/hourly',
     });
 
@@ -114,10 +114,10 @@ describe('NavigationInstrumentation', () => {
     expect(finishedSpans).to.have.lengthOf(1);
 
     const span = finishedSpans[0];
-    expect(span.name).to.equal('/test/:time');
+    expect(span.name).to.equal('/test/:time/:type');
     expect(span.attributes).to.deep.equal({
       'emb.type': 'ux.view',
-      'view.name': '/test/:time',
+      'view.name': '/test/:time/:type',
     });
   });
 

--- a/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
+++ b/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
@@ -11,8 +11,8 @@ import type { EMB_NAVIGATION_INSTRUMENTATIONS } from '../../../constants/index.j
 
 // Regular expression to match path options in the format "(option)"
 // Used to clean up paths that are like "/order/:orderState(pending|shipped|delivered)/type:(sale|normal)" to "/order/:orderState/:type"
-// Add a lookahead to prevent: https://javascript.info/regexp-catastrophic-backtracking
-const PATH_OPTIONS_RE = /\((?=[^(]*\))[^(]*\)/g;
+// Could be simplified but done this way to prevent: https://javascript.info/regexp-catastrophic-backtracking
+const PATH_OPTIONS_RE = /\([^()]+\)/g;
 
 export class NavigationInstrumentation extends EmbraceInstrumentationBase {
   private readonly _shouldCleanupPathOptionsFromRouteName: boolean = true;

--- a/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
+++ b/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
@@ -11,7 +11,8 @@ import type { EMB_NAVIGATION_INSTRUMENTATIONS } from '../../../constants/index.j
 
 // Regular expression to match path options in the format "(option)"
 // Used to clean up paths that are like "/order/:orderState(pending|shipped|delivered)/type:(sale|normal)" to "/order/:orderState/:type"
-const PATH_OPTIONS_RE = /\([^(].*?\)/g;
+// Add a lookahead to prevent: https://javascript.info/regexp-catastrophic-backtracking
+const PATH_OPTIONS_RE = /\((?=[^(]*\))[^(]*\)/g;
 
 export class NavigationInstrumentation extends EmbraceInstrumentationBase {
   private readonly _shouldCleanupPathOptionsFromRouteName: boolean = true;

--- a/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
+++ b/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
@@ -10,8 +10,8 @@ import {
 import type { EMB_NAVIGATION_INSTRUMENTATIONS } from '../../../constants/index.js';
 
 // Regular expression to match path options in the format "(option)"
-// Used to clean up paths that are like "/order/:orderState(pending|shipped|delivered)" to "/order/:orderState"
-const PATH_OPTIONS_RE = /\(.*?\)/g;
+// Used to clean up paths that are like "/order/:orderState(pending|shipped|delivered)/type:(sale|normal)" to "/order/:orderState/:type"
+const PATH_OPTIONS_RE = /\([^(].*?\)/g;
 
 export class NavigationInstrumentation extends EmbraceInstrumentationBase {
   private readonly _shouldCleanupPathOptionsFromRouteName: boolean = true;


### PR DESCRIPTION
## Goal

Trying to address: https://github.com/embrace-io/embrace-web-sdk/security/code-scanning/37

I'm not quite sure how to change this regex into a version that doesn't trigger the warning but was going to give this as a first try since it makes the regex more specific while preserving the behaviour. Another suggestion from the issue to try if this doesn't work is checking that `route.path` is some reasonable length like < 1000