### PR TITLE
EMBR-7381 feat: introduce instrumentation for detecting empty root nodes

### DIFF
--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -65,6 +65,7 @@ const App = () => {
         updateCrossTabData();
       }, 1000)
     );
+
     return () => {
       window.clearInterval(sessionRefresher);
       window.removeEventListener('storage', handleStorageChange);
@@ -522,15 +523,19 @@ const App = () => {
         </fieldset>
 
         <fieldset>
-          <legend>React Error Boundary</legend>
-          <div className={styles.actions}>
-            <button onClick={() => window.location.reload()}>
-              Trigger a render error inside EmbraceErrorBoundary
-            </button>
+          <legend>React Render Errors</legend>
+
+          <div>
+            <label>Inside an error boundary:</label>
+            <EmbraceErrorBoundary fallback={() => 'This is the fallback'}>
+              <ComponentWithErrorInRender />
+            </EmbraceErrorBoundary>
           </div>
-          <EmbraceErrorBoundary fallback={() => 'This is the fallback'}>
+
+          <div>
+            <label>Outside an error boundary:</label>
             <ComponentWithErrorInRender />
-          </EmbraceErrorBoundary>
+          </div>
         </fieldset>
       </div>
     );

--- a/demo/frontend/src/ComponentWithErrorInRender.tsx
+++ b/demo/frontend/src/ComponentWithErrorInRender.tsx
@@ -7,7 +7,7 @@ const ComponentWithErrorInRender = () => {
 
   return (
     <button onClick={() => setValue(-1)}>
-      Trigger a render error inside EmbraceErrorBoundary
+      Trigger a render error
       {/* @ts-ignore */}
       {value === -1 && someArray[value].some.property}
     </button>

--- a/demo/frontend/src/otel.ts
+++ b/demo/frontend/src/otel.ts
@@ -2,6 +2,7 @@ import { initSDK, user } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-web';
 import { createReactRouterNavigationInstrumentation } from '@embrace-io/web-sdk/react-instrumentation';
+import { DiagLogLevel } from '@opentelemetry/api';
 
 const SAMPLE_APP_ID = import.meta.env.VITE_APP_ID;
 const DATA_URL = import.meta.env.VITE_DATA_URL;
@@ -17,7 +18,9 @@ const setupOTel = () => {
       'session-visibility': {
         limitedSessionMaxDurationMs: 3000,
       },
+      extra: new Set(['empty-root']),
     },
+    logLevel: DiagLogLevel.DEBUG,
     instrumentations: [createReactRouterNavigationInstrumentation()],
     embraceDataURL: DATA_URL ?? undefined,
     embraceConfigURL: CONFIG_URL ?? undefined,

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -3,4 +3,5 @@ export type {
   URLDocument,
   PathnameDocument,
   AttributeScrubber,
+  BodyDocument,
 } from './types.js';

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -13,6 +13,11 @@ export interface PathnameDocument {
   pathname: string;
 }
 
+// Useful for testing so that we can pass in a document-like object and change its body
+export interface BodyDocument {
+  body: HTMLElement;
+}
+
 export interface AttributeScrubber {
   key: string;
   scrub: (value: string) => string;

--- a/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
+++ b/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
@@ -1,0 +1,226 @@
+import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
+import * as chai from 'chai';
+import { session } from '../../../api-sessions/index.js';
+import type { SpanSessionManager } from '../../../api-sessions/index.js';
+import {
+  DEFAULT_LIMITS,
+  EmbraceLimitManager,
+  EmbraceSpanSessionManager,
+} from '../../../managers/index.js';
+import {
+  InMemoryDiagLogger,
+  setupTestTraceExporter,
+} from '../../../testUtils/index.js';
+import { EmptyRootInstrumentation } from './EmptyRootInstrumentation.js';
+
+const { expect } = chai;
+
+describe('EmptyInstrumentation', () => {
+  let memoryExporter: InMemorySpanExporter;
+  let instrumentation: EmptyRootInstrumentation;
+  let diag: InMemoryDiagLogger;
+  let spanSessionManager: SpanSessionManager;
+  let testContainer: HTMLElement;
+
+  before(() => {
+    memoryExporter = setupTestTraceExporter();
+  });
+
+  beforeEach(() => {
+    memoryExporter.reset();
+    diag = new InMemoryDiagLogger();
+    spanSessionManager = new EmbraceSpanSessionManager({
+      limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+    });
+    session.setGlobalSessionManager(spanSessionManager);
+    spanSessionManager.startSessionSpan();
+    testContainer = document.createElement('div');
+    document.body.append(testContainer);
+  });
+
+  afterEach(() => {
+    instrumentation.disable();
+    testContainer.remove();
+  });
+
+  it('should add a span event to the session when the root node becomes empty', async () => {
+    const rootNode = document.createElement('div');
+    const child1 = document.createElement('div');
+    const child2 = document.createElement('div');
+
+    rootNode.append(child1, child2);
+    testContainer.append(rootNode);
+
+    instrumentation = new EmptyRootInstrumentation({
+      diag,
+      bodyDoc: { body: testContainer },
+      emptyCheckDelay: 10,
+    });
+
+    // Clear out the root node
+    child1.remove();
+    child2.remove();
+
+    // Yield so that the mutation observer callbacks can trigger
+    await new Promise(r => setTimeout(r, 1));
+
+    // The instrumentation shouldn't immediately emit the event
+    spanSessionManager.endSessionSpan();
+
+    let finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    let sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(0);
+    memoryExporter.reset();
+
+    spanSessionManager.startSessionSpan();
+
+    await new Promise(r => setTimeout(r, 20));
+
+    // Should now emit if the node is still empty after the timeout
+    spanSessionManager.endSessionSpan();
+    finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(1);
+
+    const event = sessionSpan.events[0];
+    expect(event.name).to.be.equal('empty-root-node');
+    expect(event.attributes).to.deep.equal({
+      'emb.type': 'empty-root-node',
+    });
+  });
+
+  it('should not emit if the root node was not fully emptied', async () => {
+    const rootNode = document.createElement('div');
+    const child1 = document.createElement('div');
+    const child2 = document.createElement('div');
+
+    rootNode.append(child1, child2);
+    testContainer.append(rootNode);
+
+    instrumentation = new EmptyRootInstrumentation({
+      diag,
+      bodyDoc: { body: testContainer },
+      emptyCheckDelay: 10,
+    });
+
+    child1.remove();
+
+    // Yield so that the mutation observer callbacks can trigger
+    await new Promise(r => setTimeout(r, 1));
+
+    // Wait for the empty check to be performed
+    await new Promise(r => setTimeout(r, 20));
+
+    // Should not emit the event
+    spanSessionManager.endSessionSpan();
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(0);
+  });
+
+  it('should not emit if the root node was populated after being emptied', async () => {
+    const rootNode = document.createElement('div');
+    const child1 = document.createElement('div');
+    const child2 = document.createElement('div');
+
+    rootNode.append(child1, child2);
+    testContainer.append(rootNode);
+
+    instrumentation = new EmptyRootInstrumentation({
+      diag,
+      bodyDoc: { body: testContainer },
+      emptyCheckDelay: 10,
+    });
+
+    child1.remove();
+    child2.remove();
+
+    // Yield so that the mutation observer callbacks can trigger
+    await new Promise(r => setTimeout(r, 1));
+
+    rootNode.append(child1);
+
+    // Wait for the empty check to be performed
+    await new Promise(r => setTimeout(r, 20));
+
+    // Should not emit the event
+    spanSessionManager.endSessionSpan();
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(0);
+  });
+
+  it('should do nothing if the root node could not be determined', async () => {
+    const child1 = document.createElement('div');
+    const child2 = document.createElement('div');
+
+    testContainer.append(child1, child2);
+
+    instrumentation = new EmptyRootInstrumentation({
+      diag,
+      bodyDoc: { body: testContainer },
+      emptyCheckDelay: 10,
+    });
+
+    expect(diag.getDebugLogs()).to.deep.equal([
+      'body did not have exactly one child, could not determine root node',
+    ]);
+
+    child1.remove();
+    child2.remove();
+
+    // Yield so that the mutation observer callbacks can trigger
+    await new Promise(r => setTimeout(r, 1));
+
+    // Wait for the empty check to be performed
+    await new Promise(r => setTimeout(r, 20));
+
+    // Should not emit the event
+    spanSessionManager.endSessionSpan();
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(0);
+  });
+
+  it('should allow the root node to be specified explicitly', async () => {
+    const child1 = document.createElement('div');
+    const child2 = document.createElement('div');
+    const child3 = document.createElement('div');
+
+    child1.append(child3);
+    testContainer.append(child1, child2);
+
+    instrumentation = new EmptyRootInstrumentation({
+      diag,
+      bodyDoc: { body: testContainer },
+      emptyCheckDelay: 10,
+      rootNode: child1,
+    });
+
+    child3.remove();
+
+    // Yield so that the mutation observer callbacks can trigger
+    await new Promise(r => setTimeout(r, 1));
+
+    // Wait for the empty check to be performed
+    await new Promise(r => setTimeout(r, 20));
+
+    // Should emit the event
+    spanSessionManager.endSessionSpan();
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.events).to.have.lengthOf(1);
+
+    const event = sessionSpan.events[0];
+    expect(event.name).to.be.equal('empty-root-node');
+    expect(event.attributes).to.deep.equal({
+      'emb.type': 'empty-root-node',
+    });
+  });
+});

--- a/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.ts
+++ b/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.ts
@@ -1,0 +1,125 @@
+import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.js';
+import type { EmptyRootInstrumentationArgs } from './types.js';
+import type { BodyDocument } from '../../../common/index.js';
+
+/*
+  EmptyRootInstrumentation observes changes to what is considered the root node of the application and emits a span
+  event on the session span if it ever finds it empty. The root node is either passed in explicitly or attempted to
+  be determined heuristically from the document
+ */
+export class EmptyRootInstrumentation extends EmbraceInstrumentationBase {
+  private readonly _observer: MutationObserver;
+  private readonly _bodyDoc: BodyDocument;
+  private readonly _emptyCheckDelay: number;
+  private _rootNode: Node | null = null;
+
+  public constructor({
+    diag,
+    perf,
+    rootNode,
+    bodyDoc = window.document,
+    emptyCheckDelay = 500,
+  }: EmptyRootInstrumentationArgs = {}) {
+    super({
+      instrumentationName: 'EmptyRootInstrumentation',
+      instrumentationVersion: '1.0.0',
+      diag,
+      perf,
+      config: {},
+    });
+    this._bodyDoc = bodyDoc;
+    this._emptyCheckDelay = emptyCheckDelay;
+
+    this._observer = new MutationObserver(
+      (mutationList: MutationRecord[], _observer: MutationObserver) => {
+        this._observerCallback(mutationList);
+      }
+    );
+
+    if (rootNode) {
+      this._diag.debug('using user supplied root node');
+      this._rootNode = rootNode;
+    }
+
+    if (this._config.enabled) {
+      this.enable();
+    }
+  }
+
+  public disable(): void {
+    this._observer.disconnect();
+  }
+
+  public enable(): void {
+    this._determineRootNode();
+
+    if (this._rootNode) {
+      this._observer.observe(this._rootNode, { childList: true });
+    }
+  }
+
+  protected _determineRootNode(): void {
+    if (this._rootNode) {
+      return;
+    }
+
+    const bodyChildren = this._bodyDoc.body.children;
+    if (bodyChildren.length === 1) {
+      this._diag.debug(
+        'body had exactly one child, considering this to be the root node'
+      );
+      this._rootNode = bodyChildren[0];
+    } else {
+      this._diag.debug(
+        'body did not have exactly one child, could not determine root node'
+      );
+    }
+  }
+
+  protected _observerCallback(mutationList: MutationRecord[]): void {
+    if (!this._rootNode) {
+      return;
+    }
+
+    let removedNodesFromRoot = false;
+    let addedNodesToRoot = false;
+
+    for (const mutation of mutationList) {
+      if (mutation.target === this._rootNode) {
+        if (mutation.removedNodes.length) {
+          removedNodesFromRoot = true;
+        }
+
+        if (mutation.addedNodes.length) {
+          addedNodesToRoot = true;
+        }
+      }
+    }
+
+    if (removedNodesFromRoot && !addedNodesToRoot) {
+      this._diag.debug(
+        'root node had child nodes removed without new ones being added, ' +
+          `checking if it's empty in ${this._emptyCheckDelay}ms`
+      );
+
+      window.setTimeout(() => {
+        this._checkForEmptyRootNode();
+      }, this._emptyCheckDelay);
+    }
+  }
+
+  protected _checkForEmptyRootNode(): void {
+    if (!this._rootNode?.childNodes.length) {
+      this._diag.debug('root node was found to be empty');
+
+      const currentSessionSpan = this.sessionManager.getSessionSpan();
+      if (currentSessionSpan) {
+        currentSessionSpan.addEvent('empty-root-node', {
+          'emb.type': 'empty-root-node',
+        });
+      } else {
+        this._diag.debug('no active session found to emit event on');
+      }
+    }
+  }
+}

--- a/src/instrumentations/empty-root/EmptyRootInstrumentation/index.ts
+++ b/src/instrumentations/empty-root/EmptyRootInstrumentation/index.ts
@@ -1,0 +1,1 @@
+export { EmptyRootInstrumentation } from './EmptyRootInstrumentation.js';

--- a/src/instrumentations/empty-root/EmptyRootInstrumentation/types.ts
+++ b/src/instrumentations/empty-root/EmptyRootInstrumentation/types.ts
@@ -1,0 +1,8 @@
+import type { EmbraceInstrumentationBaseArgs } from '../../EmbraceInstrumentationBase/index.js';
+import type { BodyDocument } from '../../../common/index.js';
+
+export type EmptyRootInstrumentationArgs = {
+  rootNode?: Node;
+  bodyDoc?: BodyDocument;
+  emptyCheckDelay?: number;
+} & Pick<EmbraceInstrumentationBaseArgs, 'diag' | 'perf'>;

--- a/src/instrumentations/empty-root/index.ts
+++ b/src/instrumentations/empty-root/index.ts
@@ -1,0 +1,2 @@
+export { EmptyRootInstrumentation } from './EmptyRootInstrumentation/index.js';
+export type { EmptyRootInstrumentationArgs } from './EmptyRootInstrumentation/types.js';

--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -34,3 +34,5 @@ export { EmbraceInstrumentationBase } from './EmbraceInstrumentationBase/index.j
 export { getNavigationInstrumentation } from './navigation/index.js';
 export { DocumentLoadInstrumentation } from '../instrumentations/document-load/index.js';
 export type { DocumentLoadInstrumentationConfig } from '../instrumentations/document-load/index.js';
+export { EmptyRootInstrumentation } from '../instrumentations/empty-root/index.js';
+export type { EmptyRootInstrumentationArgs } from '../instrumentations/empty-root/index.js';

--- a/src/sdk/setupDefaultInstrumentations.ts
+++ b/src/sdk/setupDefaultInstrumentations.ts
@@ -5,6 +5,7 @@ import {
   EmbraceFetchInstrumentation,
   EmbraceInstrumentationBase,
   EmbraceXHRInstrumentation,
+  EmptyRootInstrumentation,
   GlobalExceptionInstrumentation,
   SpanSessionBrowserActivityInstrumentation,
   SpanSessionOnLoadInstrumentation,
@@ -74,6 +75,10 @@ export const setupDefaultInstrumentations = (
         ...config['@opentelemetry/instrumentation-xml-http-request'],
       })
     );
+  }
+
+  if (config.extra?.has('empty-root')) {
+    instrumentations.push(new EmptyRootInstrumentation(config['empty-root']));
   }
 
   for (const instrumentation of instrumentations) {

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -18,6 +18,7 @@ import type {
   DocumentLoadInstrumentationConfig,
   EmbraceFetchInstrumentationArgs,
   EmbraceXHRInstrumentationArgs,
+  EmptyRootInstrumentationArgs,
   GlobalExceptionInstrumentationArgs,
   SpanSessionBrowserActivityInstrumentationArgs,
   SpanSessionOnLoadInstrumentationArgs,
@@ -321,6 +322,8 @@ type OptionalInstrumentations =
   | '@opentelemetry/instrumentation-fetch'
   | '@opentelemetry/instrumentation-xml-http-request';
 
+type ExtraInstrumentations = 'empty-root';
+
 interface NetworkInstrumentationArgs {
   ignoreUrls?: Array<string | RegExp>;
 }
@@ -333,6 +336,7 @@ export interface SetupDefaultInstrumentationsArgs {
 
 export interface DefaultInstrumentationConfig {
   omit?: Set<OptionalInstrumentations>;
+  extra?: Set<ExtraInstrumentations>;
   exception?: GlobalExceptionInstrumentationArgs;
   click?: ClicksInstrumentationArgs;
   'web-vital'?: WebVitalsInstrumentationArgs;
@@ -341,6 +345,7 @@ export interface DefaultInstrumentationConfig {
   'session-activity'?: SpanSessionBrowserActivityInstrumentationArgs;
   'session-timeout'?: SpanSessionTimeoutInstrumentationArgs;
   'document-load'?: DocumentLoadInstrumentationConfig;
+  'empty-root'?: EmptyRootInstrumentationArgs;
 
   // Convenience to allow common config arguments for '@opentelemetry/instrumentation-fetch' and
   // '@opentelemetry/instrumentation-xml-http-request' to just be specified once


### PR DESCRIPTION
## Goal

Attempting to add another signal that could be used for determining impact of an exception. This instrumentation tries to check for a situation where a page looks blank because of an uncaught rendering error in an SPA that cleared out all elements on the page. If not explicitly specified the assumption here is that there would be a single element on the `body` that the SPA is using to render the application e.g.:
```
createRoot(document.getElementById('root')!).render(
  <StrictMode>
    <App />
  </StrictMode>
);
```

Other options considered:
* Checking Performance API for a re-paint that cleared the page visually
  * There are paint entries available but these are limited to just first-paint, fcp, lcp
* Checking if `document.body.innerText.length` is below a minimum threshold
  * Could potentially work, it seems like `innerText` is maybe a bit too slow to do often since it requires some amount of parsing the DOM
* Have the existing `GlobalExceptionInstrumentation` check the root node and include an attribute on exceptions for whether it was empty or not
  * Could work in addition to this

Example from the demo:
![embrace](https://github.com/user-attachments/assets/dacd14ff-f55c-407e-ae32-9365d9ea5ef7)