### PR TITLE
feat(session): properly handle back-forward cache (bfcache) transitions

### DIFF
--- a/packages/web-sdk/src/api-sessions/manager/types.ts
+++ b/packages/web-sdk/src/api-sessions/manager/types.ts
@@ -39,7 +39,8 @@ export type ReasonSessionEnded =
   | 'timer' // max_time_reached limit
   | 'manual' // using the public api
   | 'max_size_reached'
-  | 'state_changed'; // visibility change
+  | 'state_changed' // visibility change
+  | 'bfcache'; // page entering back-forward cache
 
 export type PropertyOptions = {
   lifespan?: 'permanent';

--- a/packages/web-sdk/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.test.ts
@@ -397,4 +397,119 @@ describe('SpanSessionVisibilityInstrumentation', () => {
       'Tab visibility changed to hidden',
     );
   });
+
+  // bfcache coordination tests
+  describe('bfcache coordination', () => {
+    it('should skip visibility change handling after bfcache restoration', () => {
+      const visibilityDoc: VisibilityStateDocument = {
+        visibilityState: 'hidden',
+      };
+
+      instrumentation = new SpanSessionVisibilityInstrumentation(
+        {
+          visibilityDoc,
+        },
+        createMockSDKFeaturesManager(false),
+      );
+
+      // Simulate pageshow with persisted=true (bfcache restoration)
+      // This will trigger the session manager to start a new session
+      const pageshowEvent = new PageTransitionEvent('pageshow', {
+        persisted: true,
+      });
+      window.dispatchEvent(pageshowEvent);
+
+      // Capture the session ID after bfcache restoration
+      const sessionId = spanSessionManager.getSessionId();
+      void expect(sessionId).to.not.be.null;
+
+      // Now simulate visibilitychange to visible (which normally follows pageshow)
+      visibilityDoc.visibilityState = 'visible';
+      window.dispatchEvent(new Event('visibilitychange'));
+
+      // The session should NOT have been ended and restarted
+      // (same session ID means visibility instrumentation skipped handling)
+      expect(spanSessionManager.getSessionId()).to.equal(sessionId);
+    });
+
+    it('should NOT skip visibility change when pageshow has persisted=false', () => {
+      const visibilityDoc: VisibilityStateDocument = {
+        visibilityState: 'hidden',
+      };
+
+      instrumentation = new SpanSessionVisibilityInstrumentation(
+        {
+          visibilityDoc,
+        },
+        createMockSDKFeaturesManager(false),
+      );
+
+      // Start a session
+      spanSessionManager.startSessionSpan();
+      const sessionId = spanSessionManager.getSessionId();
+      void expect(sessionId).to.not.be.null;
+
+      // Simulate pageshow with persisted=false (normal navigation, not bfcache)
+      const pageshowEvent = new PageTransitionEvent('pageshow', {
+        persisted: false,
+      });
+      window.dispatchEvent(pageshowEvent);
+
+      // Now simulate visibilitychange to visible
+      visibilityDoc.visibilityState = 'visible';
+      window.dispatchEvent(new Event('visibilitychange'));
+
+      // The session SHOULD have been ended and a new one started
+      expect(spanSessionManager.getSessionId()).to.not.equal(sessionId);
+
+      // Verify session was ended with state_changed reason
+      const finishedSpans = memoryExporter.getFinishedSpans();
+      expect(finishedSpans.length).to.be.greaterThan(0);
+      const endedSession = finishedSpans.find(
+        (span) =>
+          span.attributes[KEY_EMB_SESSION_REASON_ENDED] === 'state_changed',
+      );
+      void expect(endedSession).to.not.be.undefined;
+    });
+
+    it('should only skip one visibility change after bfcache restoration', () => {
+      const visibilityDoc: VisibilityStateDocument = {
+        visibilityState: 'hidden',
+      };
+
+      instrumentation = new SpanSessionVisibilityInstrumentation(
+        {
+          visibilityDoc,
+        },
+        createMockSDKFeaturesManager(false),
+      );
+
+      // Simulate bfcache restoration - session manager starts a new session
+      const pageshowEvent = new PageTransitionEvent('pageshow', {
+        persisted: true,
+      });
+      window.dispatchEvent(pageshowEvent);
+
+      // Capture the session ID after bfcache restoration
+      const sessionId = spanSessionManager.getSessionId();
+      void expect(sessionId).to.not.be.null;
+
+      // First visibility change should be skipped
+      visibilityDoc.visibilityState = 'visible';
+      window.dispatchEvent(new Event('visibilitychange'));
+      expect(spanSessionManager.getSessionId()).to.equal(sessionId);
+
+      // Second visibility change should NOT be skipped
+      visibilityDoc.visibilityState = 'hidden';
+      window.dispatchEvent(new Event('visibilitychange'));
+
+      // Session should have ended - find the span with state_changed reason
+      const finishedSpans = memoryExporter.getFinishedSpans();
+      const endedSession = finishedSpans.find(
+        (span) =>
+          span.attributes[KEY_EMB_SESSION_REASON_ENDED] === 'state_changed',
+      );
+      void expect(endedSession).to.not.be.undefined;
+    });
+  });
 });

--- a/packages/web-sdk/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.ts
@@ -15,11 +15,14 @@ export class SpanSessionVisibilityInstrumentation extends EmbraceInstrumentation
   private _currentVisibilityState: DocumentVisibilityState;
   private _checkVisibilityTimeout: TimeoutRef | null;
   private _interactionSinceLastVisibilityChange: boolean;
+  // Tracks bfcache restoration to avoid double-handling with session manager's pageshow listener
+  private _restoringFromBfcache: boolean;
   private readonly _avoidEndingLimitedSessions: boolean;
   private readonly _embraceSpanProcessor?: EmbraceSessionBatchedSpanProcessor;
   private readonly _checkVisibilityChange: () => void;
   private readonly _onVisibilityChange: () => void;
   private readonly _onInteractionThrottled: () => void;
+  private readonly _onPageShow: (event: PageTransitionEvent) => void;
 
   public constructor(
     {
@@ -45,6 +48,7 @@ export class SpanSessionVisibilityInstrumentation extends EmbraceInstrumentation
     this._currentVisibilityState = visibilityDoc.visibilityState;
     this._checkVisibilityTimeout = null;
     this._interactionSinceLastVisibilityChange = false;
+    this._restoringFromBfcache = false;
     this._avoidEndingLimitedSessions =
       limitedSessionMaxDurationMs > 0 &&
       featureManager.isEmptySessionAvoidanceEnabled();
@@ -87,6 +91,16 @@ export class SpanSessionVisibilityInstrumentation extends EmbraceInstrumentation
     };
 
     this._onVisibilityChange = () => {
+      // Skip handling if this visibility change follows a bfcache restoration.
+      // The session manager's pageshow handler already started the new session.
+      if (this._restoringFromBfcache) {
+        this._diag.debug(
+          'Skipping visibility change handling after bfcache restoration',
+        );
+        this._restoringFromBfcache = false;
+        return;
+      }
+
       this._diag.debug(
         `Visibility change detected: ${visibilityDoc.visibilityState}`,
       );
@@ -156,6 +170,16 @@ export class SpanSessionVisibilityInstrumentation extends EmbraceInstrumentation
       this._interactionSinceLastVisibilityChange = true;
     }, 1000);
 
+    // Track bfcache restoration to coordinate with session manager's pageshow handler
+    this._onPageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        this._diag.debug(
+          'Page restored from bfcache, will skip next visibility change',
+        );
+        this._restoringFromBfcache = true;
+      }
+    };
+
     if (this._config.enabled) {
       this.enable();
     }
@@ -163,6 +187,7 @@ export class SpanSessionVisibilityInstrumentation extends EmbraceInstrumentation
 
   public disable(): void {
     window.removeEventListener('visibilitychange', this._checkVisibilityChange);
+    window.removeEventListener('pageshow', this._onPageShow);
 
     if (this._avoidEndingLimitedSessions) {
       bulkRemoveEventListener({
@@ -175,6 +200,7 @@ export class SpanSessionVisibilityInstrumentation extends EmbraceInstrumentation
 
   public enable(): void {
     window.addEventListener('visibilitychange', this._checkVisibilityChange);
+    window.addEventListener('pageshow', this._onPageShow, { passive: true });
 
     if (this._avoidEndingLimitedSessions) {
       bulkAddEventListener({

--- a/packages/web-sdk/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
@@ -1368,4 +1368,193 @@ describe('EmbraceSpanSessionManager', () => {
       });
     });
   });
+
+  // bfcache tests need isolation because each manager registers window listeners
+  // that can't be cleaned up, so we use a dedicated exporter for each test
+  describe('bfcache handling', () => {
+    let bfcacheExporter: InMemorySpanExporter;
+    let bfcacheProvider: WebTracerProvider;
+    let bfcacheDiag: InMemoryDiagLogger;
+    let bfcacheStorage: InMemoryStorage;
+    let bfcacheSessionStorage: InMemoryStorage;
+    let bfcacheLimitManager: EmbraceLimitManager;
+
+    beforeEach(() => {
+      bfcacheExporter = new InMemorySpanExporter();
+      bfcacheProvider = new WebTracerProvider({
+        spanProcessors: [new SimpleSpanProcessor(bfcacheExporter)],
+      });
+      bfcacheDiag = new InMemoryDiagLogger();
+      bfcacheStorage = new InMemoryStorage();
+      bfcacheSessionStorage = new InMemoryStorage();
+      bfcacheLimitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
+    });
+
+    afterEach(() => {
+      bfcacheExporter.reset();
+    });
+
+    it('should end session with bfcache reason when pagehide fires with persisted=true', () => {
+      const manager = new EmbraceSpanSessionManager({
+        diag: bfcacheDiag,
+        storage: bfcacheStorage,
+        sessionStorage: bfcacheSessionStorage,
+        limitManager: bfcacheLimitManager,
+        referrer: '',
+      });
+      manager.setTracerProvider(bfcacheProvider);
+
+      manager.startSessionSpan();
+      void expect(manager.getSessionId()).to.not.be.null;
+
+      // Simulate page entering bfcache
+      const pagehideEvent = new PageTransitionEvent('pagehide', {
+        persisted: true,
+      });
+      window.dispatchEvent(pagehideEvent);
+
+      // Session should be ended
+      void expect(manager.getSessionId()).to.be.null;
+
+      const finishedSpans = bfcacheExporter.getFinishedSpans();
+      expect(finishedSpans).to.have.lengthOf(1);
+      expect(finishedSpans[0].attributes).to.have.property(
+        KEY_EMB_SESSION_REASON_ENDED,
+        'bfcache',
+      );
+    });
+
+    it('should NOT end session when pagehide fires with persisted=false', () => {
+      const manager = new EmbraceSpanSessionManager({
+        diag: bfcacheDiag,
+        storage: bfcacheStorage,
+        sessionStorage: bfcacheSessionStorage,
+        limitManager: bfcacheLimitManager,
+        referrer: '',
+      });
+      manager.setTracerProvider(bfcacheProvider);
+
+      manager.startSessionSpan();
+      const sessionId = manager.getSessionId();
+      void expect(sessionId).to.not.be.null;
+
+      // Simulate normal page unload (not entering bfcache)
+      const pagehideEvent = new PageTransitionEvent('pagehide', {
+        persisted: false,
+      });
+      window.dispatchEvent(pagehideEvent);
+
+      // Session should still be active
+      expect(manager.getSessionId()).to.equal(sessionId);
+      expect(bfcacheExporter.getFinishedSpans()).to.have.lengthOf(0);
+    });
+
+    it('should start new session with bfcache_restore reason when pageshow fires with persisted=true', () => {
+      const manager = new EmbraceSpanSessionManager({
+        diag: bfcacheDiag,
+        storage: bfcacheStorage,
+        sessionStorage: bfcacheSessionStorage,
+        limitManager: bfcacheLimitManager,
+        referrer: '',
+      });
+      manager.setTracerProvider(bfcacheProvider);
+
+      // Simulate page restoring from bfcache (no active session)
+      const pageshowEvent = new PageTransitionEvent('pageshow', {
+        persisted: true,
+      });
+      window.dispatchEvent(pageshowEvent);
+
+      // New session should be started
+      void expect(manager.getSessionId()).to.not.be.null;
+
+      manager.endSessionSpan();
+      const finishedSpans = bfcacheExporter.getFinishedSpans();
+      expect(finishedSpans).to.have.lengthOf(1);
+      expect(finishedSpans[0].attributes).to.have.property(
+        KEY_EMB_SESSION_REASON_STARTED,
+        'bfcache_restore',
+      );
+      expect(finishedSpans[0].attributes).to.have.property(
+        KEY_EMB_NAVIGATION_SOURCE,
+        'back_forward',
+      );
+    });
+
+    it('should NOT start session when pageshow fires with persisted=false', () => {
+      const manager = new EmbraceSpanSessionManager({
+        diag: bfcacheDiag,
+        storage: bfcacheStorage,
+        sessionStorage: bfcacheSessionStorage,
+        limitManager: bfcacheLimitManager,
+        referrer: '',
+      });
+      manager.setTracerProvider(bfcacheProvider);
+
+      // No session active initially
+      void expect(manager.getSessionId()).to.be.null;
+
+      // Simulate normal page load (not from bfcache)
+      const pageshowEvent = new PageTransitionEvent('pageshow', {
+        persisted: false,
+      });
+      window.dispatchEvent(pageshowEvent);
+
+      // No session should be started
+      void expect(manager.getSessionId()).to.be.null;
+    });
+
+    it('should handle multiple bfcache cycles correctly', () => {
+      const manager = new EmbraceSpanSessionManager({
+        diag: bfcacheDiag,
+        storage: bfcacheStorage,
+        sessionStorage: bfcacheSessionStorage,
+        limitManager: bfcacheLimitManager,
+        referrer: '',
+      });
+      manager.setTracerProvider(bfcacheProvider);
+
+      // First session
+      manager.startSessionSpan();
+      const firstSessionId = manager.getSessionId();
+
+      // Enter bfcache
+      window.dispatchEvent(
+        new PageTransitionEvent('pagehide', { persisted: true }),
+      );
+      void expect(manager.getSessionId()).to.be.null;
+
+      // Restore from bfcache
+      window.dispatchEvent(
+        new PageTransitionEvent('pageshow', { persisted: true }),
+      );
+      const secondSessionId = manager.getSessionId();
+      expect(secondSessionId).to.not.equal(firstSessionId);
+
+      // Enter bfcache again
+      window.dispatchEvent(
+        new PageTransitionEvent('pagehide', { persisted: true }),
+      );
+      void expect(manager.getSessionId()).to.be.null;
+
+      // Restore from bfcache again
+      window.dispatchEvent(
+        new PageTransitionEvent('pageshow', { persisted: true }),
+      );
+      const thirdSessionId = manager.getSessionId();
+      expect(thirdSessionId).to.not.equal(secondSessionId);
+
+      // Verify all sessions ended correctly
+      const finishedSpans = bfcacheExporter.getFinishedSpans();
+      expect(finishedSpans).to.have.lengthOf(2);
+      expect(finishedSpans[0].attributes).to.have.property(
+        KEY_EMB_SESSION_REASON_ENDED,
+        'bfcache',
+      );
+      expect(finishedSpans[1].attributes).to.have.property(
+        KEY_EMB_SESSION_REASON_ENDED,
+        'bfcache',
+      );
+    });
+  });
 });

--- a/packages/web-sdk/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
@@ -70,7 +70,8 @@ export class EmbraceSpanSessionManager implements SpanSessionManagerInternal {
   private readonly _sessionStartedListeners: Array<SessionStartedListener> = [];
   private readonly _sessionEndedListeners: Array<SessionEndedListener> = [];
   private readonly _tab: Tab;
-  private readonly _navigationSource: NavigationSource;
+  // This field is mutable to support updating navigation source during bfcache restoration.
+  private _navigationSource: NavigationSource;
   private readonly _referrerInfo: {
     isValid: boolean;
     isSameOrigin: boolean;
@@ -120,6 +121,7 @@ export class EmbraceSpanSessionManager implements SpanSessionManagerInternal {
     this._tab = initResult.tab;
     this._navigationSource = initResult.navigationSource;
     this._setupNewTabClickListeners();
+    this._setupBfcacheListener();
   }
 
   // Collects all permanent session properties from localStorage
@@ -591,5 +593,36 @@ export class EmbraceSpanSessionManager implements SpanSessionManagerInternal {
     const options = { capture: true, passive: true };
     document.addEventListener('auxclick', handleNewTabClick, options);
     document.addEventListener('click', handleNewTabClick, options);
+  }
+
+  private _setupBfcacheListener(): void {
+    // Handle page entering bfcache - end the session
+    window.addEventListener(
+      'pagehide',
+      (event) => {
+        // persisted = true means page is entering bfcache and will be restored later
+        // persisted = false means page is being unloaded permanently
+        if (event.persisted) {
+          this._diag.debug('Page entering bfcache, ending session');
+          this.endSessionSpanInternal('bfcache');
+        }
+      },
+      { passive: true },
+    );
+
+    // Handle page restoring from bfcache - start a new session
+    window.addEventListener(
+      'pageshow',
+      (event) => {
+        // persisted = true means page was restored from back-forward cache
+        if (event.persisted) {
+          this._navigationSource = 'back_forward';
+          this._diag.debug('Page restored from bfcache, starting new session');
+
+          this.startSessionSpan({ reason: 'bfcache_restore' });
+        }
+      },
+      { passive: true },
+    );
   }
 }

--- a/packages/web-sdk/src/managers/EmbraceSpanSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceSpanSessionManager/README.md
@@ -46,3 +46,95 @@ emb.tab_id         - This tab's unique ID
 emb.parent_tab_id  - ID of tab that opened this one (if present)
 emb.experience_id  - Shared across related tabs
 ```
+
+## Back-Forward Cache (bfcache) Handling
+
+Modern browsers cache entire pages in memory to enable instant back/forward navigation. This preserves the JavaScript execution context, which affects session tracking.
+
+### What is bfcache?
+
+When a user navigates away from a page, Chrome may preserve the entire page state in memory rather than destroying it. When the user presses the back button, the page is restored from this cache with all JavaScript state intact—constructors don't run again, event listeners remain attached, and timers continue.
+
+### Navigation Source Detection
+
+**The Problem**: Navigation Timing API reports `type: "reload"` with `deliveryType: "cache"` when restoring from bfcache, not `type: "back_forward"`.
+
+**The Solution**: Listen for `pageshow` events and check `event.persisted`:
+- `event.persisted === true` means page was restored from bfcache
+- Update `_navigationSource` to `'back_forward'`
+- Start a new session (which inherits the updated navigation source)
+
+```typescript
+window.addEventListener('pageshow', (event) => {
+  if (event.persisted) {
+    this._navigationSource = 'back_forward';
+    this.startSessionSpan({ reason: 'bfcache_restore' });
+  }
+}, { passive: true });
+```
+
+### Session Lifecycle Behavior
+
+**Sessions end and restart** when pages enter/exit bfcache:
+
+**When entering bfcache** (`pagehide` with `event.persisted === true`):
+- If `SpanSessionVisibilityInstrumentation` is enabled: session ends with reason `'state_changed'` (visibilitychange fires before pagehide)
+- If `SpanSessionVisibilityInstrumentation` is disabled: session ends with reason `'bfcache'`
+- Session span is closed and exported with all accumulated data
+- Pending spans are flushed
+
+**When restoring from bfcache** (`pageshow` with `event.persisted === true`):
+- New session starts with reason `'bfcache_restore'`
+- `_navigationSource` set to `'back_forward'`
+- `_coldStart` remains `false` (bfcache restoration is not a cold start)
+- New session ID is generated
+- Permanent properties are reloaded from localStorage
+- `SpanSessionVisibilityInstrumentation` skips the subsequent visibilitychange event to avoid double-handling
+
+**Rationale**: Treating bfcache transitions as session boundaries provides clearer session analytics and ensures data is exported when users navigate away.
+
+### Potential Issues
+
+#### 1. Pending Network Exports (Already Handled)
+
+**The Problem**: When a page enters bfcache, pending `fetch()` requests could be aborted by the browser.
+
+**Event Timing**:
+- `pagehide` fires BEFORE page enters bfcache ✅ (you can still execute code)
+- Page freezes in bfcache ⏸️ (no events, no timers, no network)
+- `pageshow` fires AFTER restoration ✅ (execution resumes)
+
+**Current behavior**: ✅ Already handled correctly
+- Session ends synchronously in `pagehide`, triggering span export
+- Exports use `fetch()` with `keepalive: true` by default (see `exporters/constants.ts`)
+- Browser completes the request even after the page freezes
+
+### Additional Considerations
+
+1. **SDK Startup Duration**: Measures original page load, not bfcache restoration time. This is correct—SDK doesn't "start up" again on restoration.
+
+2. **Event Listeners**: All listeners remain attached and functional after bfcache restoration. Verify they don't capture stale closures.
+
+3. **Tab Activity Tracking**: Click listeners continue working correctly. Timestamps update on each click regardless of bfcache cycles.
+
+4. **Performance Observers**: If instrumentations track page lifecycle events (web vitals, resource timing), verify they handle bfcache restoration correctly—observers should not double-count or miss events.
+
+5. **Multiple Back/Forward Cycles**: Users can navigate back and forth repeatedly. Each restoration updates the navigation source correctly—logic is idempotent.
+
+### Testing bfcache Behavior
+
+1. Navigate to a page with an active session (note the session ID)
+2. Click an external link (e.g., google.com)
+3. Verify in logs: `Page entering bfcache, ending session`
+4. Press browser back button
+5. Verify in logs: `Page restored from bfcache, starting new session`
+6. Verify in logs: `Skipping visibility change handling after bfcache restoration`
+7. Verify navigation source shows `'back_forward'`
+8. Verify session ID changed (new session was created)
+9. Verify previous session was exported with reason `'state_changed'` (or `'bfcache'` if visibility instrumentation disabled)
+10. Verify new session has reason `'bfcache_restore'`
+11. Verify event listeners still work
+12. Test multiple back/forward cycles (each should create new sessions)
+13. Test behavior after extended time in bfcache
+
+**Chrome DevTools**: Use Application > Back/forward cache panel to test bfcache eligibility and behavior.


### PR DESCRIPTION
## What problem is this solving?

Browser back/forward cache (bfcache) restores pages from memory without reloading, causing sessions to never end and navigation source to be misreported as "reload" instead of "back_forward".

## Short description of changes

- Listen for `pagehide`/`pageshow` events with `event.persisted === true` to detect bfcache transitions
- End sessions with reason `'bfcache'` when entering bfcache (or `'state_changed'` if visibility instrumentation handles it first)
- Start new sessions with reason `'bfcache_restore'` and navigation source `'back_forward'` when restoring
- Add coordination in `SpanSessionVisibilityInstrumentation` to skip visibility change handling after bfcache restoration (prevents double-session creation)
- Add 8 tests for bfcache functionality across session manager and visibility instrumentation
- Document bfcache behavior and coordination in README

## Testing

- All 560 tests pass
- Navigate to external site, press back button
- Verify: New session created with `'back_forward'` navigation source
- Verify: Previous session exported (reason depends on whether visibility instrumentation is enabled)
- Verify: Only one session created on restoration (no double-handling)