### PR TITLE
chore: use activationStart and pageshow for T=0

### DIFF
--- a/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
@@ -64,7 +64,7 @@ export class ClicksInstrumentation extends EmbraceInstrumentationBase {
               ),
               'tap.coords': `${event.x.toString()},${event.y.toString()}`,
             },
-            this.perf.epochMillisFromOriginOffset(event.timeStamp),
+            this.perf.epochMillisFromZeroTime(event.timeStamp),
           );
         }
       } catch (e) {

--- a/packages/web-sdk/src/instrumentations/element-timing/ElementTimingInstrumentation/ElementTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/element-timing/ElementTimingInstrumentation/ElementTimingInstrumentation.ts
@@ -92,7 +92,7 @@ export class ElementTimingInstrumentation extends EmbraceInstrumentationBase {
     const span = this.tracer.startSpan(entry.identifier, {
       // Span start anchors to navigation start so the span duration equals "time from navigation
       // until the element was rendered" — useful for analyzing page-load render timing.
-      startTime: this.perf.epochMillisFromOriginOffset(0),
+      startTime: this.perf.epochMillisFromZeroTime(0),
       attributes: {
         [KEY_EMB_TYPE]: EMB_TYPES.ElementTiming,
         [KEY_EMB_ELEMENT_TIMING_IDENTIFIER]: entry.identifier,
@@ -106,12 +106,9 @@ export class ElementTimingInstrumentation extends EmbraceInstrumentationBase {
       },
     });
     if (entry.loadTime > 0) {
-      span.addEvent(
-        'load',
-        this.perf.epochMillisFromOriginOffset(entry.loadTime),
-      );
+      span.addEvent('load', this.perf.epochMillisFromZeroTime(entry.loadTime));
     }
     // entry.startTime = renderTime if non-zero, else loadTime
-    span.end(this.perf.epochMillisFromOriginOffset(entry.startTime));
+    span.end(this.perf.epochMillisFromZeroTime(entry.startTime));
   }
 }

--- a/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
@@ -18,14 +18,14 @@ export class GlobalExceptionInstrumentation extends EmbraceInstrumentationBase {
     this._onErrorHandler = (event: ErrorEvent) => {
       this.logManager.logException(event.error || event.message, {
         handled: false,
-        timestamp: this.perf.epochMillisFromOriginOffset(event.timeStamp),
+        timestamp: this.perf.epochMillisFromZeroTime(event.timeStamp),
         handler: 'global_exception',
       });
     };
     this._onUnhandledRejectionHandler = (event: PromiseRejectionEvent) => {
       this.logManager.logException(event.reason, {
         handled: false,
-        timestamp: this.perf.epochMillisFromOriginOffset(event.timeStamp),
+        timestamp: this.perf.epochMillisFromZeroTime(event.timeStamp),
         handler: 'promise_rejection',
       });
     };

--- a/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.ts
@@ -136,7 +136,7 @@ export class UserTimingInstrumentation extends EmbraceInstrumentationBase {
     if (entry.entryType === 'measure') {
       const measureDetail = (entry as PerformanceMeasure).detail;
       const span = this.tracer.startSpan(entry.name, {
-        startTime: this.perf.epochMillisFromOriginOffset(entry.startTime),
+        startTime: this.perf.epochMillisFromZeroTime(entry.startTime),
         attributes: {
           [KEY_EMB_TYPE]: EMB_TYPES.UserTiming,
           [KEY_EMB_INSTRUMENTATION]:
@@ -152,7 +152,7 @@ export class UserTimingInstrumentation extends EmbraceInstrumentationBase {
         },
       });
       span.end(
-        this.perf.epochMillisFromOriginOffset(entry.startTime + entry.duration),
+        this.perf.epochMillisFromZeroTime(entry.startTime + entry.duration),
       );
       return;
     }
@@ -161,7 +161,7 @@ export class UserTimingInstrumentation extends EmbraceInstrumentationBase {
     const body = detail != null ? JSON.stringify(detail) : undefined;
 
     this.logger.emit({
-      timestamp: this.perf.epochMillisFromOriginOffset(entry.startTime),
+      timestamp: this.perf.epochMillisFromZeroTime(entry.startTime),
       eventName: USER_TIMING_EVENT_NAME,
       severityNumber: SeverityNumber.INFO,
       attributes: {

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -314,13 +314,13 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
 
   private _getTimeForMetric(metric: MetricWithAttribution): number {
     if (metric.name === 'CLS' && metric.attribution.largestShiftTime) {
-      return this.perf.epochMillisFromOriginOffset(
+      return this.perf.epochMillisFromZeroTime(
         metric.attribution.largestShiftTime,
       );
     }
 
     if (metric.name === 'INP' && metric.attribution.interactionTime) {
-      return this.perf.epochMillisFromOriginOffset(
+      return this.perf.epochMillisFromZeroTime(
         metric.attribution.interactionTime,
       );
     }

--- a/packages/web-sdk/src/sdk/initSDK.ts
+++ b/packages/web-sdk/src/sdk/initSDK.ts
@@ -212,6 +212,10 @@ export const initSDK = (
       return false;
     }
 
+    window.addEventListener('pageshow', (event: PageTransitionEvent) => {
+      updatePageStartMillis(perf.epochMillisFromOriginOffset(event.timeStamp));
+    });
+
     const nsfValid = nsfConfigValidation({
       featureManager: sdkFeaturesManager,
       diag: diagLogger,

--- a/packages/web-sdk/src/sdk/initSDK.ts
+++ b/packages/web-sdk/src/sdk/initSDK.ts
@@ -134,7 +134,7 @@ export const initSDK = (
     const initSDKStart = perf.getNowMillis();
 
     window.addEventListener('pageshow', (event: PageTransitionEvent) => {
-      updatePageStartMillis(perf.epochMillisFromOriginOffset(event.timeStamp));
+      updatePageShowMillis(window.performance.timeOrigin + event.timeStamp);
     });
 
     const validatedAppID = validateAppID(appID);

--- a/packages/web-sdk/src/sdk/initSDK.ts
+++ b/packages/web-sdk/src/sdk/initSDK.ts
@@ -61,6 +61,7 @@ import {
   NamespacedStorage,
   nsfConfigValidation,
   OTelPerformanceManager,
+  updatePageStartMillis,
 } from '../utils/index.ts';
 import { getDefaultAttributeScrubbers } from './defaultAttributeScrubbers.ts';
 import { registry } from './registry.ts';
@@ -131,6 +132,11 @@ export const initSDK = (
 
     const perf = new OTelPerformanceManager();
     const initSDKStart = perf.getNowMillis();
+
+    window.addEventListener('pageshow', (event: PageTransitionEvent) => {
+      updatePageStartMillis(perf.epochMillisFromOriginOffset(event.timeStamp));
+    });
+
     const validatedAppID = validateAppID(appID);
     const validatedAppVersion = validateAppVersion(appVersion);
 

--- a/packages/web-sdk/src/sdk/initSDK.ts
+++ b/packages/web-sdk/src/sdk/initSDK.ts
@@ -61,7 +61,7 @@ import {
   NamespacedStorage,
   nsfConfigValidation,
   OTelPerformanceManager,
-  updatePageStartMillis,
+  updatePageShowMillis,
 } from '../utils/index.ts';
 import { getDefaultAttributeScrubbers } from './defaultAttributeScrubbers.ts';
 import { registry } from './registry.ts';
@@ -213,7 +213,7 @@ export const initSDK = (
     }
 
     window.addEventListener('pageshow', (event: PageTransitionEvent) => {
-      updatePageStartMillis(perf.epochMillisFromOriginOffset(event.timeStamp));
+      updatePageShowMillis(window.performance.timeOrigin + event.timeStamp);
     });
 
     const nsfValid = nsfConfigValidation({

--- a/packages/web-sdk/src/sdk/initSDK.ts
+++ b/packages/web-sdk/src/sdk/initSDK.ts
@@ -212,10 +212,6 @@ export const initSDK = (
       return false;
     }
 
-    window.addEventListener('pageshow', (event: PageTransitionEvent) => {
-      updatePageShowMillis(window.performance.timeOrigin + event.timeStamp);
-    });
-
     const nsfValid = nsfConfigValidation({
       featureManager: sdkFeaturesManager,
       diag: diagLogger,

--- a/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.test.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.test.ts
@@ -23,16 +23,16 @@ describe('OTelPerformanceManager', () => {
     performanceManager = new OTelPerformanceManager(mockClock);
   });
 
-  it('should calculate epochMillisFromOriginOffset correctly', () => {
+  it('should calculate epochMillisFromZeroTime correctly', () => {
     const offset = 300;
-    const result = performanceManager.epochMillisFromOriginOffset(offset);
+    const result = performanceManager.epochMillisFromZeroTime(offset);
     expect(result).to.equal(1300); // timeOrigin (1000) + offset (300)
   });
 
-  it('shifts epochMillisFromOriginOffset by pageshow when page start is updated', () => {
+  it('shifts epochMillisFromZeroTime by pageshow when page start is updated', () => {
     updatePageShowMillis(1500); // pageshow bumps page start to 1500
-    // getPageStartMillis() = max(timeOrigin(1000) + activationStart(0), 1500) = 1500
-    expect(performanceManager.epochMillisFromOriginOffset(300)).to.equal(1800); // 1500 + 300
+    // getZeroTime() = max(timeOrigin(1000) + activationStart(0), 1500) = 1500
+    expect(performanceManager.epochMillisFromZeroTime(300)).to.equal(1800); // 1500 + 300
   });
 
   it('should get current time in milliseconds', () => {
@@ -42,7 +42,7 @@ describe('OTelPerformanceManager', () => {
 
   it('shifts getNowMillis by pageshow when page start is updated', () => {
     updatePageShowMillis(1500); // pageshow bumps page start to 1500
-    // getNowMillis() = getPageStartMillis() + now() = 1500 + 500 = 2000
+    // getNowMillis() = getZeroTime() + now() = 1500 + 500 = 2000
     expect(performanceManager.getNowMillis()).to.equal(2000);
   });
 
@@ -54,7 +54,7 @@ describe('OTelPerformanceManager', () => {
   });
 
   it('should handle zero offset', () => {
-    const result = performanceManager.epochMillisFromOriginOffset(0);
+    const result = performanceManager.epochMillisFromZeroTime(0);
     expect(result).to.equal(1000); // timeOrigin (1000) + offset (0)
   });
 
@@ -78,7 +78,7 @@ describe('OTelPerformanceManager', () => {
   it('calculates elapsed time relative to effective page start after pageshow, clamping future HrTimes to 0', () => {
     // page start is bumped to 1800 via pageshow; now() = 1500 → getNowMillis = 1800 + 500 = 2300
     updatePageShowMillis(1800);
-    // getNowMillis() = getPageStartMillis() + now() = 1800 + 500 = 2300
+    // getNowMillis() = getZeroTime() + now() = 1800 + 500 = 2300
     // hrTimeToMilliseconds([1, 950000000]) = 1950 → 2300 - 1950 = 350, not clamped
     const beforeNow: HrTime = [1, 950000000]; // 1950ms
     expect(performanceManager.millisSinceHRTime(beforeNow)).to.equal(350);
@@ -89,7 +89,7 @@ describe('OTelPerformanceManager', () => {
   });
 
   it('returns timeOrigin when clock has no getEntriesByType (activationStart = 0)', () => {
-    expect(performanceManager.getPageStartMillis()).to.equal(1000); // timeOrigin (1000) + activationStart (0)
+    expect(performanceManager.getZeroTime()).to.equal(1000); // timeOrigin (1000) + activationStart (0)
   });
 
   it('returns timeOrigin when getEntriesByType returns an empty array', () => {
@@ -99,7 +99,7 @@ describe('OTelPerformanceManager', () => {
       getEntriesByType: sinon.stub().returns([]),
     };
     const perf = new OTelPerformanceManager(clockWithEmptyNav);
-    expect(perf.getPageStartMillis()).to.equal(1000);
+    expect(perf.getZeroTime()).to.equal(1000);
   });
 
   it('returns timeOrigin + activationStart when nav entry has nonzero activationStart', () => {
@@ -111,22 +111,22 @@ describe('OTelPerformanceManager', () => {
         .returns([{ activationStart: 200 } as PerformanceNavigationTiming]),
     };
     const perf = new OTelPerformanceManager(clockWithActivation);
-    expect(perf.getPageStartMillis()).to.equal(1200); // timeOrigin (1000) + activationStart (200)
+    expect(perf.getZeroTime()).to.equal(1200); // timeOrigin (1000) + activationStart (200)
   });
 
   it('returns pageshow epoch when updatePageShowMillis is called with a later value', () => {
     updatePageShowMillis(1500); // later than timeOrigin (1000) + activationStart (0)
-    expect(performanceManager.getPageStartMillis()).to.equal(1500);
+    expect(performanceManager.getZeroTime()).to.equal(1500);
   });
 
   it('returns timeOrigin + activationStart when updatePageShowMillis is called with an earlier value', () => {
     updatePageShowMillis(500); // earlier than timeOrigin (1000) + activationStart (0)
-    expect(performanceManager.getPageStartMillis()).to.equal(1000); // max wins
+    expect(performanceManager.getZeroTime()).to.equal(1000); // max wins
   });
 
   it('module-level state is shared across instances', () => {
     updatePageShowMillis(2000);
     const secondPerf = new OTelPerformanceManager(mockClock);
-    expect(secondPerf.getPageStartMillis()).to.equal(2000);
+    expect(secondPerf.getZeroTime()).to.equal(2000);
   });
 });

--- a/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.test.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.test.ts
@@ -1,7 +1,11 @@
 import type { HrTime } from '@opentelemetry/api';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
-import { OTelPerformanceManager } from './OTelPerformanceManager.ts';
+import {
+  _resetPageShowMillisForTesting,
+  OTelPerformanceManager,
+  updatePageShowMillis,
+} from './OTelPerformanceManager.ts';
 import type { PerformanceClock } from './types.ts';
 
 const { expect } = chai;
@@ -11,6 +15,7 @@ describe('OTelPerformanceManager', () => {
   let performanceManager: OTelPerformanceManager;
 
   beforeEach(() => {
+    _resetPageShowMillisForTesting();
     mockClock = {
       timeOrigin: 1000,
       now: sinon.stub().returns(500),
@@ -50,5 +55,58 @@ describe('OTelPerformanceManager', () => {
   it('should return originOffset unchanged from millisFromZeroTime', () => {
     expect(performanceManager.millisFromZeroTime(300)).to.equal(300);
     expect(performanceManager.millisFromZeroTime(0)).to.equal(0);
+  });
+
+  it('clamps millisSinceHRTime to 0 when the given time is after getNowMillis', () => {
+    // nowMillis = 1500, so a future HrTime of 2000ms should clamp to 0
+    const futureTime: HrTime = [2, 0]; // 2000ms
+    expect(performanceManager.millisSinceHRTime(futureTime)).to.equal(0);
+  });
+
+  it('clamps millisSinceHRTime to 0 for events registered before the effective page start', () => {
+    // page start is bumped to 1800 via pageshow; now() = 1500 → getNowMillis = 1800 + 500 = 2300
+    updatePageShowMillis(1800);
+    // an event recorded at HrTime 1900ms (after original timeOrigin but before pageshow) should clamp
+    const beforePageShow: HrTime = [1, 950000000]; // 1950ms — between timeOrigin(1000) and pageshow(1800), but expressed as HrTime ms
+    // getNowMillis() = getPageStartMillis() + now() = 1800 + 500 = 2300
+    // hrTimeToMilliseconds([1, 950000000]) = 1950
+    // 2300 - 1950 = 350, not clamped
+    expect(performanceManager.millisSinceHRTime(beforePageShow)).to.equal(350);
+
+    // an event whose HrTime exceeds getNowMillis should clamp to 0
+    const afterNow: HrTime = [2, 400000000]; // 2400ms > 2300ms
+    expect(performanceManager.millisSinceHRTime(afterNow)).to.equal(0);
+  });
+
+  it('returns timeOrigin when clock has no getEntriesByType (activationStart = 0)', () => {
+    expect(performanceManager.getPageStartMillis()).to.equal(1000); // timeOrigin (1000) + activationStart (0)
+  });
+
+  it('returns timeOrigin + activationStart when nav entry has nonzero activationStart', () => {
+    const clockWithActivation: PerformanceClock = {
+      timeOrigin: 1000,
+      now: sinon.stub().returns(500),
+      getEntriesByType: sinon
+        .stub()
+        .returns([{ activationStart: 200 } as PerformanceNavigationTiming]),
+    };
+    const perf = new OTelPerformanceManager(clockWithActivation);
+    expect(perf.getPageStartMillis()).to.equal(1200); // timeOrigin (1000) + activationStart (200)
+  });
+
+  it('returns pageshow epoch when updatePageStartMillis is called with a later value', () => {
+    updatePageShowMillis(1500); // later than timeOrigin (1000) + activationStart (0)
+    expect(performanceManager.getPageStartMillis()).to.equal(1500);
+  });
+
+  it('returns timeOrigin + activationStart when updatePageStartMillis is called with an earlier value', () => {
+    updatePageShowMillis(500); // earlier than timeOrigin (1000) + activationStart (0)
+    expect(performanceManager.getPageStartMillis()).to.equal(1000); // max wins
+  });
+
+  it('module-level state is shared across instances', () => {
+    updatePageShowMillis(2000);
+    const secondPerf = new OTelPerformanceManager(mockClock);
+    expect(secondPerf.getPageStartMillis()).to.equal(2000);
   });
 });

--- a/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.test.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.test.ts
@@ -29,9 +29,21 @@ describe('OTelPerformanceManager', () => {
     expect(result).to.equal(1300); // timeOrigin (1000) + offset (300)
   });
 
+  it('shifts epochMillisFromOriginOffset by pageshow when page start is updated', () => {
+    updatePageShowMillis(1500); // pageshow bumps page start to 1500
+    // getPageStartMillis() = max(timeOrigin(1000) + activationStart(0), 1500) = 1500
+    expect(performanceManager.epochMillisFromOriginOffset(300)).to.equal(1800); // 1500 + 300
+  });
+
   it('should get current time in milliseconds', () => {
     const result = performanceManager.getNowMillis();
     expect(result).to.equal(1500); // timeOrigin (1000) + now() (500)
+  });
+
+  it('shifts getNowMillis by pageshow when page start is updated', () => {
+    updatePageShowMillis(1500); // pageshow bumps page start to 1500
+    // getNowMillis() = getPageStartMillis() + now() = 1500 + 500 = 2000
+    expect(performanceManager.getNowMillis()).to.equal(2000);
   });
 
   it('should get current time in HR time format', () => {
@@ -63,23 +75,31 @@ describe('OTelPerformanceManager', () => {
     expect(performanceManager.millisSinceHRTime(futureTime)).to.equal(0);
   });
 
-  it('clamps millisSinceHRTime to 0 for events registered before the effective page start', () => {
+  it('calculates elapsed time relative to effective page start after pageshow, clamping future HrTimes to 0', () => {
     // page start is bumped to 1800 via pageshow; now() = 1500 → getNowMillis = 1800 + 500 = 2300
     updatePageShowMillis(1800);
-    // an event recorded at HrTime 1900ms (after original timeOrigin but before pageshow) should clamp
-    const beforePageShow: HrTime = [1, 950000000]; // 1950ms — between timeOrigin(1000) and pageshow(1800), but expressed as HrTime ms
     // getNowMillis() = getPageStartMillis() + now() = 1800 + 500 = 2300
-    // hrTimeToMilliseconds([1, 950000000]) = 1950
-    // 2300 - 1950 = 350, not clamped
-    expect(performanceManager.millisSinceHRTime(beforePageShow)).to.equal(350);
+    // hrTimeToMilliseconds([1, 950000000]) = 1950 → 2300 - 1950 = 350, not clamped
+    const beforeNow: HrTime = [1, 950000000]; // 1950ms
+    expect(performanceManager.millisSinceHRTime(beforeNow)).to.equal(350);
 
-    // an event whose HrTime exceeds getNowMillis should clamp to 0
+    // an event whose HrTime exceeds getNowMillis clamps to 0
     const afterNow: HrTime = [2, 400000000]; // 2400ms > 2300ms
     expect(performanceManager.millisSinceHRTime(afterNow)).to.equal(0);
   });
 
   it('returns timeOrigin when clock has no getEntriesByType (activationStart = 0)', () => {
     expect(performanceManager.getPageStartMillis()).to.equal(1000); // timeOrigin (1000) + activationStart (0)
+  });
+
+  it('returns timeOrigin when getEntriesByType returns an empty array', () => {
+    const clockWithEmptyNav: PerformanceClock = {
+      timeOrigin: 1000,
+      now: sinon.stub().returns(500),
+      getEntriesByType: sinon.stub().returns([]),
+    };
+    const perf = new OTelPerformanceManager(clockWithEmptyNav);
+    expect(perf.getPageStartMillis()).to.equal(1000);
   });
 
   it('returns timeOrigin + activationStart when nav entry has nonzero activationStart', () => {
@@ -94,12 +114,12 @@ describe('OTelPerformanceManager', () => {
     expect(perf.getPageStartMillis()).to.equal(1200); // timeOrigin (1000) + activationStart (200)
   });
 
-  it('returns pageshow epoch when updatePageStartMillis is called with a later value', () => {
+  it('returns pageshow epoch when updatePageShowMillis is called with a later value', () => {
     updatePageShowMillis(1500); // later than timeOrigin (1000) + activationStart (0)
     expect(performanceManager.getPageStartMillis()).to.equal(1500);
   });
 
-  it('returns timeOrigin + activationStart when updatePageStartMillis is called with an earlier value', () => {
+  it('returns timeOrigin + activationStart when updatePageShowMillis is called with an earlier value', () => {
     updatePageShowMillis(500); // earlier than timeOrigin (1000) + activationStart (0)
     expect(performanceManager.getPageStartMillis()).to.equal(1000); // max wins
   });

--- a/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.ts
@@ -19,18 +19,22 @@ export class OTelPerformanceManager implements PerformanceManager {
     this._clock = clock;
   }
 
-  public epochMillisFromOriginOffset = (originOffset: number) =>
-    this.getPageStartMillis() + originOffset;
+  public epochMillisFromZeroTime = (originOffset: number) =>
+    this.getZeroTime() + originOffset;
 
   public getNowHRTime = () => millisToHrTime(this.getNowMillis());
 
-  public getNowMillis = () =>
-    this.epochMillisFromOriginOffset(this._clock.now()); // otperformance.now() returns milliseconds since timeOrigin, timeOrigin is the time from epoch to the start of the page load
+  public getNowMillis = () => this.epochMillisFromZeroTime(this._clock.now()); // otperformance.now() returns milliseconds since timeOrigin, timeOrigin is the time from epoch to the start of the page load
 
   public millisSinceHRTime = (time: HrTime) =>
     Math.max(0, this.getNowMillis() - hrTimeToMilliseconds(time));
 
-  public getPageStartMillis = (): number =>
+  /**
+   * To measure the way a user experienced a metric, we measure metrics relative to the time the user
+   * started viewing the page. On prerendered pages, this is activationStart. On bfcache restores, this
+   * is the page restore time. On all other pages this value will be zero.
+   */
+  public getZeroTime = (): number =>
     Math.max(
       this._clock.timeOrigin + this._getNavigationActivationStart(),
       _pageShowMillis ?? 0,

--- a/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.ts
@@ -2,6 +2,16 @@ import type { HrTime } from '@opentelemetry/api';
 import { hrTimeToMilliseconds, millisToHrTime } from '@opentelemetry/core';
 import type { PerformanceClock, PerformanceManager } from './types.ts';
 
+let _pageShowMillis: number | undefined;
+
+export function updatePageShowMillis(epochMs: number): void {
+  _pageShowMillis = epochMs;
+}
+
+export function _resetPageShowMillisForTesting(): void {
+  _pageShowMillis = undefined;
+}
+
 export class OTelPerformanceManager implements PerformanceManager {
   private readonly _clock: PerformanceClock;
 
@@ -10,7 +20,7 @@ export class OTelPerformanceManager implements PerformanceManager {
   }
 
   public epochMillisFromOriginOffset = (originOffset: number) =>
-    this._clock.timeOrigin + originOffset;
+    this.getPageStartMillis() + originOffset;
 
   public getNowHRTime = () => millisToHrTime(this.getNowMillis());
 
@@ -18,7 +28,21 @@ export class OTelPerformanceManager implements PerformanceManager {
     this.epochMillisFromOriginOffset(this._clock.now()); // otperformance.now() returns milliseconds since timeOrigin, timeOrigin is the time from epoch to the start of the page load
 
   public millisSinceHRTime = (time: HrTime) =>
-    this.getNowMillis() - hrTimeToMilliseconds(time);
+    Math.max(0, this.getNowMillis() - hrTimeToMilliseconds(time));
+
+  public getPageStartMillis = (): number =>
+    Math.max(
+      this._clock.timeOrigin + this._getNavigationActivationStart(),
+      _pageShowMillis ?? 0,
+    );
+
+  private _getNavigationActivationStart(): number {
+    const entry = this._clock.getEntriesByType?.('navigation')[0] as
+      | PerformanceNavigationTiming
+      | undefined;
+
+    return entry?.activationStart ?? 0;
+  }
 
   // Returns milliseconds elapsed since the SDK's zero time (currently navigation
   // start). When soft-navigation support is added, this method will subtract the

--- a/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.ts
@@ -14,6 +14,7 @@ export function _resetPageShowMillisForTesting(): void {
 
 export class OTelPerformanceManager implements PerformanceManager {
   private readonly _clock: PerformanceClock;
+  private navigationEntry: PerformanceNavigationTiming | null = null;
 
   public constructor(clock: PerformanceClock = window.performance) {
     this._clock = clock;
@@ -40,11 +41,24 @@ export class OTelPerformanceManager implements PerformanceManager {
       _pageShowMillis ?? 0,
     );
 
-  private _getNavigationActivationStart(): number {
-    const entry = this._clock.getEntriesByType?.('navigation')[0] as
-      | PerformanceNavigationTiming
-      | undefined;
+  private _getNavigationEntry(): PerformanceNavigationTiming | null {
+    if (this.navigationEntry) {
+      return this.navigationEntry;
+    }
 
+    const [entry] = this._clock.getEntriesByType?.('navigation') ?? [];
+
+    if (entry) {
+      this.navigationEntry = entry as PerformanceNavigationTiming;
+
+      return this.navigationEntry;
+    }
+
+    return null;
+  }
+
+  private _getNavigationActivationStart(): number {
+    const entry = this._getNavigationEntry();
     return entry?.activationStart ?? 0;
   }
 

--- a/packages/web-sdk/src/utils/PerformanceManager/index.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/index.ts
@@ -1,5 +1,5 @@
 export {
-  _resetPageShowMillisForTesting as _resetPageStartMillisForTesting,
+  _resetPageShowMillisForTesting,
   OTelPerformanceManager,
   updatePageShowMillis as updatePageStartMillis,
 } from './OTelPerformanceManager.ts';

--- a/packages/web-sdk/src/utils/PerformanceManager/index.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/index.ts
@@ -1,6 +1,6 @@
 export {
   _resetPageShowMillisForTesting,
   OTelPerformanceManager,
-  updatePageShowMillis as updatePageStartMillis,
+  updatePageShowMillis,
 } from './OTelPerformanceManager.ts';
 export type { PerformanceManager } from './types.ts';

--- a/packages/web-sdk/src/utils/PerformanceManager/index.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/index.ts
@@ -1,2 +1,6 @@
-export { OTelPerformanceManager } from './OTelPerformanceManager.ts';
+export {
+  _resetPageShowMillisForTesting as _resetPageStartMillisForTesting,
+  OTelPerformanceManager,
+  updatePageShowMillis as updatePageStartMillis,
+} from './OTelPerformanceManager.ts';
 export type { PerformanceManager } from './types.ts';

--- a/packages/web-sdk/src/utils/PerformanceManager/types.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/types.ts
@@ -2,11 +2,11 @@ import type { HrTime } from '@opentelemetry/api';
 
 export interface PerformanceManager {
   getNowHRTime: () => HrTime;
-  epochMillisFromOriginOffset: (originOffset: number) => number;
+  epochMillisFromZeroTime: (originOffset: number) => number;
   getNowMillis: () => number;
   millisSinceHRTime: (time: HrTime) => number;
   millisFromZeroTime: (originOffset: number) => number;
-  getPageStartMillis: () => number;
+  getZeroTime: () => number;
 }
 
 export interface PerformanceClock {

--- a/packages/web-sdk/src/utils/PerformanceManager/types.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/types.ts
@@ -6,9 +6,11 @@ export interface PerformanceManager {
   getNowMillis: () => number;
   millisSinceHRTime: (time: HrTime) => number;
   millisFromZeroTime: (originOffset: number) => number;
+  getPageStartMillis: () => number;
 }
 
 export interface PerformanceClock {
   now: () => number;
   timeOrigin: number;
+  getEntriesByType?: (type: string) => PerformanceEntry[];
 }

--- a/packages/web-sdk/src/utils/index.ts
+++ b/packages/web-sdk/src/utils/index.ts
@@ -13,6 +13,7 @@ export { nsfConfigValidation } from './nsfConfigValidation.ts';
 export {
   OTelPerformanceManager,
   type PerformanceManager,
+  updatePageStartMillis,
 } from './PerformanceManager/index.ts';
 export {
   createPerformanceObserver,

--- a/packages/web-sdk/src/utils/index.ts
+++ b/packages/web-sdk/src/utils/index.ts
@@ -13,7 +13,7 @@ export { nsfConfigValidation } from './nsfConfigValidation.ts';
 export {
   OTelPerformanceManager,
   type PerformanceManager,
-  updatePageStartMillis,
+  updatePageShowMillis,
 } from './PerformanceManager/index.ts';
 export {
   createPerformanceObserver,


### PR DESCRIPTION
## What problem is this solving?

\`OTelPerformanceManager\` used \`window.performance.timeOrigin\` as T=0, which doesn't account for when the user actually starts seeing content. This leads to inaccurate session start times for prerendered pages and back-forward cache (BFCache) restores.

## Short description of changes

- Added \`getPageStartMillis()\` to \`OTelPerformanceManager\` and \`PerformanceManager\` interface — returns \`max(timeOrigin + activationStart, pageShowEpochMs)\` as the effective T=0
- \`epochMillisFromOriginOffset\` now uses \`getPageStartMillis()\` as the base so all timestamps are relative to the effective page start
- \`millisSinceHRTime\` is clamped to 0 to prevent negative durations for events recorded before the effective page start
- Module-level \`_pageShowMillis\` (updated via exported \`updatePageShowMillis\`, aliased as \`updatePageStartMillis\`) is shared across all \`OTelPerformanceManager\` instances
- \`initSDK\` registers a \`pageshow\` listener after all SDK validation succeeds to update T=0 on BFCache restores