### PR TITLE
EXPERIMENT refactor(exporters): move gzip compression from transport to serializer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6268,7 +6268,6 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -11570,6 +11569,7 @@
         "@opentelemetry/sdk-trace": "^2.10.0",
         "@opentelemetry/sdk-trace-web": "^2.10.0",
         "@opentelemetry/semantic-conventions": "^1.43.0",
+        "fflate": "0.8.3",
         "hoist-non-react-statics": "^3.3.2",
         "web-vitals": "^6.2.0"
       },

--- a/packages/web-sdk/THIRD_PARTY_NOTICES.txt
+++ b/packages/web-sdk/THIRD_PARTY_NOTICES.txt
@@ -435,6 +435,36 @@ Apache License
 
 The following npm package may be included in this product:
 
+ - fflate@0.8.3
+
+This package contains the following license:
+
+MIT License
+
+Copyright (c) 2026 Arjun Barrett
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----------
+
+The following npm package may be included in this product:
+
  - hoist-non-react-statics@3.3.2
 
 This package contains the following license:

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -94,6 +94,7 @@
     "@opentelemetry/sdk-trace": "^2.10.0",
     "@opentelemetry/sdk-trace-web": "^2.10.0",
     "@opentelemetry/semantic-conventions": "^1.43.0",
+    "fflate": "0.8.3",
     "hoist-non-react-statics": "^3.3.2",
     "web-vitals": "^6.2.0"
   },

--- a/packages/web-sdk/scripts/validate.ts
+++ b/packages/web-sdk/scripts/validate.ts
@@ -17,8 +17,8 @@ import { fileURLToPath } from 'node:url';
 import zlib from 'node:zlib';
 import { COLORS, log, logSection } from '../../../scripts/build-config.ts';
 
-// Maximum bundle size (gzipped) — triggers hard failure to catch bloat/duplication early
-const MAX_BUNDLE_SIZE_KB = 61;
+// Maximum bundle size (gzipped): triggers hard failure to catch bloat/duplication early
+const MAX_BUNDLE_SIZE_KB = 64;
 
 const BUNDLE_FILE = 'embrace-web-sdk.js';
 const BUNDLE_MAP_FILE = 'embrace-web-sdk.js.map';

--- a/packages/web-sdk/src/exporters/EmbraceLogExporter/EmbraceLogExporter.test.ts
+++ b/packages/web-sdk/src/exporters/EmbraceLogExporter/EmbraceLogExporter.test.ts
@@ -80,14 +80,9 @@ describe('EmbraceLogExporter', () => {
     expect((headers as Record<string, string>)['X-EM-DID']).to.equal(
       mockUserID,
     );
-    // Chrome, Webkit and Firefox have slightly different encoding processes, generating different Content-Length values.
-    const chromeContentLength = '189';
-    const firefoxWebkitContentLength = '191';
-    //TODO we should find a way to know if we are running in Chrome, Firefox or Webkit and just assert for the specific value for each browser
-    expect((headers as Record<string, string>)['Content-Length']).to.be.oneOf([
-      chromeContentLength,
-      firefoxWebkitContentLength,
-    ]);
+    // Content-Length is a forbidden fetch header, so the SDK must not set it
+    void expect((headers as Record<string, string>)['Content-Length']).to.be
+      .undefined;
     expect(fakeFetchGetUrl()).to.equal(
       'https://a-testAppID.data.emb-api.com/v2/logs',
     );

--- a/packages/web-sdk/src/exporters/EmbraceTraceExporter/EmbraceTraceExporter.test.ts
+++ b/packages/web-sdk/src/exporters/EmbraceTraceExporter/EmbraceTraceExporter.test.ts
@@ -68,11 +68,9 @@ describe('EmbraceTraceExporter', () => {
     expect((headers as Record<string, string>)['X-EM-DID']).to.equal(
       mockUserID,
     );
-    // Browser engines emit gzip streams that differ by a byte for the same input.
-    expect((headers as Record<string, string>)['Content-Length']).to.be.oneOf([
-      '268',
-      '269',
-    ]);
+    // Content-Length is a forbidden fetch header, so the SDK must not set it
+    void expect((headers as Record<string, string>)['Content-Length']).to.be
+      .undefined;
     expect(fakeFetchGetUrl()).to.equal(
       'https://a-testAppID.data.emb-api.com/v2/spans',
     );

--- a/packages/web-sdk/src/exporters/EmbraceTraceExporter/OTLPFetchTraceExporter.ts
+++ b/packages/web-sdk/src/exporters/EmbraceTraceExporter/OTLPFetchTraceExporter.ts
@@ -14,10 +14,7 @@ export class OTLPFetchTraceExporter
   public constructor(config: OtlpFetchExporterConfig) {
     super(
       createOtlpBrowserFetchExportDelegate(
-        {
-          ...config,
-          compression: 'gzip',
-        },
+        config,
         JsonTraceSerializer,
         'otlp_http_span_exporter',
         TraceExporterMetricsHelper,

--- a/packages/web-sdk/src/exporters/GzipSerializer/GzipSerializer.test.ts
+++ b/packages/web-sdk/src/exporters/GzipSerializer/GzipSerializer.test.ts
@@ -1,7 +1,5 @@
-import { DiagLogLevel, diag } from '@opentelemetry/api';
 import * as chai from 'chai';
 import type { ISerializer } from '#embrace-io/otlp-transformer';
-import { InMemoryDiagLogger } from '../../../tests/utils/index.ts';
 import { GzipSerializer } from './GzipSerializer.ts';
 
 const { expect } = chai;
@@ -60,75 +58,5 @@ describe('GzipSerializer', () => {
     const result = serializer.deserializeResponse(responseData);
 
     expect(result).to.deep.equal({ status: 200 });
-  });
-
-  it('should return undefined and log when compression fails with an Error', () => {
-    const diagLogger = new InMemoryDiagLogger();
-    diag.setLogger(diagLogger, DiagLogLevel.ALL);
-
-    // Coupled to fflate internals: gzipSync reads properties off its input,
-    // so a throwing get trap is the only way to force its failure path.
-    const poisoned = new Proxy(new Uint8Array(0), {
-      get() {
-        throw new Error('out of memory');
-      },
-    });
-
-    const poisonedSerializer: ISerializer<string, FakeResponse> = {
-      serializeRequest(): Uint8Array | undefined {
-        return poisoned;
-      },
-      deserializeResponse: fakeSerializer.deserializeResponse,
-    };
-
-    const serializer = new GzipSerializer(poisonedSerializer);
-    const result = serializer.serializeRequest('test');
-
-    expect(result).to.be.undefined;
-    expect(
-      diagLogger
-        .getErrorLogs()
-        .some((msg) =>
-          msg.includes(
-            'gzip compression failed, dropping export: out of memory',
-          ),
-        ),
-    ).to.be.true;
-
-    diag.disable();
-  });
-
-  it('should return undefined and log when compression fails with a non-Error', () => {
-    const diagLogger = new InMemoryDiagLogger();
-    diag.setLogger(diagLogger, DiagLogLevel.ALL);
-
-    const poisoned = new Proxy(new Uint8Array(0), {
-      get() {
-        throw 'string error';
-      },
-    });
-
-    const poisonedSerializer: ISerializer<string, FakeResponse> = {
-      serializeRequest(): Uint8Array | undefined {
-        return poisoned;
-      },
-      deserializeResponse: fakeSerializer.deserializeResponse,
-    };
-
-    const serializer = new GzipSerializer(poisonedSerializer);
-    const result = serializer.serializeRequest('test');
-
-    expect(result).to.be.undefined;
-    expect(
-      diagLogger
-        .getErrorLogs()
-        .some((msg) =>
-          msg.includes(
-            'gzip compression failed, dropping export: string error',
-          ),
-        ),
-    ).to.be.true;
-
-    diag.disable();
   });
 });

--- a/packages/web-sdk/src/exporters/GzipSerializer/GzipSerializer.test.ts
+++ b/packages/web-sdk/src/exporters/GzipSerializer/GzipSerializer.test.ts
@@ -1,0 +1,134 @@
+import { DiagLogLevel, diag } from '@opentelemetry/api';
+import * as chai from 'chai';
+import type { ISerializer } from '#embrace-io/otlp-transformer';
+import { InMemoryDiagLogger } from '../../../tests/utils/index.ts';
+import { GzipSerializer } from './GzipSerializer.ts';
+
+const { expect } = chai;
+
+interface FakeResponse {
+  status: number;
+}
+
+const fakeSerializer: ISerializer<string, FakeResponse> = {
+  serializeRequest(request: string): Uint8Array | undefined {
+    if (!request) {
+      return undefined;
+    }
+    return new TextEncoder().encode(request);
+  },
+  deserializeResponse(data: Uint8Array): FakeResponse {
+    const text = new TextDecoder().decode(data);
+    return JSON.parse(text) as FakeResponse;
+  },
+};
+
+describe('GzipSerializer', () => {
+  it('should return gzip-compressed bytes from serializeRequest', async () => {
+    const serializer = new GzipSerializer(fakeSerializer);
+    const result = serializer.serializeRequest('{"data": "hello"}');
+
+    expect(result).to.be.instanceOf(Uint8Array);
+    expect(result?.length).to.be.greaterThan(0);
+    // gzip magic number and deflate method, checked without DecompressionStream
+    expect([result?.[0], result?.[1], result?.[2]]).to.deep.equal([
+      0x1f, 0x8b, 0x08,
+    ]);
+    // mtime field stays zeroed so payloads carry no wall clock
+    expect([result?.[4], result?.[5], result?.[6], result?.[7]]).to.deep.equal([
+      0, 0, 0, 0,
+    ]);
+
+    const decompressed = await new Response(
+      new Response(result as Uint8Array<ArrayBuffer>).body?.pipeThrough(
+        new DecompressionStream('gzip'),
+      ),
+    ).text();
+    expect(decompressed).to.equal('{"data": "hello"}');
+  });
+
+  it('should return undefined when inner serializer returns undefined', () => {
+    const serializer = new GzipSerializer(fakeSerializer);
+    const result = serializer.serializeRequest('');
+
+    expect(result).to.be.undefined;
+  });
+
+  it('should delegate deserializeResponse to inner serializer', () => {
+    const serializer = new GzipSerializer(fakeSerializer);
+    const responseData = new TextEncoder().encode('{"status": 200}');
+    const result = serializer.deserializeResponse(responseData);
+
+    expect(result).to.deep.equal({ status: 200 });
+  });
+
+  it('should return undefined and log when compression fails with an Error', () => {
+    const diagLogger = new InMemoryDiagLogger();
+    diag.setLogger(diagLogger, DiagLogLevel.ALL);
+
+    // Coupled to fflate internals: gzipSync reads properties off its input,
+    // so a throwing get trap is the only way to force its failure path.
+    const poisoned = new Proxy(new Uint8Array(0), {
+      get() {
+        throw new Error('out of memory');
+      },
+    });
+
+    const poisonedSerializer: ISerializer<string, FakeResponse> = {
+      serializeRequest(): Uint8Array | undefined {
+        return poisoned;
+      },
+      deserializeResponse: fakeSerializer.deserializeResponse,
+    };
+
+    const serializer = new GzipSerializer(poisonedSerializer);
+    const result = serializer.serializeRequest('test');
+
+    expect(result).to.be.undefined;
+    expect(
+      diagLogger
+        .getErrorLogs()
+        .some((msg) =>
+          msg.includes(
+            'gzip compression failed, dropping export: out of memory',
+          ),
+        ),
+    ).to.be.true;
+
+    diag.disable();
+  });
+
+  it('should return undefined and log when compression fails with a non-Error', () => {
+    const diagLogger = new InMemoryDiagLogger();
+    diag.setLogger(diagLogger, DiagLogLevel.ALL);
+
+    const poisoned = new Proxy(new Uint8Array(0), {
+      get() {
+        throw 'string error';
+      },
+    });
+
+    const poisonedSerializer: ISerializer<string, FakeResponse> = {
+      serializeRequest(): Uint8Array | undefined {
+        return poisoned;
+      },
+      deserializeResponse: fakeSerializer.deserializeResponse,
+    };
+
+    const serializer = new GzipSerializer(poisonedSerializer);
+    const result = serializer.serializeRequest('test');
+
+    expect(result).to.be.undefined;
+    expect(
+      diagLogger
+        .getErrorLogs()
+        .some((msg) =>
+          msg.includes(
+            'gzip compression failed, dropping export: string error',
+          ),
+        ),
+    ).to.be.true;
+
+    diag.disable();
+  });
+});

--- a/packages/web-sdk/src/exporters/GzipSerializer/GzipSerializer.ts
+++ b/packages/web-sdk/src/exporters/GzipSerializer/GzipSerializer.ts
@@ -1,0 +1,37 @@
+import { diag } from '@opentelemetry/api';
+import { gzipSync } from 'fflate';
+import type { ISerializer } from '#embrace-io/otlp-transformer';
+
+// Compression has to be synchronous so the unload-path keepalive fetch is
+// issued in the same task, which rules out the async CompressionStream.
+export class GzipSerializer<Request, Response>
+  implements ISerializer<Request, Response>
+{
+  public constructor(
+    private readonly _serializer: ISerializer<Request, Response>,
+  ) {}
+
+  public serializeRequest(request: Request): Uint8Array | undefined {
+    const serialized = this._serializer.serializeRequest(request);
+    if (!serialized) {
+      return undefined;
+    }
+    try {
+      // mtime 0 keeps the wall clock out of the gzip header.
+      return gzipSync(serialized, { mtime: 0 });
+    } catch (error) {
+      // The export delegate turns undefined into a generic 'Nothing to send'
+      // failure, so this is the only place the real cause is reported.
+      diag.error(
+        `gzip compression failed, dropping export: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return undefined;
+    }
+  }
+
+  public deserializeResponse(data: Uint8Array): Response {
+    return this._serializer.deserializeResponse(data);
+  }
+}

--- a/packages/web-sdk/src/exporters/GzipSerializer/GzipSerializer.ts
+++ b/packages/web-sdk/src/exporters/GzipSerializer/GzipSerializer.ts
@@ -1,4 +1,3 @@
-import { diag } from '@opentelemetry/api';
 import { gzipSync } from 'fflate';
 import type { ISerializer } from '#embrace-io/otlp-transformer';
 
@@ -16,19 +15,8 @@ export class GzipSerializer<Request, Response>
     if (!serialized) {
       return undefined;
     }
-    try {
-      // mtime 0 keeps the wall clock out of the gzip header.
-      return gzipSync(serialized, { mtime: 0 });
-    } catch (error) {
-      // The export delegate turns undefined into a generic 'Nothing to send'
-      // failure, so this is the only place the real cause is reported.
-      diag.error(
-        `gzip compression failed, dropping export: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      return undefined;
-    }
+    // mtime 0 keeps the wall clock out of the gzip header.
+    return gzipSync(serialized, { mtime: 0 });
   }
 
   public deserializeResponse(data: Uint8Array): Response {

--- a/packages/web-sdk/src/exporters/GzipSerializer/index.ts
+++ b/packages/web-sdk/src/exporters/GzipSerializer/index.ts
@@ -1,0 +1,1 @@
+export { GzipSerializer } from './GzipSerializer.ts';

--- a/packages/web-sdk/src/exporters/otlpBrowserFetchExportDelegate.test.ts
+++ b/packages/web-sdk/src/exporters/otlpBrowserFetchExportDelegate.test.ts
@@ -1,12 +1,24 @@
 import type { ExportResult } from '@opentelemetry/core';
 import { ExportResultCode } from '@opentelemetry/core';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {
   JsonTraceSerializer,
   TraceExporterMetricsHelper,
 } from '#embrace-io/otlp-transformer'; // internal package: https://nodejs.org/api/packages.html#imports
+import {
+  fakeFetchGetBody,
+  fakeFetchGetKeepalive,
+  fakeFetchGetRequestHeaders,
+  fakeFetchInstall,
+  fakeFetchRespondWith,
+  fakeFetchRestore,
+  fakeFetchWasCalled,
+} from '../../tests/utils/index.ts';
 import { mockSpan } from '../../tests/utils/mock-entities/ReadableSpan.ts';
+import { _resetKeepaliveTracking } from '../transport/FetchTransport/FetchTransport.ts';
+import { BaseFetchExporter } from './BaseFetchExporter/index.ts';
 import { createOtlpBrowserFetchExportDelegate } from './otlpBrowserFetchExportDelegate.ts';
 import type { OtlpFetchExporterConfig } from './types.ts';
 
@@ -116,5 +128,89 @@ describe('createOtlpBrowserFetchExportDelegate', () => {
     });
     resolveFetch(new Response());
     await flushPromise;
+  });
+
+  it('should not compress or set Content-Encoding when compression is none', async () => {
+    fakeFetchInstall();
+    fakeFetchRespondWith('');
+
+    try {
+      const exporter = new BaseFetchExporter(createTestDelegate());
+      await new Promise<void>((resolve) => {
+        exporter.export([mockSpan], (result) => {
+          expect(result.code).to.equal(ExportResultCode.SUCCESS);
+          resolve();
+        });
+      });
+
+      const headers = fakeFetchGetRequestHeaders() as Record<string, string>;
+      expect(headers['Content-Encoding']).to.be.undefined;
+
+      const body = fakeFetchGetBody() as Uint8Array<ArrayBuffer>;
+      const parsed = JSON.parse(new TextDecoder().decode(body)) as {
+        resourceSpans: unknown[];
+      };
+      expect(parsed.resourceSpans).to.be.an('array');
+    } finally {
+      fakeFetchRestore();
+    }
+  });
+  it('should charge the keepalive budget the compressed size', async () => {
+    fakeFetchInstall();
+    fakeFetchRespondWith('');
+    _resetKeepaliveTracking();
+
+    try {
+      // Serializes far past the 48KiB keepalive budget but gzips to a fraction
+      // of it, so keepalive survives only if the budget sees compressed bytes.
+      const bulkySpan: ReadableSpan = {
+        ...mockSpan,
+        attributes: { 'test.attribute': 'a'.repeat(80 * 1024) },
+      };
+
+      const exporter = new BaseFetchExporter(
+        createOtlpBrowserFetchExportDelegate(
+          { ...TEST_CONFIG, compression: 'gzip' },
+          JsonTraceSerializer,
+          'otlp_http_span_exporter',
+          TraceExporterMetricsHelper,
+        ),
+      );
+      await new Promise<void>((resolve) => {
+        exporter.export([bulkySpan], (result) => {
+          expect(result.code).to.equal(ExportResultCode.SUCCESS);
+          resolve();
+        });
+      });
+
+      const body = fakeFetchGetBody() as Uint8Array<ArrayBuffer>;
+      expect(body.byteLength).to.be.lessThan(49152);
+      expect(fakeFetchGetKeepalive()).to.equal(true);
+    } finally {
+      fakeFetchRestore();
+    }
+  });
+  it('should reach fetch in the same task as export', () => {
+    fakeFetchInstall();
+    fakeFetchRespondWith('');
+
+    try {
+      const exporter = new BaseFetchExporter(
+        createOtlpBrowserFetchExportDelegate(
+          { ...TEST_CONFIG, compression: 'gzip' },
+          JsonTraceSerializer,
+          'otlp_http_span_exporter',
+          TraceExporterMetricsHelper,
+        ),
+      );
+
+      exporter.export([mockSpan], () => undefined);
+
+      // Deliberately not awaited: teardown grants only a synchronous budget, so
+      // an await anywhere before fetch loses the payload on the unload path.
+      expect(fakeFetchWasCalled()).to.equal(true);
+    } finally {
+      fakeFetchRestore();
+    }
   });
 });

--- a/packages/web-sdk/src/exporters/otlpBrowserFetchExportDelegate.ts
+++ b/packages/web-sdk/src/exporters/otlpBrowserFetchExportDelegate.ts
@@ -10,6 +10,7 @@ import {
   createFetchTransport,
   createRetryingTransport,
 } from '../transport/index.ts';
+import { GzipSerializer } from './GzipSerializer/index.ts';
 import type { OtlpFetchExporterConfig } from './types.ts';
 
 // createOtlpBrowserFetchExportDelegate creates an export delegate that uses
@@ -19,12 +20,20 @@ export const createOtlpBrowserFetchExportDelegate = <Internal, Response>(
   serializer: ISerializer<Internal, Response>,
   componentType: string,
   metricsHelper: IExporterMetricsHelper<Internal>,
-) =>
+) => {
+  const useGzip = config.compression === 'gzip';
+  const compressingSerializer = useGzip
+    ? new GzipSerializer(serializer)
+    : serializer;
+  const headers = useGzip
+    ? { ...config.headers, 'Content-Encoding': 'gzip' }
+    : config.headers;
+
   // createOtlpNetworkExportDelegate has an internal bounded queue that tracks
   // in-flight exports and fails exports beyond config.concurrencyLimit.
-  createOtlpNetworkExportDelegate(
+  return createOtlpNetworkExportDelegate(
     config,
-    serializer,
+    compressingSerializer,
     new ExporterMetrics({
       componentType,
       metricsHelper,
@@ -35,6 +44,7 @@ export const createOtlpBrowserFetchExportDelegate = <Internal, Response>(
       responseAttributesFromError: () => ({}),
     }),
     createRetryingTransport({
-      transport: createFetchTransport(config),
+      transport: createFetchTransport({ url: config.url, headers }),
     }),
   );
+};

--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -676,23 +676,6 @@ describe('initSDK', () => {
     expect(diagLogger.getErrorLogs()).to.have.lengthOf(0);
   });
 
-  it('should initialize without CompressionStream when sending to Embrace', () => {
-    const diagLogger = new InMemoryDiagLogger();
-    const originalCompressionStream = (globalThis as never)[
-      'CompressionStream'
-    ];
-    delete (globalThis as never)['CompressionStream'];
-
-    try {
-      const result = initSDK({ appID: 'app12', diagLogger });
-      void expect(result).not.to.be.false;
-
-      expect(diagLogger.getErrorLogs()).to.have.lengthOf(0);
-    } finally {
-      (globalThis as never)['CompressionStream'] = originalCompressionStream;
-    }
-  });
-
   describe('communication with Embrace', () => {
     it('should include the correct resource attributes', async () => {
       fakeFetchRespondWith('');

--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -676,7 +676,7 @@ describe('initSDK', () => {
     expect(diagLogger.getErrorLogs()).to.have.lengthOf(0);
   });
 
-  it('should not initialize when CompressionStream is unavailable and sending to Embrace', () => {
+  it('should initialize without CompressionStream when sending to Embrace', () => {
     const diagLogger = new InMemoryDiagLogger();
     const originalCompressionStream = (globalThis as never)[
       'CompressionStream'
@@ -685,36 +685,10 @@ describe('initSDK', () => {
 
     try {
       const result = initSDK({ appID: 'app12', diagLogger });
-      void expect(result).to.be.false;
-
-      expect(diagLogger.getErrorLogs()).to.have.lengthOf(1);
-      expect(diagLogger.getErrorLogs()[0]).to.equal(
-        'failed to initialize the SDK: CompressionStream is not supported in this browser and required for data compression.',
-      );
-    } finally {
-      // Restore CompressionStream
-      (globalThis as never)['CompressionStream'] = originalCompressionStream;
-    }
-  });
-
-  it('should initialize when CompressionStream is unavailable but using custom exporters', () => {
-    const diagLogger = new InMemoryDiagLogger();
-    const originalCompressionStream = (globalThis as never)[
-      'CompressionStream'
-    ];
-    delete (globalThis as never)['CompressionStream'];
-
-    try {
-      const result = initSDK({
-        logExporters: [logExporter],
-        spanExporters: [spanExporter],
-        diagLogger,
-      });
       void expect(result).not.to.be.false;
 
       expect(diagLogger.getErrorLogs()).to.have.lengthOf(0);
     } finally {
-      // Restore CompressionStream
       (globalThis as never)['CompressionStream'] = originalCompressionStream;
     }
   });

--- a/packages/web-sdk/src/sdk/initSDK.ts
+++ b/packages/web-sdk/src/sdk/initSDK.ts
@@ -151,12 +151,6 @@ export const initSDK = (
       );
     }
 
-    if (sendingToEmbrace && typeof CompressionStream === 'undefined') {
-      throw new Error(
-        'CompressionStream is not supported in this browser and required for data compression.',
-      );
-    }
-
     const namespace = appID ?? undefined;
     const sdkLocalStorage = new NamespacedStorage({
       namespace,

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
@@ -2,13 +2,10 @@ import { DiagLogLevel, diag } from '@opentelemetry/api';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {
-  fakeFetchGetBody,
   fakeFetchGetKeepalive,
-  fakeFetchGetRequestHeaders,
   fakeFetchInstall,
   fakeFetchRespondWith,
   fakeFetchRestore,
-  fakeFetchWasCalled,
   InMemoryDiagLogger,
 } from '../../../tests/utils/index.ts';
 import { _resetKeepaliveTracking, FetchTransport } from './FetchTransport.ts';
@@ -21,24 +18,11 @@ const makeTransport = (
   new FetchTransport({
     url: 'http://example.com',
     headers: {},
-    compression: 'none',
     ...overrides,
   });
 
 const smallPayload = new TextEncoder().encode('{"small": true}');
 const largePayload = new Uint8Array(49153); // 1 byte over the 48KiB budget
-
-// Random bytes barely shrink under gzip, so the compressed size stays close to
-// the requested one and keepalive budget arithmetic is exercised for real.
-const incompressiblePayload = (byteLength: number) =>
-  crypto.getRandomValues(new Uint8Array(byteLength));
-
-const gunzipToText = async (body: Uint8Array<ArrayBuffer>) => {
-  const stream = new Response(body).body?.pipeThrough(
-    new DecompressionStream('gzip'),
-  );
-  return new Response(stream).text();
-};
 
 interface Deferred {
   promise: Promise<Response>;
@@ -228,132 +212,6 @@ describe('FetchTransport', () => {
       await transport.send(payload30k, 5000);
 
       expect(fakeFetchGetKeepalive(2)).to.equal(true);
-    });
-  });
-
-  describe('keepalive tracking with gzip compression', () => {
-    it('should use compressed size for budget check', async () => {
-      const deferred = createDeferred();
-      const stub = reinstallFetch();
-
-      let firstFetchCalled!: () => void;
-      const firstFetchCalledPromise = new Promise<void>((r) => {
-        firstFetchCalled = r;
-      });
-
-      stub.onCall(0).callsFake(() => {
-        firstFetchCalled();
-        return deferred.promise;
-      });
-      stub.onCall(1).resolves(new Response('ok', { status: 200 }));
-
-      const transport = makeTransport({ compression: 'gzip' });
-
-      // 40KiB of zeros: exceeds 48KiB budget uncompressed (40K + 40K > 48K)
-      // but compresses to ~30 bytes, well within budget
-      const payload40k = new Uint8Array(40 * 1024);
-
-      const first = transport.send(payload40k, 5000);
-
-      // Wait for compression and first fetch call
-      await firstFetchCalledPromise;
-
-      // Second send: budget check uses compressed size of first (~30 bytes),
-      // so this 40KiB (also ~30 bytes compressed) easily fits
-      await transport.send(payload40k, 5000);
-
-      expect(fakeFetchGetKeepalive(0)).to.equal(true);
-      expect(fakeFetchGetKeepalive(1)).to.equal(true);
-
-      deferred.resolve(new Response('ok', { status: 200 }));
-      await first;
-    });
-
-    it('should disable keepalive when compressed bytes exceed budget', async () => {
-      const deferred = createDeferred();
-      const stub = reinstallFetch();
-
-      let firstFetchCalled!: () => void;
-      const firstFetchCalledPromise = new Promise<void>((r) => {
-        firstFetchCalled = r;
-      });
-
-      stub.onCall(0).callsFake(() => {
-        firstFetchCalled();
-        return deferred.promise;
-      });
-      stub.onCall(1).resolves(new Response('ok', { status: 200 }));
-
-      const transport = makeTransport({ compression: 'gzip' });
-
-      const first = transport.send(incompressiblePayload(30 * 1024), 5000);
-      await firstFetchCalledPromise;
-
-      // Compressed ~30KiB still inflight + another compressed ~30KiB > 48KiB
-      await transport.send(incompressiblePayload(30 * 1024), 5000);
-
-      expect(fakeFetchGetKeepalive(0)).to.equal(true);
-      expect(fakeFetchGetKeepalive(1)).to.equal(false);
-
-      deferred.resolve(new Response('ok', { status: 200 }));
-      await first;
-    });
-
-    it('should free budget after gzip request completes', async () => {
-      fakeFetchRespondWith('ok', { status: 200 });
-      const transport = makeTransport({ compression: 'gzip' });
-
-      // Two of these compress to ~60KiB combined, over the 48KiB budget, so the
-      // second send only keeps keepalive if the first freed its share.
-      await transport.send(incompressiblePayload(30 * 1024), 5000);
-      await transport.send(incompressiblePayload(30 * 1024), 5000);
-
-      expect(fakeFetchGetKeepalive(0)).to.equal(true);
-      expect(fakeFetchGetKeepalive(1)).to.equal(true);
-    });
-
-    it('should free budget after gzip request fails', async () => {
-      const stub = reinstallFetch();
-      stub.onCall(0).rejects(new TypeError('Failed to fetch'));
-      stub.onCall(1).resolves(new Response('ok', { status: 200 }));
-
-      const transport = makeTransport({ compression: 'gzip' });
-
-      await transport.send(incompressiblePayload(30 * 1024), 5000);
-      await transport.send(incompressiblePayload(30 * 1024), 5000);
-
-      expect(fakeFetchGetKeepalive(0)).to.equal(true);
-      expect(fakeFetchGetKeepalive(1)).to.equal(true);
-    });
-  });
-
-  describe('gzip compression', () => {
-    it('should set Content-Encoding and send compressed bytes', async () => {
-      fakeFetchRespondWith('ok', { status: 200 });
-      const transport = makeTransport({ compression: 'gzip' });
-
-      const json = '{"a":"' + 'x'.repeat(5000) + '"}';
-      await transport.send(new TextEncoder().encode(json), 5000);
-
-      const headers = fakeFetchGetRequestHeaders() as Record<string, string>;
-      expect(headers['Content-Encoding']).to.equal('gzip');
-      // Content-Length is a forbidden fetch header, so the SDK must not set it
-      expect(headers['Content-Length']).to.be.undefined;
-
-      const body = fakeFetchGetBody() as Uint8Array<ArrayBuffer>;
-      expect(body.byteLength).to.be.lessThan(json.length);
-      expect(await gunzipToText(body)).to.equal(json);
-    });
-
-    it('should reach fetch in the same task as send', () => {
-      fakeFetchRespondWith('ok', { status: 200 });
-      const transport = makeTransport({ compression: 'gzip' });
-
-      void transport.send(smallPayload, 5000);
-
-      // Deliberately not awaited: teardown grants only a synchronous budget, so
-      // an await between send and fetch loses the payload on the unload path.
-      expect(fakeFetchWasCalled()).to.equal(true);
     });
   });
 

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
@@ -2,6 +2,7 @@ import { DiagLogLevel, diag } from '@opentelemetry/api';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {
+  fakeFetchGetBody,
   fakeFetchGetKeepalive,
   fakeFetchGetRequestHeaders,
   fakeFetchInstall,
@@ -26,6 +27,18 @@ const makeTransport = (
 
 const smallPayload = new TextEncoder().encode('{"small": true}');
 const largePayload = new Uint8Array(49153); // 1 byte over the 48KiB budget
+
+// Random bytes barely shrink under gzip, so the compressed size stays close to
+// the requested one and keepalive budget arithmetic is exercised for real.
+const incompressiblePayload = (byteLength: number) =>
+  crypto.getRandomValues(new Uint8Array(byteLength));
+
+const gunzipToText = async (body: Uint8Array<ArrayBuffer>) => {
+  const stream = new Response(body).body?.pipeThrough(
+    new DecompressionStream('gzip'),
+  );
+  return new Response(stream).text();
+};
 
 interface Deferred {
   promise: Promise<Response>;
@@ -273,17 +286,11 @@ describe('FetchTransport', () => {
 
       const transport = makeTransport({ compression: 'gzip' });
 
-      // Random data does not compress well — stays close to original size
-      const payload30k = new Uint8Array(30 * 1024);
-      crypto.getRandomValues(payload30k);
-
-      const first = transport.send(payload30k, 5000);
+      const first = transport.send(incompressiblePayload(30 * 1024), 5000);
       await firstFetchCalledPromise;
 
-      // Second random payload: compressed ~30KiB + compressed ~30KiB > 48KiB
-      const payload30k2 = new Uint8Array(30 * 1024);
-      crypto.getRandomValues(payload30k2);
-      await transport.send(payload30k2, 5000);
+      // Compressed ~30KiB still inflight + another compressed ~30KiB > 48KiB
+      await transport.send(incompressiblePayload(30 * 1024), 5000);
 
       expect(fakeFetchGetKeepalive(0)).to.equal(true);
       expect(fakeFetchGetKeepalive(1)).to.equal(false);
@@ -296,10 +303,10 @@ describe('FetchTransport', () => {
       fakeFetchRespondWith('ok', { status: 200 });
       const transport = makeTransport({ compression: 'gzip' });
 
-      const payload40k = new Uint8Array(40 * 1024);
-
-      await transport.send(payload40k, 5000);
-      await transport.send(payload40k, 5000);
+      // Two of these compress to ~60KiB combined, over the 48KiB budget, so the
+      // second send only keeps keepalive if the first freed its share.
+      await transport.send(incompressiblePayload(30 * 1024), 5000);
+      await transport.send(incompressiblePayload(30 * 1024), 5000);
 
       expect(fakeFetchGetKeepalive(0)).to.equal(true);
       expect(fakeFetchGetKeepalive(1)).to.equal(true);
@@ -312,10 +319,8 @@ describe('FetchTransport', () => {
 
       const transport = makeTransport({ compression: 'gzip' });
 
-      const payload40k = new Uint8Array(40 * 1024);
-
-      await transport.send(payload40k, 5000);
-      await transport.send(payload40k, 5000);
+      await transport.send(incompressiblePayload(30 * 1024), 5000);
+      await transport.send(incompressiblePayload(30 * 1024), 5000);
 
       expect(fakeFetchGetKeepalive(0)).to.equal(true);
       expect(fakeFetchGetKeepalive(1)).to.equal(true);
@@ -327,15 +332,17 @@ describe('FetchTransport', () => {
       fakeFetchRespondWith('ok', { status: 200 });
       const transport = makeTransport({ compression: 'gzip' });
 
-      const payload = new TextEncoder().encode(
-        '{"a":"' + 'x'.repeat(5000) + '"}',
-      );
-      await transport.send(payload, 5000);
+      const json = '{"a":"' + 'x'.repeat(5000) + '"}';
+      await transport.send(new TextEncoder().encode(json), 5000);
 
       const headers = fakeFetchGetRequestHeaders() as Record<string, string>;
       expect(headers['Content-Encoding']).to.equal('gzip');
       // Content-Length is a forbidden fetch header, so the SDK must not set it
       expect(headers['Content-Length']).to.be.undefined;
+
+      const body = fakeFetchGetBody() as Uint8Array<ArrayBuffer>;
+      expect(body.byteLength).to.be.lessThan(json.length);
+      expect(await gunzipToText(body)).to.equal(json);
     });
 
     it('should reach fetch in the same task as send', () => {
@@ -347,49 +354,6 @@ describe('FetchTransport', () => {
       // Deliberately not awaited: teardown grants only a synchronous budget, so
       // an await between send and fetch loses the payload on the unload path.
       expect(fakeFetchWasCalled()).to.equal(true);
-    });
-  });
-
-  describe('compression failure', () => {
-    // gzipSync is a pure function, so the only way to force its failure path is
-    // to hand it input that throws when read.
-    const poisonedPayload = () =>
-      new Proxy(new Uint8Array(0), {
-        get() {
-          throw new Error('gzip input unreadable');
-        },
-      });
-
-    it('should return failure with diagnostic log when compression fails', async () => {
-      const transport = makeTransport({ compression: 'gzip' });
-      const result = await transport.send(poisonedPayload(), 1000);
-
-      expect(result.status).to.equal('failure');
-
-      const warns = diagLogger.getWarnLogs();
-      expect(
-        warns.some((msg) =>
-          msg.includes('gzip compression failed: gzip input unreadable'),
-        ),
-      ).to.be.true;
-    });
-
-    it('should not corrupt keepalive counters when compression fails', async () => {
-      const transport = makeTransport({ compression: 'gzip' });
-      await transport.send(poisonedPayload(), 1000);
-
-      fakeFetchRespondWith('ok', { status: 200 });
-      const transport2 = makeTransport();
-      await transport2.send(smallPayload, 1000);
-
-      expect(fakeFetchGetKeepalive()).to.equal(true);
-    });
-
-    it('should not send when compression fails', async () => {
-      const transport = makeTransport({ compression: 'gzip' });
-      await transport.send(poisonedPayload(), 1000);
-
-      expect(fakeFetchWasCalled()).to.equal(false);
     });
   });
 

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
@@ -3,9 +3,11 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {
   fakeFetchGetKeepalive,
+  fakeFetchGetRequestHeaders,
   fakeFetchInstall,
   fakeFetchRespondWith,
   fakeFetchRestore,
+  fakeFetchWasCalled,
   InMemoryDiagLogger,
 } from '../../../tests/utils/index.ts';
 import { _resetKeepaliveTracking, FetchTransport } from './FetchTransport.ts';
@@ -320,47 +322,74 @@ describe('FetchTransport', () => {
     });
   });
 
+  describe('gzip compression', () => {
+    it('should set Content-Encoding and send compressed bytes', async () => {
+      fakeFetchRespondWith('ok', { status: 200 });
+      const transport = makeTransport({ compression: 'gzip' });
+
+      const payload = new TextEncoder().encode(
+        '{"a":"' + 'x'.repeat(5000) + '"}',
+      );
+      await transport.send(payload, 5000);
+
+      const headers = fakeFetchGetRequestHeaders() as Record<string, string>;
+      expect(headers['Content-Encoding']).to.equal('gzip');
+      // Content-Length is a forbidden fetch header, so the SDK must not set it
+      expect(headers['Content-Length']).to.be.undefined;
+    });
+
+    it('should reach fetch in the same task as send', () => {
+      fakeFetchRespondWith('ok', { status: 200 });
+      const transport = makeTransport({ compression: 'gzip' });
+
+      void transport.send(smallPayload, 5000);
+
+      // Deliberately not awaited: teardown grants only a synchronous budget, so
+      // an await between send and fetch loses the payload on the unload path.
+      expect(fakeFetchWasCalled()).to.equal(true);
+    });
+  });
+
   describe('compression failure', () => {
+    // gzipSync is a pure function, so the only way to force its failure path is
+    // to hand it input that throws when read.
+    const poisonedPayload = () =>
+      new Proxy(new Uint8Array(0), {
+        get() {
+          throw new Error('gzip input unreadable');
+        },
+      });
+
     it('should return failure with diagnostic log when compression fails', async () => {
-      const original = globalThis.CompressionStream;
-      globalThis.CompressionStream = class {
-        constructor() {
-          throw new Error('CompressionStream not supported');
-        }
-      } as unknown as typeof CompressionStream;
+      const transport = makeTransport({ compression: 'gzip' });
+      const result = await transport.send(poisonedPayload(), 1000);
 
-      try {
-        const transport = makeTransport({ compression: 'gzip' });
-        const result = await transport.send(smallPayload, 1000);
+      expect(result.status).to.equal('failure');
 
-        expect(result.status).to.equal('failure');
-
-        const warns = diagLogger.getWarnLogs();
-        expect(warns.some((msg) => msg.includes('gzip compression failed'))).to
-          .be.true;
-      } finally {
-        globalThis.CompressionStream = original;
-      }
+      const warns = diagLogger.getWarnLogs();
+      expect(
+        warns.some((msg) =>
+          msg.includes('gzip compression failed: gzip input unreadable'),
+        ),
+      ).to.be.true;
     });
 
     it('should not corrupt keepalive counters when compression fails', async () => {
-      const original = globalThis.CompressionStream;
-      globalThis.CompressionStream = class {
-        constructor() {
-          throw new Error('CompressionStream not supported');
-        }
-      } as unknown as typeof CompressionStream;
-
       const transport = makeTransport({ compression: 'gzip' });
-      await transport.send(smallPayload, 1000);
-
-      globalThis.CompressionStream = original;
+      await transport.send(poisonedPayload(), 1000);
 
       fakeFetchRespondWith('ok', { status: 200 });
       const transport2 = makeTransport();
       await transport2.send(smallPayload, 1000);
 
       expect(fakeFetchGetKeepalive()).to.equal(true);
+    });
+
+    it('should not send when compression fails', async () => {
+      const transport = makeTransport({ compression: 'gzip' });
+      await transport.send(poisonedPayload(), 1000);
+
+      expect(fakeFetchWasCalled()).to.equal(false);
     });
   });
 

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
@@ -3,6 +3,7 @@ import type {
   ExportResponse,
   IExporterTransport,
 } from '@opentelemetry/otlp-exporter-base';
+import { gzipSync } from 'fflate';
 import type { FetchRequestParameters } from './types.ts';
 
 // The fetch spec limits inflight keepalive request bodies to 64KiB total per
@@ -25,44 +26,6 @@ export function _resetKeepaliveTracking(): void {
 
 export class FetchTransport implements IExporterTransport {
   public constructor(private readonly _config: FetchRequestParameters) {}
-
-  // Embrace endpoints require request bodies to be compressed with gzip
-  private static async _compressRequest(
-    data: Uint8Array<ArrayBuffer>,
-  ): Promise<Uint8Array<ArrayBuffer>> {
-    const stream = new CompressionStream('gzip');
-    const writer = stream.writable.getWriter();
-
-    void writer.write(data);
-    void writer.close();
-
-    const compressedChunks: Uint8Array[] = [];
-    const reader = stream.readable.getReader();
-
-    let done = false;
-    while (!done) {
-      const result = await reader.read();
-
-      if (result.value) {
-        compressedChunks.push(result.value);
-      }
-
-      done = result.done;
-    }
-
-    const compressedData = new Uint8Array(
-      compressedChunks.reduce((acc, chunk) => acc + chunk.length, 0),
-    );
-
-    let offset = 0;
-
-    for (const chunk of compressedChunks) {
-      compressedData.set(chunk, offset);
-      offset += chunk.length;
-    }
-
-    return compressedData;
-  }
 
   public send(
     data: Uint8Array<ArrayBuffer>,
@@ -107,7 +70,9 @@ export class FetchTransport implements IExporterTransport {
     try {
       if (this._config.compression === 'gzip') {
         try {
-          request = await FetchTransport._compressRequest(data);
+          // Synchronous so the unload-path keepalive fetch is issued in the
+          // same task; mtime 0 keeps the wall clock out of the gzip header.
+          request = gzipSync(data, { mtime: 0 });
         } catch (error) {
           const compressError =
             error instanceof Error ? error : new Error(String(error));
@@ -117,7 +82,6 @@ export class FetchTransport implements IExporterTransport {
           return { status: 'failure', error: compressError };
         }
         headers['Content-Encoding'] = 'gzip';
-        headers['Content-Length'] = request.length.toString();
       }
 
       const wouldExceedBytes =

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
@@ -3,7 +3,6 @@ import type {
   ExportResponse,
   IExporterTransport,
 } from '@opentelemetry/otlp-exporter-base';
-import { gzipSync } from 'fflate';
 import type { FetchRequestParameters } from './types.ts';
 
 // The fetch spec limits inflight keepalive request bodies to 64KiB total per
@@ -42,7 +41,6 @@ export class FetchTransport implements IExporterTransport {
     data: Uint8Array<ArrayBuffer>,
     timeoutMillis: number,
   ): Promise<ExportResponse> {
-    let request = data;
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       ...this._config.headers,
@@ -68,24 +66,17 @@ export class FetchTransport implements IExporterTransport {
     let keepalive = false;
 
     try {
-      if (this._config.compression === 'gzip') {
-        // Synchronous so the unload-path keepalive fetch is issued in the same
-        // task; mtime 0 keeps the wall clock out of the gzip header.
-        request = gzipSync(data, { mtime: 0 });
-        headers['Content-Encoding'] = 'gzip';
-      }
-
       const wouldExceedBytes =
-        inflightKeepaliveBytes + request.byteLength > KEEPALIVE_BYTE_BUDGET;
+        inflightKeepaliveBytes + data.byteLength > KEEPALIVE_BYTE_BUDGET;
       const wouldExceedCount = inflightKeepaliveCount >= MAX_KEEPALIVE_REQUESTS;
       keepalive = !wouldExceedBytes && !wouldExceedCount;
 
       if (keepalive) {
-        inflightKeepaliveBytes += request.byteLength;
+        inflightKeepaliveBytes += data.byteLength;
         inflightKeepaliveCount++;
       } else {
         const reason = wouldExceedBytes
-          ? `inflight bytes (${inflightKeepaliveBytes} + ${request.byteLength}) would exceed ${KEEPALIVE_BYTE_BUDGET}B budget`
+          ? `inflight bytes (${inflightKeepaliveBytes} + ${data.byteLength}) would exceed ${KEEPALIVE_BYTE_BUDGET}B budget`
           : `concurrent count (${inflightKeepaliveCount}) at limit of ${MAX_KEEPALIVE_REQUESTS}`;
         diag.debug(`Sending without keepalive: ${reason}`);
       }
@@ -94,7 +85,7 @@ export class FetchTransport implements IExporterTransport {
         method: 'POST',
         keepalive,
         headers,
-        body: request,
+        body: data,
         signal,
       });
 
@@ -132,7 +123,7 @@ export class FetchTransport implements IExporterTransport {
         clearTimeout(timeoutId);
       }
       if (keepalive) {
-        inflightKeepaliveBytes -= request.byteLength;
+        inflightKeepaliveBytes -= data.byteLength;
         inflightKeepaliveCount--;
       }
     }

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
@@ -69,18 +69,9 @@ export class FetchTransport implements IExporterTransport {
 
     try {
       if (this._config.compression === 'gzip') {
-        try {
-          // Synchronous so the unload-path keepalive fetch is issued in the
-          // same task; mtime 0 keeps the wall clock out of the gzip header.
-          request = gzipSync(data, { mtime: 0 });
-        } catch (error) {
-          const compressError =
-            error instanceof Error ? error : new Error(String(error));
-          diag.warn(
-            `Fetch transport gzip compression failed: ${compressError.message}`,
-          );
-          return { status: 'failure', error: compressError };
-        }
+        // Synchronous so the unload-path keepalive fetch is issued in the same
+        // task; mtime 0 keeps the wall clock out of the gzip header.
+        request = gzipSync(data, { mtime: 0 });
         headers['Content-Encoding'] = 'gzip';
       }
 

--- a/packages/web-sdk/src/transport/FetchTransport/createFetchTransport.test.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/createFetchTransport.test.ts
@@ -24,11 +24,10 @@ describe('createFetchTransport', () => {
     fakeFetchRestore();
   });
 
-  it('should allow sending without compression', async () => {
+  it('should send data with configured headers', async () => {
     const transport = createFetchTransport({
       url: 'http://example.com',
       headers: { foo: 'bar' },
-      compression: 'none',
     });
 
     fakeFetchRespondWith('ok', { status: 200 });
@@ -50,39 +49,10 @@ describe('createFetchTransport', () => {
     expect(result).to.deep.equal({ status: 'success' });
   });
 
-  it('should allow sending with compression', async () => {
-    const transport = createFetchTransport({
-      url: 'http://example.com',
-      headers: { foo: 'bar' },
-      compression: 'gzip',
-    });
-
-    fakeFetchRespondWith('ok', { status: 200 });
-    const result = await transport.send(
-      new TextEncoder().encode('{"data": "my data"}'),
-      1000,
-    );
-
-    expect(fakeFetchGetUrl()).to.equal('http://example.com');
-    expect(fakeFetchGetMethod()).to.equal('POST');
-    const decompressedStream = new Response(
-      fakeFetchGetBody(),
-    ).body?.pipeThrough(new DecompressionStream('gzip'));
-    const body = await new Response(decompressedStream).text();
-    expect(body).to.equal('{"data": "my data"}');
-    expect(
-      (fakeFetchGetRequestHeaders() as Record<string, string>)[
-        'Content-Encoding'
-      ],
-    ).to.equal('gzip');
-    expect(result).to.deep.equal({ status: 'success' });
-  });
-
   it('should handle request failures', async () => {
     const transport = createFetchTransport({
       url: 'http://example.com',
       headers: { foo: 'bar' },
-      compression: 'none',
     });
 
     fakeFetchRespondWith('error', { status: 500 });

--- a/packages/web-sdk/src/transport/FetchTransport/types.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/types.ts
@@ -1,5 +1,4 @@
 export interface FetchRequestParameters {
   url: string;
   headers: Record<string, string>;
-  compression: 'gzip' | 'none';
 }

--- a/tests/integration/config/thresholds.ts
+++ b/tests/integration/config/thresholds.ts
@@ -10,7 +10,7 @@ const TOTAL_UNCOMPRESSED_SIZE_THRESHOLD_IN_KB = getFromEnv(
 );
 const TOTAL_GZIP_SIZE_THRESHOLD_IN_KB = getFromEnv(
   'TOTAL_GZIP_SIZE_THRESHOLD_IN_KB',
-  76,
+  80,
 );
 
 export {

--- a/tests/performance/config/thresholds.ts
+++ b/tests/performance/config/thresholds.ts
@@ -16,9 +16,10 @@ const TOTAL_TASK_DURATION_THRESHOLD_IN_MS = getFromEnv(
   'TOTAL_TASK_DURATION_THRESHOLD_IN_MS',
   1000,
 );
+// Includes headroom for the bundled fflate gzip dependency.
 const TOTAL_HEAP_SIZE_THRESHOLD_IN_MB = getFromEnv(
   'TOTAL_HEAP_SIZE_THRESHOLD_IN_MB',
-  16,
+  20,
 );
 const TOTAL_BLOCKING_TIME_THRESHOLD_IN_MS = getFromEnv(
   'TOTAL_BLOCKING_TIME_THRESHOLD_IN_MS',
@@ -28,9 +29,10 @@ const MAIN_THREAD_TIME_THRESHOLD_IN_MS = getFromEnv(
   'MAIN_THREAD_TIME_THRESHOLD_IN_MS',
   175,
 );
+// Includes headroom for evaluating the bundled fflate gzip dependency.
 const SCRIPT_EVAL_THRESHOLD_IN_MS = getFromEnv(
   'SCRIPT_EVAL_THRESHOLD_IN_MS',
-  175,
+  200,
 );
 
 export {


### PR DESCRIPTION
## What problem is this solving?

Compression lived in `FetchTransport`, which meant the transport had to know about encoding and the keepalive byte budget only measured wire size because it happened to compress first. Encoding is a serialization concern, so this moves it above the transport. Stacked on #1519, which made compression synchronous; this PR changes only where it runs.

## Short description of changes

- Add `GzipSerializer`, an `ISerializer` decorator that gzips at serialization time.
- Wire it into `createOtlpBrowserFetchExportDelegate`, which sets `Content-Encoding: gzip` from the same flag that installs the wrapper, so the header cannot drift from the body.
- Remove compression from `FetchTransport` and drop `compression` from `FetchRequestParameters`. The transport now sends the bytes it is handed, and the keepalive budget measures wire size by construction.
- Drop the hardcoded `compression: 'gzip'` in `OTLPFetchTraceExporter`, which was redundant with `DEFAULT_EMBRACE_EXPORTER_CONFIG`.

## How has this been tested?

Unit tests for the transport and exporters. Notable coverage:

- Both branches of the gzip flag: `Content-Encoding` present with a compressed body, and absent with plain JSON.
- The keepalive budget is charged compressed bytes, via a span that serializes past the 48KiB budget but gzips well under it.
- Export reaches `fetch` in the same task, so the unload-path guarantee survives the move.

## Checklist

- [ ] Documentation added
- [x] Tests added

