### PR TITLE
refactor(demo): replace backend script endpoints with static files

### DIFF
--- a/.github/workflows/publish-demo.yaml
+++ b/.github/workflows/publish-demo.yaml
@@ -3,11 +3,6 @@ name: Publish Frontend Demo to GitHub Pages
 on:
   push:
     branches: [main]
-    paths:
-      - demo/**
-      - package*.json
-      - packages/web-sdk/src/**
-      - .nvmrc
   workflow_dispatch:
 
 permissions:

--- a/demo/frontend/index.html
+++ b/demo/frontend/index.html
@@ -4,11 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Embrace Web SDK React Demo</title>
-    <script src="http://localhost:3001/script/100"></script>
-    <script src="http://localhost:3001/script/101"></script>
+    <script src="/script1.js"></script>
+    <script src="/script2.js"></script>
     <script type="module">
-      // Redirect to correct demo if accessing a router demo path
       const baseUrl = import.meta.env.BASE_URL;
+
+      // Redirect to correct demo if accessing a router demo path
       const path = window.location.pathname;
 
       const getRouterPath = routerName => {

--- a/demo/frontend/package.json
+++ b/demo/frontend/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "check": "tsc",
     "clean": "npx -y rimraf .sonda dist",
-    "dev": "VITE_BASE_URL=/embrace-web-sdk/ vite --open",
-    "build": "VITE_BASE_URL=/embrace-web-sdk/ vite build",
-    "preview": "VITE_BASE_URL=/embrace-web-sdk/ vite preview --open",
+    "dev": "vite --open",
+    "build": "vite build",
+    "preview": "vite preview --open",
     "demo": "bash ./scripts/runDemo.sh",
     "upload-sourcemaps": "embrace-web-cli upload --app-version 0.0.1",
     "upload-sourcemaps:dry": "embrace-web-cli upload -d --app-version 0.0.1"

--- a/demo/frontend/public/loaf200.js
+++ b/demo/frontend/public/loaf200.js
@@ -1,0 +1,7 @@
+const count = Math.floor(Math.random() * 4) + 2;
+for (let i = 0; i < count; i++) {
+  setTimeout(() => {
+    const start = Date.now();
+    while (Date.now() - start < 200) {}
+  }, Math.random() * 2000);
+}

--- a/demo/frontend/public/loaf400.js
+++ b/demo/frontend/public/loaf400.js
@@ -1,0 +1,7 @@
+const count = Math.floor(Math.random() * 4) + 2;
+for (let i = 0; i < count; i++) {
+  setTimeout(() => {
+    const start = Date.now();
+    while (Date.now() - start < 400) {}
+  }, Math.random() * 2000);
+}

--- a/demo/frontend/public/loaf600.js
+++ b/demo/frontend/public/loaf600.js
@@ -1,0 +1,7 @@
+const count = Math.floor(Math.random() * 4) + 2;
+for (let i = 0; i < count; i++) {
+  setTimeout(() => {
+    const start = Date.now();
+    while (Date.now() - start < 600) {}
+  }, Math.random() * 2000);
+}

--- a/demo/frontend/public/loaf800.js
+++ b/demo/frontend/public/loaf800.js
@@ -1,0 +1,7 @@
+const count = Math.floor(Math.random() * 4) + 2;
+for (let i = 0; i < count; i++) {
+  setTimeout(() => {
+    const start = Date.now();
+    while (Date.now() - start < 800) {}
+  }, Math.random() * 2000);
+}

--- a/demo/frontend/public/script1.js
+++ b/demo/frontend/public/script1.js
@@ -1,0 +1,1 @@
+console.info('script1.js loaded', performance.now());

--- a/demo/frontend/public/script2.js
+++ b/demo/frontend/public/script2.js
@@ -1,0 +1,1 @@
+console.info('script2.js loaded', performance.now());

--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -208,13 +208,15 @@ const App = () => {
     }, 100);
   };
 
+  const loafDurations = [200, 400, 600, 800];
+
   const handleLoadLoafScripts = () => {
-    for (let i = 1; i <= 4; i++) {
+    for (const duration of loafDurations) {
       const script = document.createElement('script');
       script.type = 'module';
-      script.src = `http://localhost:3001/loaf/${i}`;
+      script.src = `${import.meta.env.BASE_URL}loaf${duration}.js`;
       script.onerror = () => {
-        console.error(`failed to load loaf script ${i}`);
+        console.error(`failed to load loaf script ${duration}`);
       };
       document.body.appendChild(script);
     }

--- a/demo/frontend/src/otel-base.ts
+++ b/demo/frontend/src/otel-base.ts
@@ -22,6 +22,12 @@ const setupSDK = (instrumentations?: Instrumentation[]) => {
       'empty-root': {
         rootNode: document.getElementById('root'),
       },
+      // To exclude specific instrumentations use the `omit` field:
+      // omit: new Set([
+      //   '@opentelemetry/instrumentation-fetch',
+      //   '@opentelemetry/instrumentation-xml-http-request',
+      //   'document-load',
+      // ]),
     },
     ...(instrumentations ? { instrumentations } : {}),
     embraceDataURL: DATA_URL ?? undefined,

--- a/demo/frontend/vite.config.ts
+++ b/demo/frontend/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from 'vite';
 // To send telemetry to it, set VITE_DATA_URL=http://localhost:3001 in .env.
 // https://vite.dev/config/
 export default defineConfig({
-  base: process.env.VITE_BASE_URL || '/',
+  base: process.env.GITHUB_ACTIONS ? '/embrace-web-sdk/' : '/',
   plugins: [Sonda({ enabled: false })],
   build: {
     sourcemap: true,

--- a/server/server.ts
+++ b/server/server.ts
@@ -162,29 +162,6 @@ const server = createServer((req, res) => {
     return;
   }
 
-  if (req.method === 'GET' && pathname.startsWith('/loaf/')) {
-    res.writeHead(200, { 'Content-Type': 'application/javascript' });
-    const duration = Math.floor(Math.random() * 901) + 100;
-    res.end(
-      `
-const count = Math.floor(Math.random() * 4) + 2;
-for (let i = 0; i < count; i++) {
-  setTimeout(() => {
-    const start = Date.now();
-    while (Date.now() - start < ${duration}) {}
-  }, Math.random() * 2000);
-}
-    `.trim(),
-    );
-    return;
-  }
-
-  if (req.method === 'GET' && pathname.startsWith('/script/')) {
-    res.writeHead(200, { 'Content-Type': 'application/javascript' });
-    res.end(`console.log('script loaded', '${JSON.stringify(pathname)}')`);
-    return;
-  }
-
   if (pathname === '/embrace-web-sdk.js') {
     serveFile(res, join(sdkDistDir, 'embrace-web-sdk.js'));
     return;


### PR DESCRIPTION
## What problem is this solving?
The demo frontend required a running backend server to serve script and LoAF files, making it harder to deploy as a standalone GitHub Pages site.

## Short description of changes
- Replace localhost backend URLs with static JS files served from `public/`
- Remove `/loaf/` and `/script/` endpoints from the API server
- Simplify vite base URL config to use `GITHUB_ACTIONS` env var instead of `VITE_BASE_URL`
- Remove path filters from publish-demo workflow so it triggers on any push to main
- Add example comment showing how to omit specific instrumentations

## Testing
- Verify demo builds and runs locally with `npm run dev` from `demo/frontend/`
- Verify GitHub Pages deployment works after merge