### PR TITLE
fix(demo): use tsc --build to follow project references in check script

### DIFF
--- a/demo/frontend/package.json
+++ b/demo/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "tsc",
+    "check": "tsc --build",
     "clean": "npx -y rimraf .sonda dist",
     "dev": "vite --open",
     "build": "vite build",

--- a/demo/frontend/turbo.json
+++ b/demo/frontend/turbo.json
@@ -16,6 +16,10 @@
       "with": ["//#server"],
       "cache": false,
       "persistent": true
+    },
+    "check": {
+      "dependsOn": ["^build"],
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## What problem is this solving?
The demo frontend's `check` script ran bare `tsc`, which used the root `tsconfig.json` with `"files": []` and project references. Without `--build`, TypeScript checked zero files and always passed, silently skipping type errors.

## Short description of changes
- Changed `check` script from `tsc` to `tsc --build` so TypeScript follows project references and actually type-checks `tsconfig.app.json` and `tsconfig.node.json`
- Added `check` task to demo's `turbo.json` with `dependsOn: ["^build"]` so dependencies are built before type-checking

## Testing
- Verified `tsc --build` catches real TS errors when present
- Verified pre-commit hook passes after a clean build