### PR TITLE
fix: add emb.web_vital.id to LoafInstrumentation report

### DIFF
--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
@@ -165,6 +165,9 @@ describe('LoafInstrumentation', () => {
     expect(report?.eventName).to.equal('emb-loaf-report');
     expect(report?.severityNumber).to.equal(SeverityNumber.INFO);
     expect(report?.attributes['emb.type']).to.equal('ux.web_vital');
+    expect(report?.attributes['emb.web_vital.id'])
+      .to.be.a('string')
+      .and.to.have.length.greaterThan(0);
     expect(report?.attributes['emb.web_vital.name']).to.equal('TBD');
     expect(report?.attributes['emb.tbd.loaf_total_duration']).to.equal(180);
     expect(report?.attributes['emb.tbd.loaf_count']).to.equal(2);
@@ -172,7 +175,7 @@ describe('LoafInstrumentation', () => {
     expect(
       report?.attributes['emb.tbd.loaf_longest_duration_excluding_first'],
     ).to.equal(80);
-    expect(Object.keys(report?.attributes ?? {})).to.have.lengthOf(10);
+    expect(Object.keys(report?.attributes ?? {})).to.have.lengthOf(11);
 
     instrumentation.disable();
   });
@@ -515,6 +518,35 @@ describe('LoafInstrumentation', () => {
       .getFinishedLogRecords()
       .filter((l) => l.eventName === 'emb-loaf-report');
     expect(reports).to.have.lengthOf(0);
+  });
+
+  it('should generate a unique web vital id per session', () => {
+    const instrumentation = new LoafInstrumentation({ perf });
+    instrumentation.setSessionManager(spanSessionManager);
+
+    triggerEntries([makeEntry({ duration: 100 })]);
+    spanSessionManager.endSessionSpan();
+
+    const firstReport = memoryExporter
+      .getFinishedLogRecords()
+      .find((l) => l.eventName === 'emb-loaf-report');
+    const firstId = firstReport?.attributes['emb.web_vital.id'];
+    expect(firstId).to.be.a('string').and.to.have.length.greaterThan(0);
+
+    memoryExporter.reset();
+    spanSessionManager.startSessionSpan();
+
+    triggerEntries([makeEntry({ duration: 80 })]);
+    spanSessionManager.endSessionSpan();
+
+    const secondReport = memoryExporter
+      .getFinishedLogRecords()
+      .find((l) => l.eventName === 'emb-loaf-report');
+    const secondId = secondReport?.attributes['emb.web_vital.id'];
+    expect(secondId).to.be.a('string').and.to.have.length.greaterThan(0);
+    expect(secondId).to.not.equal(firstId);
+
+    instrumentation.disable();
   });
 
   it('should not bleed accumulated data across sessions', () => {

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
@@ -47,7 +47,6 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
   private _longestDurationExcludingFirst = 0;
   private _totalBlockingDuration = 0;
   private _scriptSummaries: ScriptSummaries = new Map();
-  private _id: string = generateWebVitalID();
 
   public constructor({ diag, perf }: LoafInstrumentationArgs = {}) {
     super({
@@ -212,7 +211,7 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
 
     const attrs: Record<string, string | number> = {
       [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
-      ['emb.web_vital.id']: this._id,
+      ['emb.web_vital.id']: generateWebVitalID(),
       ['emb.web_vital.name']: 'TBD',
       ['emb.web_vital.value']: Math.round(this._totalBlockingDuration),
       ['emb.web_vital.rating']: rating,
@@ -279,6 +278,5 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
     this._longestDurationExcludingFirst = 0;
     this._totalBlockingDuration = 0;
     this._scriptSummaries = new Map();
-    this._id = generateWebVitalID();
   }
 }

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
@@ -7,6 +7,7 @@ import {
   createPerformanceObserver,
   isEntryTypeSupported,
 } from '../../../utils/index.ts';
+import { generateUUID } from '../../../utils/generateUUID.ts';
 import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
 import {
   ATTR_TBD_LOAF_COUNT,
@@ -46,6 +47,7 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
   private _longestDurationExcludingFirst = 0;
   private _totalBlockingDuration = 0;
   private _scriptSummaries: ScriptSummaries = new Map();
+  private _id: string = generateUUID();
 
   public constructor({ diag, perf }: LoafInstrumentationArgs = {}) {
     super({
@@ -210,6 +212,7 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
 
     const attrs: Record<string, string | number> = {
       [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
+      ['emb.web_vital.id']: this._id,
       ['emb.web_vital.name']: 'TBD',
       ['emb.web_vital.value']: Math.round(this._totalBlockingDuration),
       ['emb.web_vital.rating']: rating,
@@ -276,5 +279,6 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
     this._longestDurationExcludingFirst = 0;
     this._totalBlockingDuration = 0;
     this._scriptSummaries = new Map();
+    this._id = generateUUID(); 
   }
 }

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
@@ -3,11 +3,11 @@ import { SeverityNumber } from '@opentelemetry/api-logs';
 import type { Metric } from 'web-vitals';
 import type { SpanSessionManager } from '../../../api-sessions/index.ts';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/index.ts';
+import { generateWebVitalID } from '../../../utils/generateWebVitalID.ts';
 import {
   createPerformanceObserver,
   isEntryTypeSupported,
 } from '../../../utils/index.ts';
-import { generateWebVitalID } from '../../../utils/generateWebVitalID.ts';
 import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
 import {
   ATTR_TBD_LOAF_COUNT,

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
@@ -7,7 +7,7 @@ import {
   createPerformanceObserver,
   isEntryTypeSupported,
 } from '../../../utils/index.ts';
-import { generateUUID } from '../../../utils/generateUUID.ts';
+import { generateWebVitalID } from '../../../utils/generateWebVitalID.ts';
 import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
 import {
   ATTR_TBD_LOAF_COUNT,
@@ -47,7 +47,7 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
   private _longestDurationExcludingFirst = 0;
   private _totalBlockingDuration = 0;
   private _scriptSummaries: ScriptSummaries = new Map();
-  private _id: string = generateUUID();
+  private _id: string = generateWebVitalID();
 
   public constructor({ diag, perf }: LoafInstrumentationArgs = {}) {
     super({
@@ -279,6 +279,6 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
     this._longestDurationExcludingFirst = 0;
     this._totalBlockingDuration = 0;
     this._scriptSummaries = new Map();
-    this._id = generateUUID(); 
+    this._id = generateWebVitalID();
   }
 }

--- a/packages/web-sdk/src/utils/generateWebVitalID.test.ts
+++ b/packages/web-sdk/src/utils/generateWebVitalID.test.ts
@@ -4,9 +4,9 @@ import { generateWebVitalID } from './generateWebVitalID.ts';
 const { expect } = chai;
 
 describe('generateWebVitalID', () => {
-  it('should generate an id with the embracev1 prefix', () => {
+  it('should generate an id with the embracev2 prefix', () => {
     const id = generateWebVitalID();
-    expect(id).to.match(/^embracev1-/);
+    expect(id).to.match(/^embracev2-/);
   });
 
   it('should generate different ids on subsequent calls', () => {

--- a/packages/web-sdk/src/utils/generateWebVitalID.test.ts
+++ b/packages/web-sdk/src/utils/generateWebVitalID.test.ts
@@ -1,0 +1,35 @@
+import * as chai from 'chai';
+import { generateWebVitalID } from './generateWebVitalID.ts';
+
+const { expect } = chai;
+
+describe('generateWebVitalID', () => {
+  it('should generate an id with the v5 prefix', () => {
+    const id = generateWebVitalID();
+    expect(id).to.match(/^v5-/);
+  });
+
+  it('should generate different ids on subsequent calls', () => {
+    const id1 = generateWebVitalID();
+    const id2 = generateWebVitalID();
+    expect(id1).to.not.equal(id2);
+  });
+
+  it('should contain a timestamp and random component', () => {
+    const id = generateWebVitalID();
+    const parts = id.split('-');
+    // format: v5-<timestamp>-<random>
+    expect(parts).to.have.lengthOf(3);
+    expect(Number(parts[1])).to.be.a('number').and.greaterThan(0);
+    expect(Number(parts[2])).to.be.a('number').and.greaterThan(0);
+  });
+
+  it('should generate a random component within the expected range', () => {
+    for (let i = 0; i < 100; i++) {
+      const id = generateWebVitalID();
+      const random = Number(id.split('-')[2]);
+      expect(random).to.be.greaterThanOrEqual(1e12);
+      expect(random).to.be.lessThan(1e13);
+    }
+  });
+});

--- a/packages/web-sdk/src/utils/generateWebVitalID.test.ts
+++ b/packages/web-sdk/src/utils/generateWebVitalID.test.ts
@@ -4,9 +4,9 @@ import { generateWebVitalID } from './generateWebVitalID.ts';
 const { expect } = chai;
 
 describe('generateWebVitalID', () => {
-  it('should generate an id with the v5 prefix', () => {
+  it('should generate an id with the embracev1 prefix', () => {
     const id = generateWebVitalID();
-    expect(id).to.match(/^v5-/);
+    expect(id).to.match(/^embracev1-/);
   });
 
   it('should generate different ids on subsequent calls', () => {

--- a/packages/web-sdk/src/utils/generateWebVitalID.ts
+++ b/packages/web-sdk/src/utils/generateWebVitalID.ts
@@ -1,5 +1,5 @@
 // Generates a unique ID for web vitals metrics, following the format "v5-{timestamp}-{randomNumber}"
 // https://github.com/GoogleChrome/web-vitals/blob/main/src/lib/generateUniqueID.ts
 export const generateWebVitalID = () => {
-  return `v5-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
+  return `embracev1-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
 };

--- a/packages/web-sdk/src/utils/generateWebVitalID.ts
+++ b/packages/web-sdk/src/utils/generateWebVitalID.ts
@@ -1,5 +1,5 @@
 // Generates a unique ID for web vitals metrics, following the format "v5-{timestamp}-{randomNumber}"
 // https://github.com/GoogleChrome/web-vitals/blob/main/src/lib/generateUniqueID.ts
 export const generateWebVitalID = () => {
-  return `embracev1-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
+  return `embracev2-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
 };

--- a/packages/web-sdk/src/utils/generateWebVitalID.ts
+++ b/packages/web-sdk/src/utils/generateWebVitalID.ts
@@ -1,0 +1,5 @@
+// Generates a unique ID for web vitals metrics, following the format "v5-{timestamp}-{randomNumber}"
+// https://github.com/GoogleChrome/web-vitals/blob/main/src/lib/generateUniqueID.ts
+export const generateWebVitalID = () => {
+  return `v5-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
+};

--- a/packages/web-sdk/src/utils/index.ts
+++ b/packages/web-sdk/src/utils/index.ts
@@ -6,6 +6,7 @@ export {
   type SpanStorageOptions,
 } from './EmbraceSpanStorage/index.ts';
 export { generateUUID } from './generateUUID.ts';
+export { generateWebVitalID } from './generateWebVitalID.ts';
 export { getIncrementedCount } from './getIncrementedCount.ts';
 export { getVisibilityState } from './getVisibilityState.ts';
 export { GLOBAL_CONFIG } from './globalConfig.ts';


### PR DESCRIPTION
## What problem is this solving?
LoAF reports were missing the `emb.web_vital.id` attribute

## Short description of changes
- Add `generateWebVitalID` utility (matching the web-vitals library ID format) and export it from `utils/index.ts`
- Use it in `LoafInstrumentation` to set `emb.web_vital.id` on each session's report, regenerated on every session reset