### PR TITLE
fix: add start_time and duration attributes to measure spans

### DIFF
--- a/packages/web-sdk/src/instrumentations/userTiming/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/userTiming/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
@@ -265,7 +265,7 @@ describe('UserTimingInstrumentation', () => {
     expect(span.attributes['emb.user_timing.duration']).to.equal(
       spanDurationMs,
     );
-    expect(span.attributes['user_timing.detail']).to.be.undefined;
+    expect(span.attributes['emb.user_timing.detail']).to.be.undefined;
 
     instrumentation.disable();
   });
@@ -281,7 +281,7 @@ describe('UserTimingInstrumentation', () => {
     ]);
 
     const span = spanExporter.getFinishedSpans()[0];
-    expect(span.attributes['user_timing.detail']).to.equal(
+    expect(span.attributes['emb.user_timing.detail']).to.equal(
       JSON.stringify({ component: 'nav', phase: 'render' }),
     );
 

--- a/packages/web-sdk/src/instrumentations/userTiming/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/userTiming/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
@@ -256,6 +256,15 @@ describe('UserTimingInstrumentation', () => {
     expect(span.name).to.equal('my-measure');
     expect(span.attributes['emb.instrumentation']).to.equal('user_timing');
     expect(span.attributes['emb.user_timing.entry_type']).to.equal('measure');
+    expect(span.attributes['emb.user_timing.start_time']).to.equal(50);
+    expect(span.attributes['emb.user_timing.duration']).to.equal(300);
+    // duration attribute must equal the span's own end-start delta
+    const spanDurationMs =
+      (span.endTime[0] - span.startTime[0]) * 1000 +
+      (span.endTime[1] - span.startTime[1]) / 1e6;
+    expect(span.attributes['emb.user_timing.duration']).to.equal(
+      spanDurationMs,
+    );
     expect(span.attributes['user_timing.detail']).to.be.undefined;
 
     instrumentation.disable();

--- a/packages/web-sdk/src/instrumentations/userTiming/UserTimingInstrumentation/UserTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/userTiming/UserTimingInstrumentation/UserTimingInstrumentation.ts
@@ -8,11 +8,11 @@ import {
 import { createPerformanceObserver } from '../../../utils/index.ts';
 import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
 import {
+  KEY_EMB_USER_TIMING_DETAIL,
   KEY_EMB_USER_TIMING_DURATION,
   KEY_EMB_USER_TIMING_ENTRY_TYPE,
   KEY_EMB_USER_TIMING_NAME,
   KEY_EMB_USER_TIMING_START_TIME,
-  KEY_USER_TIMING_DETAIL,
   USER_TIMING_EVENT_NAME,
 } from './constants.ts';
 import type {
@@ -126,6 +126,7 @@ export class UserTimingInstrumentation extends EmbraceInstrumentationBase {
       const span = this.tracer.startSpan(entry.name, {
         startTime: this.perf.epochMillisFromOriginOffset(entry.startTime),
         attributes: {
+          [KEY_EMB_TYPE]: EMB_TYPES.UserTiming,
           [KEY_EMB_INSTRUMENTATION]:
             EMB_PERFORMANCE_INSTRUMENTATIONS.UserTiming,
           [KEY_EMB_USER_TIMING_ENTRY_TYPE]: entry.entryType,
@@ -134,7 +135,7 @@ export class UserTimingInstrumentation extends EmbraceInstrumentationBase {
           ),
           [KEY_EMB_USER_TIMING_DURATION]: entry.duration,
           ...(measureDetail != null && {
-            [KEY_USER_TIMING_DETAIL]: JSON.stringify(measureDetail),
+            [KEY_EMB_USER_TIMING_DETAIL]: JSON.stringify(measureDetail),
           }),
         },
       });

--- a/packages/web-sdk/src/instrumentations/userTiming/UserTimingInstrumentation/UserTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/userTiming/UserTimingInstrumentation/UserTimingInstrumentation.ts
@@ -129,6 +129,10 @@ export class UserTimingInstrumentation extends EmbraceInstrumentationBase {
           [KEY_EMB_INSTRUMENTATION]:
             EMB_PERFORMANCE_INSTRUMENTATIONS.UserTiming,
           [KEY_EMB_USER_TIMING_ENTRY_TYPE]: entry.entryType,
+          [KEY_EMB_USER_TIMING_START_TIME]: this.perf.millisFromZeroTime(
+            entry.startTime,
+          ),
+          [KEY_EMB_USER_TIMING_DURATION]: entry.duration,
           ...(measureDetail != null && {
             [KEY_USER_TIMING_DETAIL]: JSON.stringify(measureDetail),
           }),

--- a/packages/web-sdk/src/instrumentations/userTiming/UserTimingInstrumentation/constants.ts
+++ b/packages/web-sdk/src/instrumentations/userTiming/UserTimingInstrumentation/constants.ts
@@ -4,4 +4,4 @@ export const KEY_EMB_USER_TIMING_NAME = 'emb.user_timing.name';
 export const KEY_EMB_USER_TIMING_START_TIME = 'emb.user_timing.start_time';
 export const KEY_EMB_USER_TIMING_DURATION = 'emb.user_timing.duration';
 export const KEY_EMB_USER_TIMING_ENTRY_TYPE = 'emb.user_timing.entry_type';
-export const KEY_USER_TIMING_DETAIL = 'user_timing.detail';
+export const KEY_EMB_USER_TIMING_DETAIL = 'emb.user_timing.detail';


### PR DESCRIPTION
## What problem is this solving?

`UserTimingInstrumentation` creates spans for `performance.measure` entries but was missing `emb.user_timing.start_time`, `emb.user_timing.duration`, and the `emb.user_timing.detail` attribute key lacked the `emb.` prefix used by all other keys.

## Short description of changes

- Added `emb.user_timing.start_time` and `emb.user_timing.duration` to measure span attributes, consistent with mark logs
- Renamed `user_timing.detail` → `emb.user_timing.detail` and its constant `KEY_USER_TIMING_DETAIL` → `KEY_EMB_USER_TIMING_DETAIL`
- Added test assertions for the new attributes, including a cross-check that `emb.user_timing.duration` equals the span's own `endTime - startTime` delta