### PR TITLE
EMBR-11208 test(integration): update goldens and harness for session-part attributes 2/3

### DIFF
--- a/tests/integration/platforms/webpack-4/src/index.js
+++ b/tests/integration/platforms/webpack-4/src/index.js
@@ -21,7 +21,7 @@ registerInstrumentations({
 });
 
 initSDK({
-  appID: '',
+  appID: '11111',
   appVersion: 'YOUR_APP_VERSION',
   logLevel: DiagLogLevel.INFO,
   spanExporters: [new ConsoleSpanExporter()],

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "service.name",
-            "value": {
-              "stringValue": "embrace-web-sdk"
-            }
-          },
-          {
             "key": "telemetry.sdk.name",
             "value": {
               "stringValue": "embrace-web-sdk"
@@ -60,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "FA8AC8E5166BD5544F9BD785A7138F35"
+              "stringValue": "38E4785D594F9AC9EA1D1A57D2F42749"
             }
           },
           {
@@ -74,6 +68,12 @@
             "value": {
               "stringValue": "1280x720"
             }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "embrace-web-sdk"
+            }
           }
         ],
         "droppedAttributesCount": 0
@@ -85,8 +85,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1775548362557500000",
-              "observedTimeUnixNano": "1775548362557000000",
+              "timeUnixNano": "1776992649971099854",
+              "observedTimeUnixNano": "1776992649971000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -102,13 +102,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at Fc.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:79323)\n    at _E.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:219639\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:967\n    at new Promise (<anonymous>)\n    at Zt (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:787)\n    at a (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:219611)\n    at F_ (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127510)"
+                    "stringValue": "Error\n    at Jc.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:83451)\n    at hy.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:233919\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:967\n    at new Promise (<anonymous>)\n    at $t (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:787)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:233891)\n    at W_ (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127510)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:126\":\"3d9bf9584dd68a94fe0fe5b0deec00f5\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:126\":\"29937d3984834c95529ba178c0e4d8c7\"}"
                   }
                 },
                 {
@@ -120,18 +120,38 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "F2F32DE8A4465E4C67AE1AA1E45CA3B7"
+                    "stringValue": "DE75956E3657F5D861298DD9AF65F19E"
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "83A57AC39CB4D4331343E93BE56F1BD0"
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "782CF2502D0162908A55A1F69AEDFC45"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "74CC1C0BECA6D604CF7D6605FC5D925E"
+                    "stringValue": "782CF2502D0162908A55A1F69AEDFC45"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
                   "key": "session.previous_id",
-                  "value": {}
+                  "value": {
+                    "stringValue": ""
+                  }
                 },
                 {
                   "key": "browser.url.full",

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "5DD77748CD9CB7D9518991B35DFE17FC"
+              "stringValue": "F3F14691A97627C293C1396D5ED073C8"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "84d6f4f731069c0fdf63106a33d444fb",
-              "spanId": "41a2cf3990223609",
+              "traceId": "36da5affd4b0dd07c8547d3d8a87f40b",
+              "spanId": "0a5677d9279136d0",
               "name": "emb-session",
               "kind": 1,
-              "startTimeUnixNano": "1776224086125000000",
-              "endTimeUnixNano": "1776224086719200000",
+              "startTimeUnixNano": "1777001909824000000",
+              "endTimeUnixNano": "1777001910403300000",
               "attributes": [
                 {
                   "key": "emb.type",
                   "value": {
-                    "stringValue": "ux.session"
+                    "stringValue": "ux.session_part"
                   }
                 },
                 {
@@ -105,9 +105,15 @@
                   }
                 },
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "918749690EC91BBF8B2897E78FAC2395"
+                    "stringValue": "796314C0D4E9F1774BE50C581DC0CA12"
+                  }
+                },
+                {
+                  "key": "emb.session_part_start_reason",
+                  "value": {
+                    "stringValue": "init"
                   }
                 },
                 {
@@ -117,27 +123,81 @@
                   }
                 },
                 {
-                  "key": "emb.session_number",
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "DA775DB0C59F035482F66D15188AE63F"
+                  }
+                },
+                {
+                  "key": "emb.user_session_number",
                   "value": {
                     "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_start_type",
+                  "key": "emb.user_session_part_number",
                   "value": {
-                    "stringValue": "init"
+                    "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_end_type",
+                  "key": "emb.user_session_start_ts",
                   "value": {
-                    "stringValue": "manual"
+                    "doubleValue": 1777001909824.1
+                  }
+                },
+                {
+                  "key": "emb.user_session_max_duration_seconds",
+                  "value": {
+                    "intValue": 43200
+                  }
+                },
+                {
+                  "key": "emb.user_session_inactivity_timeout_seconds",
+                  "value": {
+                    "intValue": 1800
+                  }
+                },
+                {
+                  "key": "emb.session_part_end_reason",
+                  "value": {
+                    "stringValue": "user_session_ended"
                   }
                 },
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 9
+                    "intValue": 8
+                  }
+                },
+                {
+                  "key": "emb.is_final_session_part",
+                  "value": {
+                    "intValue": 1
+                  }
+                },
+                {
+                  "key": "emb.user_session_termination_reason",
+                  "value": {
+                    "stringValue": "manual"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "DA775DB0C59F035482F66D15188AE63F"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -196,31 +256,31 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224086127-6476895305947"
+                        "stringValue": "v5-1777001909826-9114297367495"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "doubleValue": 2.400000002235174
+                        "doubleValue": 2.2000000029802322
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "doubleValue": 2.400000002235174
+                        "doubleValue": 2.2000000029802322
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.waitingDuration",
                       "value": {
-                        "doubleValue": 0.10000000149011612
+                        "intValue": 0
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.cacheDuration",
                       "value": {
-                        "doubleValue": 1.300000000745058
+                        "doubleValue": 1.2000000029802322
                       }
                     },
                     {
@@ -232,13 +292,13 @@
                     {
                       "key": "emb.web_vital.attribution.connectionDuration",
                       "value": {
-                        "doubleValue": 0.30000000074505806
+                        "doubleValue": 0.29999999701976776
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.requestDuration",
                       "value": {
-                        "doubleValue": 0.6999999992549419
+                        "doubleValue": 0.7000000029802322
                       }
                     },
                     {
@@ -285,7 +345,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1776224086133000000",
+                  "timeUnixNano": "1777001909832000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -329,31 +389,31 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224086127-9566146357688"
+                        "stringValue": "v5-1777001909826-6852280761578"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "intValue": 84
+                        "intValue": 80
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "intValue": 84
+                        "intValue": 80
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.timeToFirstByte",
                       "value": {
-                        "doubleValue": 2.400000002235174
+                        "doubleValue": 2.2000000029802322
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.firstByteToFCP",
                       "value": {
-                        "doubleValue": 81.59999999776483
+                        "doubleValue": 77.79999999701977
                       }
                     },
                     {
@@ -370,7 +430,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1776224086151199951",
+                  "timeUnixNano": "1777001909846199951",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -395,7 +455,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1776224086261300049",
+                  "timeUnixNano": "1777001909954199951",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -439,25 +499,25 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224086127-1154147689610"
+                        "stringValue": "v5-1777001909826-3799129332794"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "intValue": 84
+                        "intValue": 80
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "intValue": 84
+                        "intValue": 80
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.timeToFirstByte",
                       "value": {
-                        "doubleValue": 2.400000002235174
+                        "doubleValue": 2.2000000029802322
                       }
                     },
                     {
@@ -475,7 +535,7 @@
                     {
                       "key": "emb.web_vital.attribution.elementRenderDelay",
                       "value": {
-                        "doubleValue": 81.59999999776483
+                        "doubleValue": 77.79999999701977
                       }
                     },
                     {
@@ -492,7 +552,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-LCP",
-                  "timeUnixNano": "1776224086269199951",
+                  "timeUnixNano": "1777001909959900146",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -517,7 +577,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1776224086694300049",
+                  "timeUnixNano": "1777001910378800049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -538,18 +598,18 @@
           },
           "spans": [
             {
-              "traceId": "37b4bbe919f953076e4505bbf5597f86",
-              "spanId": "b48c755511d78700",
-              "parentSpanId": "c90ed1834b9d9d1b",
+              "traceId": "572e748a4e3ebd01260baee089ca18d1",
+              "spanId": "fda0476388defb47",
+              "parentSpanId": "1dcccc8d6ab3c34d",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224086062200098",
-              "endTimeUnixNano": "1776224086064800098",
+              "startTimeUnixNano": "1777001909764100098",
+              "endTimeUnixNano": "1777001909766600098",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "918749690EC91BBF8B2897E78FAC2395"
+                    "stringValue": "796314C0D4E9F1774BE50C581DC0CA12"
                   }
                 },
                 {
@@ -562,6 +622,30 @@
                   "key": "http.response_content_length",
                   "value": {
                     "intValue": 252
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "DA775DB0C59F035482F66D15188AE63F"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "DA775DB0C59F035482F66D15188AE63F"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -582,55 +666,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224086062200098",
+                  "timeUnixNano": "1777001909764100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224086063500098",
+                  "timeUnixNano": "1777001909765300098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224086063500098",
+                  "timeUnixNano": "1777001909765300098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224086063500098",
+                  "timeUnixNano": "1777001909765300098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1776224086062100098",
+                  "timeUnixNano": "1777001909764100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224086063800098",
+                  "timeUnixNano": "1777001909765600098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224086063800098",
+                  "timeUnixNano": "1777001909765700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224086064500098",
+                  "timeUnixNano": "1777001909766300098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224086064800098",
+                  "timeUnixNano": "1777001909766600098",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -643,18 +727,18 @@
               "flags": 257
             },
             {
-              "traceId": "37b4bbe919f953076e4505bbf5597f86",
-              "spanId": "f73b13246fe4b3b3",
-              "parentSpanId": "c90ed1834b9d9d1b",
+              "traceId": "572e748a4e3ebd01260baee089ca18d1",
+              "spanId": "c86b53b2ac8a9673",
+              "parentSpanId": "1dcccc8d6ab3c34d",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224086067199903",
-              "endTimeUnixNano": "1776224086072999903",
+              "startTimeUnixNano": "1777001909768400000",
+              "endTimeUnixNano": "1777001909772100000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "918749690EC91BBF8B2897E78FAC2395"
+                    "stringValue": "796314C0D4E9F1774BE50C581DC0CA12"
                   }
                 },
                 {
@@ -666,13 +750,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-B7p7wL93.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DWDXMVg7.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
                   }
                 },
                 {
@@ -696,19 +780,43 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 374995
+                    "intValue": 392459
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "DA775DB0C59F035482F66D15188AE63F"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "DA775DB0C59F035482F66D15188AE63F"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -729,49 +837,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224086067199903",
+                  "timeUnixNano": "1777001909768400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224086067199903",
+                  "timeUnixNano": "1777001909768400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224086067199903",
+                  "timeUnixNano": "1777001909768400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224086067199903",
+                  "timeUnixNano": "1777001909768400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224086067199903",
+                  "timeUnixNano": "1777001909768400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224086069799903",
+                  "timeUnixNano": "1777001909770400000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224086071699903",
+                  "timeUnixNano": "1777001909771100000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224086072999903",
+                  "timeUnixNano": "1777001909772100000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -784,17 +892,17 @@
               "flags": 257
             },
             {
-              "traceId": "37b4bbe919f953076e4505bbf5597f86",
-              "spanId": "c90ed1834b9d9d1b",
+              "traceId": "572e748a4e3ebd01260baee089ca18d1",
+              "spanId": "1dcccc8d6ab3c34d",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1776224086062299951",
-              "endTimeUnixNano": "1776224086128899951",
+              "startTimeUnixNano": "1777001909764300049",
+              "endTimeUnixNano": "1777001909828100049",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "918749690EC91BBF8B2897E78FAC2395"
+                    "stringValue": "796314C0D4E9F1774BE50C581DC0CA12"
                   }
                 },
                 {
@@ -816,6 +924,30 @@
                   }
                 },
                 {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "DA775DB0C59F035482F66D15188AE63F"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "DA775DB0C59F035482F66D15188AE63F"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -832,44 +964,38 @@
               "events": [
                 {
                   "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1776224086062299951",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1776224086070099951",
+                  "timeUnixNano": "1777001909770600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1776224086128799951",
+                  "timeUnixNano": "1777001909827900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1776224086128799951",
+                  "timeUnixNano": "1777001909828000049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1776224086128799951",
+                  "timeUnixNano": "1777001909828000049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1776224086128799951",
+                  "timeUnixNano": "1777001909828000049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1776224086128899951",
+                  "timeUnixNano": "1777001909828100049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -890,12 +1016,12 @@
           },
           "spans": [
             {
-              "traceId": "0f1ae187829048118c94278b81c7846a",
-              "spanId": "e746558237f9690e",
+              "traceId": "816605b97042d58fdbb033dd2f4e9b5d",
+              "spanId": "21047bab5e5fbbe5",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1776224086263000000",
-              "endTimeUnixNano": "1776224086268000000",
+              "startTimeUnixNano": "1777001909956000000",
+              "endTimeUnixNano": "1777001909960000000",
               "attributes": [
                 {
                   "key": "component",
@@ -916,9 +1042,9 @@
                   }
                 },
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "918749690EC91BBF8B2897E78FAC2395"
+                    "stringValue": "796314C0D4E9F1774BE50C581DC0CA12"
                   }
                 },
                 {
@@ -955,6 +1081,30 @@
                   "key": "http.response_content_length",
                   "value": {
                     "intValue": 9
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "DA775DB0C59F035482F66D15188AE63F"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "DA775DB0C59F035482F66D15188AE63F"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -1009,49 +1159,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224086263999903",
+                  "timeUnixNano": "1777001909956799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224086263999903",
+                  "timeUnixNano": "1777001909956799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224086263999903",
+                  "timeUnixNano": "1777001909956799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224086263999903",
+                  "timeUnixNano": "1777001909956799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224086263999903",
+                  "timeUnixNano": "1777001909956799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224086263999903",
+                  "timeUnixNano": "1777001909956799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224086266799903",
+                  "timeUnixNano": "1777001909959399903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224086266799903",
+                  "timeUnixNano": "1777001909959399903",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "service.name",
-            "value": {
-              "stringValue": "embrace-web-sdk"
-            }
-          },
-          {
             "key": "telemetry.sdk.name",
             "value": {
               "stringValue": "embrace-web-sdk"
@@ -60,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "0DE7D1EFA82A061CEA67C603DBC1A096"
+              "stringValue": "BD0BFB0990A97E420EA847902E4C0441"
             }
           },
           {
@@ -74,6 +68,12 @@
             "value": {
               "stringValue": "1280x720"
             }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "embrace-web-sdk"
+            }
           }
         ],
         "droppedAttributesCount": 0
@@ -85,8 +85,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1775548359659200195",
-              "observedTimeUnixNano": "1775548359659000000",
+              "timeUnixNano": "1776992645975700195",
+              "observedTimeUnixNano": "1776992645975000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -102,13 +102,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at Fc.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:79323)\n    at _E.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:219639\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:967\n    at new Promise (<anonymous>)\n    at Zt (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:787)\n    at a (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:219611)\n    at F_ (http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127510)"
+                    "stringValue": "Error\n    at Jc.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:83451)\n    at hy.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:233919\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:967\n    at new Promise (<anonymous>)\n    at $t (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:787)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:233891)\n    at W_ (http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127510)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:126\":\"3d9bf9584dd68a94fe0fe5b0deec00f5\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:126\":\"29937d3984834c95529ba178c0e4d8c7\"}"
                   }
                 },
                 {
@@ -120,18 +120,38 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "A99B8C7A3798B2B7D923A6529394CC55"
+                    "stringValue": "0A3063565958292CA242A471D032816E"
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "0EB5534634E281E7D49C01CC67A000C0"
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "07DE4D7B1435C342B4CFEB35EAC38ACF"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "064C2FC8212CCF8E1D74450F67FFD882"
+                    "stringValue": "07DE4D7B1435C342B4CFEB35EAC38ACF"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
                   "key": "session.previous_id",
-                  "value": {}
+                  "value": {
+                    "stringValue": ""
+                  }
                 },
                 {
                   "key": "browser.url.full",

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "2E3AED7E6AF46EDE2EF11A1CC953A418"
+              "stringValue": "C25EABEBA2C3D0ABB99617B820D4DFF4"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "782679e70c5588bdcac9c9994da48fba",
-              "spanId": "9a9a029132b1e2a1",
+              "traceId": "aabd8f824f2d1d0e9c011aaaaf0f219e",
+              "spanId": "dbd10f7e7e02bc3c",
               "name": "emb-session",
               "kind": 1,
-              "startTimeUnixNano": "1776224082756000000",
-              "endTimeUnixNano": "1776224082888800000",
+              "startTimeUnixNano": "1777001906547000000",
+              "endTimeUnixNano": "1777001906679600000",
               "attributes": [
                 {
                   "key": "emb.type",
                   "value": {
-                    "stringValue": "ux.session"
+                    "stringValue": "ux.session_part"
                   }
                 },
                 {
@@ -105,9 +105,15 @@
                   }
                 },
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "CDB8E0AE955B7F2F19F7B1AAA7BB7BA6"
+                    "stringValue": "7561E932822B09F5A343F8649944EFAE"
+                  }
+                },
+                {
+                  "key": "emb.session_part_start_reason",
+                  "value": {
+                    "stringValue": "init"
                   }
                 },
                 {
@@ -117,27 +123,81 @@
                   }
                 },
                 {
-                  "key": "emb.session_number",
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "9FAECD6735BA866F15D080D18218877A"
+                  }
+                },
+                {
+                  "key": "emb.user_session_number",
                   "value": {
                     "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_start_type",
+                  "key": "emb.user_session_part_number",
                   "value": {
-                    "stringValue": "init"
+                    "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_end_type",
+                  "key": "emb.user_session_start_ts",
                   "value": {
-                    "stringValue": "manual"
+                    "doubleValue": 1777001906547.4
+                  }
+                },
+                {
+                  "key": "emb.user_session_max_duration_seconds",
+                  "value": {
+                    "intValue": 43200
+                  }
+                },
+                {
+                  "key": "emb.user_session_inactivity_timeout_seconds",
+                  "value": {
+                    "intValue": 1800
+                  }
+                },
+                {
+                  "key": "emb.session_part_end_reason",
+                  "value": {
+                    "stringValue": "user_session_ended"
                   }
                 },
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
                     "intValue": 8
+                  }
+                },
+                {
+                  "key": "emb.is_final_session_part",
+                  "value": {
+                    "intValue": 1
+                  }
+                },
+                {
+                  "key": "emb.user_session_termination_reason",
+                  "value": {
+                    "stringValue": "manual"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "9FAECD6735BA866F15D080D18218877A"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -196,31 +256,31 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224082758-6947408399955"
+                        "stringValue": "v5-1777001906549-1154162486451"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "doubleValue": 2.5
+                        "intValue": 2
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "doubleValue": 2.5
+                        "intValue": 2
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.waitingDuration",
                       "value": {
-                        "doubleValue": 0.09999999776482582
+                        "intValue": 0
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.cacheDuration",
                       "value": {
-                        "doubleValue": 1.5
+                        "doubleValue": 1.2000000029802322
                       }
                     },
                     {
@@ -232,13 +292,13 @@
                     {
                       "key": "emb.web_vital.attribution.connectionDuration",
                       "value": {
-                        "doubleValue": 0.30000000074505806
+                        "doubleValue": 0.20000000298023224
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.requestDuration",
                       "value": {
-                        "doubleValue": 0.6000000014901161
+                        "doubleValue": 0.5999999940395355
                       }
                     },
                     {
@@ -274,7 +334,7 @@
                     {
                       "key": "emb.web_vital.attribution.unattributed",
                       "value": {
-                        "intValue": 2
+                        "intValue": 1
                       }
                     },
                     {
@@ -285,7 +345,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1776224082764199951",
+                  "timeUnixNano": "1777001906555300049",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -329,7 +389,7 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224082758-8757531102243"
+                        "stringValue": "v5-1777001906549-3033644093830"
                       }
                     },
                     {
@@ -347,13 +407,13 @@
                     {
                       "key": "emb.web_vital.attribution.timeToFirstByte",
                       "value": {
-                        "doubleValue": 2.5
+                        "intValue": 2
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.firstByteToFCP",
                       "value": {
-                        "doubleValue": 77.5
+                        "intValue": 78
                       }
                     },
                     {
@@ -370,7 +430,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1776224082777699951",
+                  "timeUnixNano": "1777001906572000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -391,18 +451,18 @@
           },
           "spans": [
             {
-              "traceId": "2f9284e9edb2ddd784df97a76a4f89d1",
-              "spanId": "deb1368875492bc8",
-              "parentSpanId": "2fc1a69d9821dd3a",
+              "traceId": "93a52ee71167608fb08c19702270bb6b",
+              "spanId": "761b360da78070cc",
+              "parentSpanId": "0643c2b4bd73161f",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224082697100000",
-              "endTimeUnixNano": "1776224082699800000",
+              "startTimeUnixNano": "1777001906489500000",
+              "endTimeUnixNano": "1777001906491900000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "CDB8E0AE955B7F2F19F7B1AAA7BB7BA6"
+                    "stringValue": "7561E932822B09F5A343F8649944EFAE"
                   }
                 },
                 {
@@ -415,6 +475,30 @@
                   "key": "http.response_content_length",
                   "value": {
                     "intValue": 252
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "9FAECD6735BA866F15D080D18218877A"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "9FAECD6735BA866F15D080D18218877A"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -435,55 +519,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224082697100000",
+                  "timeUnixNano": "1777001906489500000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224082698600000",
+                  "timeUnixNano": "1777001906490700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224082698600000",
+                  "timeUnixNano": "1777001906490700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224082698600000",
+                  "timeUnixNano": "1777001906490700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1776224082697000000",
+                  "timeUnixNano": "1777001906489500000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224082698900000",
+                  "timeUnixNano": "1777001906490900000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224082698900000",
+                  "timeUnixNano": "1777001906490900000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224082699500000",
+                  "timeUnixNano": "1777001906491500000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224082699800000",
+                  "timeUnixNano": "1777001906491900000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -496,18 +580,18 @@
               "flags": 257
             },
             {
-              "traceId": "2f9284e9edb2ddd784df97a76a4f89d1",
-              "spanId": "15723a46f74d3ca6",
-              "parentSpanId": "2fc1a69d9821dd3a",
+              "traceId": "93a52ee71167608fb08c19702270bb6b",
+              "spanId": "274b4cf1666c04b8",
+              "parentSpanId": "0643c2b4bd73161f",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224082702299902",
-              "endTimeUnixNano": "1776224082706899902",
+              "startTimeUnixNano": "1777001906494400049",
+              "endTimeUnixNano": "1777001906498100049",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "CDB8E0AE955B7F2F19F7B1AAA7BB7BA6"
+                    "stringValue": "7561E932822B09F5A343F8649944EFAE"
                   }
                 },
                 {
@@ -519,13 +603,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-B7p7wL93.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DWDXMVg7.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
                   }
                 },
                 {
@@ -549,19 +633,43 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 374995
+                    "intValue": 392459
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "9FAECD6735BA866F15D080D18218877A"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "9FAECD6735BA866F15D080D18218877A"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -582,49 +690,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224082702299902",
+                  "timeUnixNano": "1777001906494400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224082702299902",
+                  "timeUnixNano": "1777001906494400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224082702299902",
+                  "timeUnixNano": "1777001906494400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224082702299902",
+                  "timeUnixNano": "1777001906494400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224082702299902",
+                  "timeUnixNano": "1777001906494400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224082704699902",
+                  "timeUnixNano": "1777001906496500049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224082705699902",
+                  "timeUnixNano": "1777001906497100049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224082706899902",
+                  "timeUnixNano": "1777001906498100049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -637,17 +745,17 @@
               "flags": 257
             },
             {
-              "traceId": "2f9284e9edb2ddd784df97a76a4f89d1",
-              "spanId": "2fc1a69d9821dd3a",
+              "traceId": "93a52ee71167608fb08c19702270bb6b",
+              "spanId": "0643c2b4bd73161f",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1776224082696200098",
-              "endTimeUnixNano": "1776224082759900098",
+              "startTimeUnixNano": "1777001906489600098",
+              "endTimeUnixNano": "1777001906551000098",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "CDB8E0AE955B7F2F19F7B1AAA7BB7BA6"
+                    "stringValue": "7561E932822B09F5A343F8649944EFAE"
                   }
                 },
                 {
@@ -669,6 +777,30 @@
                   }
                 },
                 {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "9FAECD6735BA866F15D080D18218877A"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "9FAECD6735BA866F15D080D18218877A"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -685,44 +817,38 @@
               "events": [
                 {
                   "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1776224082696200098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1776224082703500098",
+                  "timeUnixNano": "1777001906495600098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1776224082759800098",
+                  "timeUnixNano": "1777001906551000098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1776224082759800098",
+                  "timeUnixNano": "1777001906551000098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1776224082759800098",
+                  "timeUnixNano": "1777001906551000098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1776224082759800098",
+                  "timeUnixNano": "1777001906551000098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1776224082759900098",
+                  "timeUnixNano": "1777001906551000098",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "service.name",
-            "value": {
-              "stringValue": "embrace-web-sdk"
-            }
-          },
-          {
             "key": "telemetry.sdk.name",
             "value": {
               "stringValue": "embrace-web-sdk"
@@ -60,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "3D9921C1BAD07528406FA3491D346064"
+              "stringValue": "B46AEF4BC0784384118E4D4278944F40"
             }
           },
           {
@@ -74,6 +68,12 @@
             "value": {
               "stringValue": "1280x720"
             }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "embrace-web-sdk"
+            }
           }
         ],
         "droppedAttributesCount": 0
@@ -85,8 +85,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1775548376360000000",
-              "observedTimeUnixNano": "1775548376361000000",
+              "timeUnixNano": "1776992672142000000",
+              "observedTimeUnixNano": "1776992672144000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -102,13 +102,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:79323\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:38001\nH1</Ps/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:37542\nH1</z1/a/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:219639\nZt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:967\nZt@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:787\na@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:219613\nF_@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127511\nH1</oE/Ko/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:132565\ned@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:15162\nKo@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:128746\nlc@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:28581\nYb@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:28401\nEventListener.handleEvent*Z_@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:128307\nXo@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127707\nH1</oE/Qo/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127873\nQo@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127818\nH1</oE/Ls.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:36448\nH1<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:220224\ntE/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:681\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:220278\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:83451\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:38001\ngM</Ks/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:37542\ngM</hM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:233919\n$t/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:967\n$t@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:787\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:233893\nW_@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127511\ngM</uy/Zo/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:132565\nsd@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:15162\nZo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:128746\ncc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:28581\nqb@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:28401\nEventListener.handleEvent*tg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:128307\nQo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127707\ngM</uy/Fo/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127873\nFo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127818\ngM</uy/Us.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:36448\ngM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:234504\nWb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:681\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:234558\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:126\\n\":\"3d9bf9584dd68a94fe0fe5b0deec00f5\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:126\\n\":\"29937d3984834c95529ba178c0e4d8c7\"}"
                   }
                 },
                 {
@@ -120,18 +120,38 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "9CFE06049F9698881DAA1077F3CC03B4"
+                    "stringValue": "59E44302712037679A755604F6E2F511"
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "9F946D3FB888600DE8B52AAA0491859A"
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "A8985686FA2C01D706F4B0889938AA8D"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "A0A4D4E665E506AAD5EAAE23E6DF7FB0"
+                    "stringValue": "A8985686FA2C01D706F4B0889938AA8D"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
                   "key": "session.previous_id",
-                  "value": {}
+                  "value": {
+                    "stringValue": ""
+                  }
                 },
                 {
                   "key": "browser.url.full",

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "81E31A0F735E5C4D5D8C0D08A186331A"
+              "stringValue": "BFC154A9A2E043C42F4A70B36EFBFD72"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "36f071ca0068a034821f0dae08131049",
-              "spanId": "63909f42b6df8d16",
+              "traceId": "3546e87d9dd5a0762df0e84ef86f8111",
+              "spanId": "306b27ce0f786be3",
               "name": "emb-session",
               "kind": 1,
-              "startTimeUnixNano": "1776224108409000000",
-              "endTimeUnixNano": "1776224109240000000",
+              "startTimeUnixNano": "1777057017203000000",
+              "endTimeUnixNano": "1777057018046000000",
               "attributes": [
                 {
                   "key": "emb.type",
                   "value": {
-                    "stringValue": "ux.session"
+                    "stringValue": "ux.session_part"
                   }
                 },
                 {
@@ -105,9 +105,15 @@
                   }
                 },
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E59F33D4033C12971456E12FE0C52869"
+                    "stringValue": "13DE89E61E848941B67D27F4505444FD"
+                  }
+                },
+                {
+                  "key": "emb.session_part_start_reason",
+                  "value": {
+                    "stringValue": "init"
                   }
                 },
                 {
@@ -117,27 +123,81 @@
                   }
                 },
                 {
-                  "key": "emb.session_number",
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "10BE93802DA934D8A566E98673D41682"
+                  }
+                },
+                {
+                  "key": "emb.user_session_number",
                   "value": {
                     "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_start_type",
+                  "key": "emb.user_session_part_number",
                   "value": {
-                    "stringValue": "init"
+                    "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_end_type",
+                  "key": "emb.user_session_start_ts",
                   "value": {
-                    "stringValue": "manual"
+                    "intValue": 1777057017202
+                  }
+                },
+                {
+                  "key": "emb.user_session_max_duration_seconds",
+                  "value": {
+                    "intValue": 43200
+                  }
+                },
+                {
+                  "key": "emb.user_session_inactivity_timeout_seconds",
+                  "value": {
+                    "intValue": 1800
+                  }
+                },
+                {
+                  "key": "emb.session_part_end_reason",
+                  "value": {
+                    "stringValue": "user_session_ended"
                   }
                 },
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 9
+                    "intValue": 22
+                  }
+                },
+                {
+                  "key": "emb.is_final_session_part",
+                  "value": {
+                    "intValue": 1
+                  }
+                },
+                {
+                  "key": "emb.user_session_termination_reason",
+                  "value": {
+                    "stringValue": "manual"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "10BE93802DA934D8A566E98673D41682"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -196,19 +256,19 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224108410-5143986092712"
+                        "stringValue": "v5-1777057017207-1796920728101"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "intValue": 5
+                        "intValue": 17
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "intValue": 5
+                        "intValue": 17
                       }
                     },
                     {
@@ -220,7 +280,7 @@
                     {
                       "key": "emb.web_vital.attribution.cacheDuration",
                       "value": {
-                        "intValue": 4
+                        "intValue": 13
                       }
                     },
                     {
@@ -232,13 +292,13 @@
                     {
                       "key": "emb.web_vital.attribution.connectionDuration",
                       "value": {
-                        "intValue": 0
+                        "intValue": 1
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.requestDuration",
                       "value": {
-                        "intValue": 1
+                        "intValue": 3
                       }
                     },
                     {
@@ -256,7 +316,7 @@
                     {
                       "key": "emb.web_vital.attribution.tcpConnection",
                       "value": {
-                        "intValue": 0
+                        "intValue": 1
                       }
                     },
                     {
@@ -268,13 +328,13 @@
                     {
                       "key": "emb.web_vital.attribution.serverResponse",
                       "value": {
-                        "intValue": 1
+                        "intValue": 3
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.unattributed",
                       "value": {
-                        "intValue": 4
+                        "intValue": 13
                       }
                     },
                     {
@@ -285,7 +345,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1776224108423000000",
+                  "timeUnixNano": "1777057017251000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -329,31 +389,31 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224108410-8431149627056"
+                        "stringValue": "v5-1777057017207-3325984480978"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "intValue": 72
+                        "intValue": 279
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "intValue": 72
+                        "intValue": 279
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.timeToFirstByte",
                       "value": {
-                        "intValue": 5
+                        "intValue": 17
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.firstByteToFCP",
                       "value": {
-                        "intValue": 67
+                        "intValue": 262
                       }
                     },
                     {
@@ -370,7 +430,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1776224108426000000",
+                  "timeUnixNano": "1777057017265000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -395,7 +455,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1776224108623000000",
+                  "timeUnixNano": "1777057017499000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -439,25 +499,25 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224108410-4971509553699"
+                        "stringValue": "v5-1777057017205-1530407442576"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "intValue": 72
+                        "intValue": 279
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "intValue": 72
+                        "intValue": 279
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.timeToFirstByte",
                       "value": {
-                        "intValue": 5
+                        "intValue": 17
                       }
                     },
                     {
@@ -475,7 +535,7 @@
                     {
                       "key": "emb.web_vital.attribution.elementRenderDelay",
                       "value": {
-                        "intValue": 67
+                        "intValue": 262
                       }
                     },
                     {
@@ -492,7 +552,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-LCP",
-                  "timeUnixNano": "1776224108636000000",
+                  "timeUnixNano": "1777057017513000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -517,7 +577,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1776224109102000000",
+                  "timeUnixNano": "1777057017975000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -538,18 +598,18 @@
           },
           "spans": [
             {
-              "traceId": "07f15335d1b1080a0be9c50b8dac4ef2",
-              "spanId": "0521c3fb534105ad",
-              "parentSpanId": "e79e076a70385a0d",
+              "traceId": "9d9d1b80a548c82140d51c3a1ada3348",
+              "spanId": "0a7519b0aa563d95",
+              "parentSpanId": "248eef939ed6f114",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224108350000000",
-              "endTimeUnixNano": "1776224108355000000",
+              "startTimeUnixNano": "1777057016959000000",
+              "endTimeUnixNano": "1777057016977000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E59F33D4033C12971456E12FE0C52869"
+                    "stringValue": "13DE89E61E848941B67D27F4505444FD"
                   }
                 },
                 {
@@ -562,6 +622,30 @@
                   "key": "http.response_content_length",
                   "value": {
                     "intValue": 252
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "10BE93802DA934D8A566E98673D41682"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "10BE93802DA934D8A566E98673D41682"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -582,55 +666,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224108350000000",
+                  "timeUnixNano": "1777057016959000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224108354000000",
+                  "timeUnixNano": "1777057016973000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224108354000000",
+                  "timeUnixNano": "1777057016973000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224108354000000",
+                  "timeUnixNano": "1777057016973000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1776224108350000000",
+                  "timeUnixNano": "1777057016960000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224108354000000",
+                  "timeUnixNano": "1777057016974000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224108354000000",
+                  "timeUnixNano": "1777057016974000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224108355000000",
+                  "timeUnixNano": "1777057016977000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224108355000000",
+                  "timeUnixNano": "1777057016977000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -643,18 +727,18 @@
               "flags": 257
             },
             {
-              "traceId": "07f15335d1b1080a0be9c50b8dac4ef2",
-              "spanId": "9d153afcf8dacb15",
-              "parentSpanId": "e79e076a70385a0d",
+              "traceId": "9d9d1b80a548c82140d51c3a1ada3348",
+              "spanId": "6d19cdafab259bf1",
+              "parentSpanId": "248eef939ed6f114",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224108359000000",
-              "endTimeUnixNano": "1776224108372000000",
+              "startTimeUnixNano": "1777057016994000000",
+              "endTimeUnixNano": "1777057017126000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E59F33D4033C12971456E12FE0C52869"
+                    "stringValue": "13DE89E61E848941B67D27F4505444FD"
                   }
                 },
                 {
@@ -666,13 +750,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-B7p7wL93.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-D34A2__c.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 387531
                   }
                 },
                 {
@@ -690,19 +774,43 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 387531
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 374995
+                    "intValue": 387831
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 387531
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "10BE93802DA934D8A566E98673D41682"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "10BE93802DA934D8A566E98673D41682"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -723,49 +831,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224108359000000",
+                  "timeUnixNano": "1777057016994000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224108359000000",
+                  "timeUnixNano": "1777057016994000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224108359000000",
+                  "timeUnixNano": "1777057016994000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224108359000000",
+                  "timeUnixNano": "1777057016994000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224108359000000",
+                  "timeUnixNano": "1777057016994000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224108372000000",
+                  "timeUnixNano": "1777057017124000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224108372000000",
+                  "timeUnixNano": "1777057017125000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224108372000000",
+                  "timeUnixNano": "1777057017126000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -778,17 +886,17 @@
               "flags": 257
             },
             {
-              "traceId": "07f15335d1b1080a0be9c50b8dac4ef2",
-              "spanId": "e79e076a70385a0d",
+              "traceId": "9d9d1b80a548c82140d51c3a1ada3348",
+              "spanId": "248eef939ed6f114",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1776224108350000000",
-              "endTimeUnixNano": "1776224108421000000",
+              "startTimeUnixNano": "1777057016959000000",
+              "endTimeUnixNano": "1777057017238000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E59F33D4033C12971456E12FE0C52869"
+                    "stringValue": "13DE89E61E848941B67D27F4505444FD"
                   }
                 },
                 {
@@ -810,6 +918,30 @@
                   }
                 },
                 {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "10BE93802DA934D8A566E98673D41682"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "10BE93802DA934D8A566E98673D41682"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -826,44 +958,50 @@
               "events": [
                 {
                   "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1777057016959000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1776224108360000000",
+                  "timeUnixNano": "1777057017003000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1776224108414000000",
+                  "timeUnixNano": "1777057017219000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1776224108414000000",
+                  "timeUnixNano": "1777057017220000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1776224108421000000",
+                  "timeUnixNano": "1777057017237000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1776224108421000000",
+                  "timeUnixNano": "1777057017237000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1776224108421000000",
+                  "timeUnixNano": "1777057017238000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "firstContentfulPaint",
-                  "timeUnixNano": "1776224108422000000",
+                  "timeUnixNano": "1777057017239000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -884,12 +1022,12 @@
           },
           "spans": [
             {
-              "traceId": "6d9218c5537c54161bb9e857a78526d1",
-              "spanId": "04b8c0b17450a270",
+              "traceId": "2372e95676e5557f8efdd31729d96bb4",
+              "spanId": "0b38f0b4d083a384",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1776224108627000000",
-              "endTimeUnixNano": "1776224108637000000",
+              "startTimeUnixNano": "1777057017502000000",
+              "endTimeUnixNano": "1777057017525000000",
               "attributes": [
                 {
                   "key": "component",
@@ -910,9 +1048,9 @@
                   }
                 },
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E59F33D4033C12971456E12FE0C52869"
+                    "stringValue": "13DE89E61E848941B67D27F4505444FD"
                   }
                 },
                 {
@@ -949,6 +1087,30 @@
                   "key": "http.response_content_length",
                   "value": {
                     "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "10BE93802DA934D8A566E98673D41682"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "10BE93802DA934D8A566E98673D41682"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -1003,49 +1165,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224108628000000",
+                  "timeUnixNano": "1777057017503000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224108628000000",
+                  "timeUnixNano": "1777057017503000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224108628000000",
+                  "timeUnixNano": "1777057017503000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224108628000000",
+                  "timeUnixNano": "1777057017503000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224108628000000",
+                  "timeUnixNano": "1777057017503000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224108628000000",
+                  "timeUnixNano": "1777057017503000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224108628000000",
+                  "timeUnixNano": "1777057017503000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224108628000000",
+                  "timeUnixNano": "1777057017503000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "service.name",
-            "value": {
-              "stringValue": "embrace-web-sdk"
-            }
-          },
-          {
             "key": "telemetry.sdk.name",
             "value": {
               "stringValue": "embrace-web-sdk"
@@ -60,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "433875C7630907ACE86E3CAB875B890B"
+              "stringValue": "6EC4642D4B010BAB3A2795CE326FE034"
             }
           },
           {
@@ -74,6 +68,12 @@
             "value": {
               "stringValue": "1280x720"
             }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "embrace-web-sdk"
+            }
           }
         ],
         "droppedAttributesCount": 0
@@ -85,8 +85,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1775548372731000000",
-              "observedTimeUnixNano": "1775548372731000000",
+              "timeUnixNano": "1776992666119000000",
+              "observedTimeUnixNano": "1776992666121000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -102,13 +102,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:79323\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:38001\nH1</Ps/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:37542\nH1</z1/a/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:219639\nZt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:967\nZt@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:787\na@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:219613\nF_@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127511\nH1</oE/Ko/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:132565\ned@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:15162\nKo@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:128746\nlc@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:28581\nYb@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:28401\nEventListener.handleEvent*Z_@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:128307\nXo@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127707\nH1</oE/Qo/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127873\nQo@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127818\nH1</oE/Ls.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:36448\nH1<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:220224\ntE/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:681\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:220278\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:83451\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:38001\ngM</Ks/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:37542\ngM</hM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:233919\n$t/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:967\n$t@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:787\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:233893\nW_@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127511\ngM</uy/Zo/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:132565\nsd@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:15162\nZo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:128746\ncc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:28581\nqb@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:28401\nEventListener.handleEvent*tg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:128307\nQo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127707\ngM</uy/Fo/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127873\nFo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127818\ngM</uy/Us.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:36448\ngM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:234504\nWb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:681\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:234558\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:126\\n\":\"3d9bf9584dd68a94fe0fe5b0deec00f5\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:126\\n\":\"29937d3984834c95529ba178c0e4d8c7\"}"
                   }
                 },
                 {
@@ -120,18 +120,38 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "982254D8A3A41F58B90BF3A38EEB4D20"
+                    "stringValue": "A2A84AD4BB6068E49733322477C9BE5A"
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "32589F69B8ED5DA9D5D661BA0B099C29"
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "AA118ED6C8AD1FBB6AD264F17288D897"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "3E6B586C27F1E1B0E4C74B00404AA75A"
+                    "stringValue": "AA118ED6C8AD1FBB6AD264F17288D897"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
                   "key": "session.previous_id",
-                  "value": {}
+                  "value": {
+                    "stringValue": ""
+                  }
                 },
                 {
                   "key": "browser.url.full",

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "78A3E840E14B8D742F7BA4448932C526"
+              "stringValue": "D100FC45939F576F9E94BDCA09C8EEFC"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "ac7bfbd9e29a6fb2203525e996fd2f97",
-              "spanId": "f36cb2cae31f021b",
+              "traceId": "0b7d1d848faff838a24063d461b3705c",
+              "spanId": "ee02927c44f13859",
               "name": "emb-session",
               "kind": 1,
-              "startTimeUnixNano": "1776224102128000000",
-              "endTimeUnixNano": "1776224102305000000",
+              "startTimeUnixNano": "1777001924725000000",
+              "endTimeUnixNano": "1777001925010000000",
               "attributes": [
                 {
                   "key": "emb.type",
                   "value": {
-                    "stringValue": "ux.session"
+                    "stringValue": "ux.session_part"
                   }
                 },
                 {
@@ -105,9 +105,15 @@
                   }
                 },
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "578228E335EE2472A0C201508E9A5999"
+                    "stringValue": "9011A77ED972C86EF293F69486023028"
+                  }
+                },
+                {
+                  "key": "emb.session_part_start_reason",
+                  "value": {
+                    "stringValue": "init"
                   }
                 },
                 {
@@ -117,27 +123,81 @@
                   }
                 },
                 {
-                  "key": "emb.session_number",
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "CFE3A15F8740B0EE2DC79E67D17CA3CA"
+                  }
+                },
+                {
+                  "key": "emb.user_session_number",
                   "value": {
                     "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_start_type",
+                  "key": "emb.user_session_part_number",
                   "value": {
-                    "stringValue": "init"
+                    "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_end_type",
+                  "key": "emb.user_session_start_ts",
                   "value": {
-                    "stringValue": "manual"
+                    "intValue": 1777001924724
+                  }
+                },
+                {
+                  "key": "emb.user_session_max_duration_seconds",
+                  "value": {
+                    "intValue": 43200
+                  }
+                },
+                {
+                  "key": "emb.user_session_inactivity_timeout_seconds",
+                  "value": {
+                    "intValue": 1800
+                  }
+                },
+                {
+                  "key": "emb.session_part_end_reason",
+                  "value": {
+                    "stringValue": "user_session_ended"
                   }
                 },
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 8
+                    "intValue": 12
+                  }
+                },
+                {
+                  "key": "emb.is_final_session_part",
+                  "value": {
+                    "intValue": 1
+                  }
+                },
+                {
+                  "key": "emb.user_session_termination_reason",
+                  "value": {
+                    "stringValue": "manual"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "CFE3A15F8740B0EE2DC79E67D17CA3CA"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -196,19 +256,19 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224102130-5258429640800"
+                        "stringValue": "v5-1777001924728-8923128855213"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "intValue": 4
+                        "intValue": 9
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "intValue": 4
+                        "intValue": 9
                       }
                     },
                     {
@@ -220,7 +280,7 @@
                     {
                       "key": "emb.web_vital.attribution.cacheDuration",
                       "value": {
-                        "intValue": 3
+                        "intValue": 8
                       }
                     },
                     {
@@ -274,7 +334,7 @@
                     {
                       "key": "emb.web_vital.attribution.unattributed",
                       "value": {
-                        "intValue": 3
+                        "intValue": 8
                       }
                     },
                     {
@@ -285,7 +345,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1776224102145000000",
+                  "timeUnixNano": "1777001924743000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -329,31 +389,31 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224102130-2357204418589"
+                        "stringValue": "v5-1777001924728-6650356732277"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "intValue": 71
+                        "intValue": 90
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "intValue": 71
+                        "intValue": 90
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.timeToFirstByte",
                       "value": {
-                        "intValue": 4
+                        "intValue": 9
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.firstByteToFCP",
                       "value": {
-                        "intValue": 67
+                        "intValue": 81
                       }
                     },
                     {
@@ -370,7 +430,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1776224102147000000",
+                  "timeUnixNano": "1777001924750000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -391,18 +451,18 @@
           },
           "spans": [
             {
-              "traceId": "05128ee8da2c795c2aa5c0cb3a99d7fa",
-              "spanId": "c5b9b2d69e5172a5",
-              "parentSpanId": "92315542e76e0ab2",
+              "traceId": "777f8687f1cfad2ae555d297e634142f",
+              "spanId": "79c4156e252dd759",
+              "parentSpanId": "09f1b9108b446cc8",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224102071000000",
-              "endTimeUnixNano": "1776224102076000000",
+              "startTimeUnixNano": "1777001924650000000",
+              "endTimeUnixNano": "1777001924660000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "578228E335EE2472A0C201508E9A5999"
+                    "stringValue": "9011A77ED972C86EF293F69486023028"
                   }
                 },
                 {
@@ -415,6 +475,30 @@
                   "key": "http.response_content_length",
                   "value": {
                     "intValue": 252
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "CFE3A15F8740B0EE2DC79E67D17CA3CA"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "CFE3A15F8740B0EE2DC79E67D17CA3CA"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -435,55 +519,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224102071000000",
+                  "timeUnixNano": "1777001924650000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224102075000000",
+                  "timeUnixNano": "1777001924659000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224102075000000",
+                  "timeUnixNano": "1777001924659000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224102075000000",
+                  "timeUnixNano": "1777001924659000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1776224102072000000",
+                  "timeUnixNano": "1777001924651000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224102075000000",
+                  "timeUnixNano": "1777001924659000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224102075000000",
+                  "timeUnixNano": "1777001924659000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224102076000000",
+                  "timeUnixNano": "1777001924660000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224102076000000",
+                  "timeUnixNano": "1777001924660000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -496,18 +580,18 @@
               "flags": 257
             },
             {
-              "traceId": "05128ee8da2c795c2aa5c0cb3a99d7fa",
-              "spanId": "29125ed947a68fc9",
-              "parentSpanId": "92315542e76e0ab2",
+              "traceId": "777f8687f1cfad2ae555d297e634142f",
+              "spanId": "adc5bac0658ab9a3",
+              "parentSpanId": "09f1b9108b446cc8",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224102079000000",
-              "endTimeUnixNano": "1776224102090000000",
+              "startTimeUnixNano": "1777001924666000000",
+              "endTimeUnixNano": "1777001924685000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "578228E335EE2472A0C201508E9A5999"
+                    "stringValue": "9011A77ED972C86EF293F69486023028"
                   }
                 },
                 {
@@ -519,13 +603,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-B7p7wL93.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DWDXMVg7.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
                   }
                 },
                 {
@@ -543,19 +627,43 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 374995
+                    "intValue": 392459
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "CFE3A15F8740B0EE2DC79E67D17CA3CA"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "CFE3A15F8740B0EE2DC79E67D17CA3CA"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -576,49 +684,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224102079000000",
+                  "timeUnixNano": "1777001924666000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224102079000000",
+                  "timeUnixNano": "1777001924666000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224102079000000",
+                  "timeUnixNano": "1777001924666000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224102079000000",
+                  "timeUnixNano": "1777001924666000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224102079000000",
+                  "timeUnixNano": "1777001924666000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224102089000000",
+                  "timeUnixNano": "1777001924683000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224102090000000",
+                  "timeUnixNano": "1777001924684000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224102090000000",
+                  "timeUnixNano": "1777001924685000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -631,17 +739,17 @@
               "flags": 257
             },
             {
-              "traceId": "05128ee8da2c795c2aa5c0cb3a99d7fa",
-              "spanId": "92315542e76e0ab2",
+              "traceId": "777f8687f1cfad2ae555d297e634142f",
+              "spanId": "09f1b9108b446cc8",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1776224102071000000",
-              "endTimeUnixNano": "1776224102143000000",
+              "startTimeUnixNano": "1777001924650000000",
+              "endTimeUnixNano": "1777001924741000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "578228E335EE2472A0C201508E9A5999"
+                    "stringValue": "9011A77ED972C86EF293F69486023028"
                   }
                 },
                 {
@@ -663,6 +771,30 @@
                   }
                 },
                 {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "CFE3A15F8740B0EE2DC79E67D17CA3CA"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "CFE3A15F8740B0EE2DC79E67D17CA3CA"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -680,49 +812,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224102071000000",
+                  "timeUnixNano": "1777001924650000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1776224102082000000",
+                  "timeUnixNano": "1777001924667000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1776224102134000000",
+                  "timeUnixNano": "1777001924734000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1776224102135000000",
+                  "timeUnixNano": "1777001924735000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1776224102143000000",
+                  "timeUnixNano": "1777001924741000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1776224102143000000",
+                  "timeUnixNano": "1777001924741000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1776224102143000000",
+                  "timeUnixNano": "1777001924741000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "firstContentfulPaint",
-                  "timeUnixNano": "1776224102143000000",
+                  "timeUnixNano": "1777001924741000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "service.name",
-            "value": {
-              "stringValue": "embrace-web-sdk"
-            }
-          },
-          {
             "key": "telemetry.sdk.name",
             "value": {
               "stringValue": "embrace-web-sdk"
@@ -60,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "586EDADF8D159E1D2DA2CF890AAB6121"
+              "stringValue": "B66274144410EE26433A5B273650D17E"
             }
           },
           {
@@ -74,6 +68,12 @@
             "value": {
               "stringValue": "1280x720"
             }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "embrace-web-sdk"
+            }
           }
         ],
         "droppedAttributesCount": 0
@@ -85,8 +85,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1775548384482000000",
-              "observedTimeUnixNano": "1775548384482000000",
+              "timeUnixNano": "1776992684193000000",
+              "observedTimeUnixNano": "1776992684194000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -102,13 +102,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:79332\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:219646\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:971\nPromise@[native code]\nZt@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:798\nF_@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:132565\ned@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:15162\nKo@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:128746\nlc@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:28581\nYb@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:28403"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:83460\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:233926\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:971\nPromise@[native code]\n$t@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:798\nW_@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:132565\nsd@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:15162\nZo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:128746\ncc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:28581\nqb@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:28403"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:126\":\"3d9bf9584dd68a94fe0fe5b0deec00f5\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:126\":\"29937d3984834c95529ba178c0e4d8c7\"}"
                   }
                 },
                 {
@@ -120,18 +120,38 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "6FFC20E0D49031FA5F1123918B8A2190"
+                    "stringValue": "4370F4837702B0429E27570009921B82"
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "85B0A2511695E5A78717BD51885A0051"
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "E4557BF41C4BD6F446393D1A94A5C45E"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "C77AC0117D77EB70C8636398939CE7C8"
+                    "stringValue": "E4557BF41C4BD6F446393D1A94A5C45E"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
                   "key": "session.previous_id",
-                  "value": {}
+                  "value": {
+                    "stringValue": ""
+                  }
                 },
                 {
                   "key": "browser.url.full",

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "34B3A76C1F2B9E0F328502969EE514D8"
+              "stringValue": "85EBC4698CB2DE3C518EE95B3686DCE2"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "5c5f7611bc3b39598461a76e30c82578",
-              "spanId": "2a715e12abe95d1b",
+              "traceId": "6ebdd8a878e42f7d027ba1435a9aed46",
+              "spanId": "26925d47472af72f",
               "name": "emb-session",
               "kind": 1,
-              "startTimeUnixNano": "1776224120343000000",
-              "endTimeUnixNano": "1776224120971000000",
+              "startTimeUnixNano": "1777001942598000000",
+              "endTimeUnixNano": "1777001943285000000",
               "attributes": [
                 {
                   "key": "emb.type",
                   "value": {
-                    "stringValue": "ux.session"
+                    "stringValue": "ux.session_part"
                   }
                 },
                 {
@@ -105,9 +105,15 @@
                   }
                 },
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D05CE6EB0066024C7D17C6A2C611D894"
+                    "stringValue": "2B9AF0DFEF3D824FBDBD5700E92D45EF"
+                  }
+                },
+                {
+                  "key": "emb.session_part_start_reason",
+                  "value": {
+                    "stringValue": "init"
                   }
                 },
                 {
@@ -117,27 +123,81 @@
                   }
                 },
                 {
-                  "key": "emb.session_number",
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "47434D134E32AC7AC9E8A64DB4894877"
+                  }
+                },
+                {
+                  "key": "emb.user_session_number",
                   "value": {
                     "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_start_type",
+                  "key": "emb.user_session_part_number",
                   "value": {
-                    "stringValue": "init"
+                    "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_end_type",
+                  "key": "emb.user_session_start_ts",
                   "value": {
-                    "stringValue": "manual"
+                    "doubleValue": 1777001942597.0002
+                  }
+                },
+                {
+                  "key": "emb.user_session_max_duration_seconds",
+                  "value": {
+                    "intValue": 43200
+                  }
+                },
+                {
+                  "key": "emb.user_session_inactivity_timeout_seconds",
+                  "value": {
+                    "intValue": 1800
+                  }
+                },
+                {
+                  "key": "emb.session_part_end_reason",
+                  "value": {
+                    "stringValue": "user_session_ended"
                   }
                 },
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 10
+                    "intValue": 9
+                  }
+                },
+                {
+                  "key": "emb.is_final_session_part",
+                  "value": {
+                    "intValue": 1
+                  }
+                },
+                {
+                  "key": "emb.user_session_termination_reason",
+                  "value": {
+                    "stringValue": "manual"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "47434D134E32AC7AC9E8A64DB4894877"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -196,7 +256,7 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224120345-6959731786151"
+                        "stringValue": "v5-1777001942600-6658053078857"
                       }
                     },
                     {
@@ -214,7 +274,7 @@
                     {
                       "key": "emb.web_vital.attribution.waitingDuration",
                       "value": {
-                        "intValue": 2
+                        "intValue": 1
                       }
                     },
                     {
@@ -238,7 +298,7 @@
                     {
                       "key": "emb.web_vital.attribution.requestDuration",
                       "value": {
-                        "intValue": 0
+                        "intValue": 1
                       }
                     },
                     {
@@ -268,13 +328,13 @@
                     {
                       "key": "emb.web_vital.attribution.serverResponse",
                       "value": {
-                        "intValue": 0
+                        "intValue": 1
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.unattributed",
                       "value": {
-                        "intValue": 3
+                        "intValue": 1
                       }
                     },
                     {
@@ -285,7 +345,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1776224120348000000",
+                  "timeUnixNano": "1777001942607000244",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -329,19 +389,19 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224120345-9578103683148"
+                        "stringValue": "v5-1777001942600-4829516827671"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "intValue": 68
+                        "intValue": 47
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "intValue": 68
+                        "intValue": 47
                       }
                     },
                     {
@@ -353,7 +413,7 @@
                     {
                       "key": "emb.web_vital.attribution.firstByteToFCP",
                       "value": {
-                        "intValue": 66
+                        "intValue": 45
                       }
                     },
                     {
@@ -370,7 +430,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1776224120376000000",
+                  "timeUnixNano": "1777001942613000244",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -395,7 +455,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "2574123684737000000",
+                  "timeUnixNano": "2575599907811000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -439,19 +499,19 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224120344-6232122061236"
+                        "stringValue": "v5-1777001942600-8888680966758"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "intValue": 68
+                        "intValue": 47
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "intValue": 68
+                        "intValue": 47
                       }
                     },
                     {
@@ -475,7 +535,7 @@
                     {
                       "key": "emb.web_vital.attribution.elementRenderDelay",
                       "value": {
-                        "intValue": 66
+                        "intValue": 45
                       }
                     },
                     {
@@ -492,7 +552,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-LCP",
-                  "timeUnixNano": "1776224120483000000",
+                  "timeUnixNano": "1777001942747000244",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -517,7 +577,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "2574123685163000000",
+                  "timeUnixNano": "2575599908255000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -538,18 +598,18 @@
           },
           "spans": [
             {
-              "traceId": "9a6d007cd810493c8f0280fbe14f9c01",
-              "spanId": "fa5d4d29313b22d6",
-              "parentSpanId": "4e396d7ad539bbca",
+              "traceId": "14b59a664006155357e1bcd2504b58e7",
+              "spanId": "397842b0e8c289b1",
+              "parentSpanId": "bf35acd8660be21a",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224120309000000",
-              "endTimeUnixNano": "1776224120310000000",
+              "startTimeUnixNano": "1777001942565000000",
+              "endTimeUnixNano": "1777001942566000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D05CE6EB0066024C7D17C6A2C611D894"
+                    "stringValue": "2B9AF0DFEF3D824FBDBD5700E92D45EF"
                   }
                 },
                 {
@@ -571,6 +631,30 @@
                   }
                 },
                 {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "47434D134E32AC7AC9E8A64DB4894877"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "47434D134E32AC7AC9E8A64DB4894877"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -588,55 +672,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224120309000000",
+                  "timeUnixNano": "1777001942565000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224120309000000",
+                  "timeUnixNano": "1777001942565000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224120309000000",
+                  "timeUnixNano": "1777001942565000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224120309000000",
+                  "timeUnixNano": "1777001942565000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1776224120307000000",
+                  "timeUnixNano": "1777001942564000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224120309000000",
+                  "timeUnixNano": "1777001942565000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224120309000000",
+                  "timeUnixNano": "1777001942565000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224120309000000",
+                  "timeUnixNano": "1777001942566000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224120310000000",
+                  "timeUnixNano": "1777001942566000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -649,18 +733,18 @@
               "flags": 257
             },
             {
-              "traceId": "9a6d007cd810493c8f0280fbe14f9c01",
-              "spanId": "c207b90f82fb5a5c",
-              "parentSpanId": "4e396d7ad539bbca",
+              "traceId": "14b59a664006155357e1bcd2504b58e7",
+              "spanId": "2d3581f1b6d933e5",
+              "parentSpanId": "bf35acd8660be21a",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224120316000000",
-              "endTimeUnixNano": "1776224120318000000",
+              "startTimeUnixNano": "1777001942573000000",
+              "endTimeUnixNano": "1777001942574000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D05CE6EB0066024C7D17C6A2C611D894"
+                    "stringValue": "2B9AF0DFEF3D824FBDBD5700E92D45EF"
                   }
                 },
                 {
@@ -672,19 +756,19 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-B7p7wL93.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DWDXMVg7.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 374707
+                    "intValue": 392171
                   }
                 },
                 {
                   "key": "http.response_content_length_uncompressed",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
                   }
                 },
                 {
@@ -696,19 +780,43 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 374707
+                    "intValue": 392171
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 375007
+                    "intValue": 392471
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "47434D134E32AC7AC9E8A64DB4894877"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "47434D134E32AC7AC9E8A64DB4894877"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -729,49 +837,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224120316000000",
+                  "timeUnixNano": "1777001942573000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224120316000000",
+                  "timeUnixNano": "1777001942573000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224120316000000",
+                  "timeUnixNano": "1777001942573000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224120316000000",
+                  "timeUnixNano": "1777001942573000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224120316000000",
+                  "timeUnixNano": "1777001942573000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224120316000000",
+                  "timeUnixNano": "1777001942573000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224120317000000",
+                  "timeUnixNano": "1777001942574000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224120318000000",
+                  "timeUnixNano": "1777001942574000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -784,17 +892,17 @@
               "flags": 257
             },
             {
-              "traceId": "9a6d007cd810493c8f0280fbe14f9c01",
-              "spanId": "4e396d7ad539bbca",
+              "traceId": "14b59a664006155357e1bcd2504b58e7",
+              "spanId": "bf35acd8660be21a",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1776224120309000000",
-              "endTimeUnixNano": "1776224120348000000",
+              "startTimeUnixNano": "1777001942566000000",
+              "endTimeUnixNano": "1777001942603000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D05CE6EB0066024C7D17C6A2C611D894"
+                    "stringValue": "2B9AF0DFEF3D824FBDBD5700E92D45EF"
                   }
                 },
                 {
@@ -816,6 +924,30 @@
                   }
                 },
                 {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "47434D134E32AC7AC9E8A64DB4894877"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "47434D134E32AC7AC9E8A64DB4894877"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -833,19 +965,19 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224120309000000",
+                  "timeUnixNano": "1777001942566000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1776224120347000000",
+                  "timeUnixNano": "1777001942603000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1776224120348000000",
+                  "timeUnixNano": "1777001942603000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -866,12 +998,12 @@
           },
           "spans": [
             {
-              "traceId": "84049bc81aa74c23f027fa19795e945c",
-              "spanId": "55bfae13cdeca72e",
+              "traceId": "607d2313e04cfacb1bb29ba367c69843",
+              "spanId": "1a2c78630dceedbb",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1776224120482000000",
-              "endTimeUnixNano": "1776224120484000000",
+              "startTimeUnixNano": "1777001942746000000",
+              "endTimeUnixNano": "1777001942749000000",
               "attributes": [
                 {
                   "key": "component",
@@ -892,9 +1024,9 @@
                   }
                 },
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D05CE6EB0066024C7D17C6A2C611D894"
+                    "stringValue": "2B9AF0DFEF3D824FBDBD5700E92D45EF"
                   }
                 },
                 {
@@ -931,6 +1063,30 @@
                   "key": "http.response_content_length",
                   "value": {
                     "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "47434D134E32AC7AC9E8A64DB4894877"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "47434D134E32AC7AC9E8A64DB4894877"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -985,43 +1141,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224120482000000",
+                  "timeUnixNano": "1777001942746000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224120482000000",
+                  "timeUnixNano": "1777001942746000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224120482000000",
+                  "timeUnixNano": "1777001942746000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224120482000000",
+                  "timeUnixNano": "1777001942746000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224120482000000",
+                  "timeUnixNano": "1777001942746000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224120482000000",
+                  "timeUnixNano": "1777001942746000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224120484000000",
+                  "timeUnixNano": "1777001942748000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
@@ -4,12 +4,6 @@
       "resource": {
         "attributes": [
           {
-            "key": "service.name",
-            "value": {
-              "stringValue": "embrace-web-sdk"
-            }
-          },
-          {
             "key": "telemetry.sdk.name",
             "value": {
               "stringValue": "embrace-web-sdk"
@@ -60,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "AC6C3D985B048F2DD3DA41F7033A1192"
+              "stringValue": "BAC3A512288C5138825E5F29F7B47465"
             }
           },
           {
@@ -74,6 +68,12 @@
             "value": {
               "stringValue": "1280x720"
             }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "embrace-web-sdk"
+            }
           }
         ],
         "droppedAttributesCount": 0
@@ -85,8 +85,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1775548382262000000",
-              "observedTimeUnixNano": "1775548382263000000",
+              "timeUnixNano": "1776992681223000000",
+              "observedTimeUnixNano": "1776992681224000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -102,13 +102,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:79332\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:219646\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:971\nPromise@[native code]\nZt@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:1:798\nF_@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:132565\ned@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:15162\nKo@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:8:128746\nlc@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:28581\nYb@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:9:28403"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:83460\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:233926\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:971\nPromise@[native code]\n$t@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:1:798\nW_@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:132565\nsd@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:15162\nZo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:8:128746\ncc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:28581\nqb@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:9:28403"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-qINAsadP.js:11:126\":\"3d9bf9584dd68a94fe0fe5b0deec00f5\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-BTz-mbE9.js:11:126\":\"29937d3984834c95529ba178c0e4d8c7\"}"
                   }
                 },
                 {
@@ -120,18 +120,38 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "FF5E6FEDB6D68202F5C9BACB6F84D938"
+                    "stringValue": "ECFE23C431BFB5770465B308E2557BD9"
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "E7581195E0D2731B503C2F1CDDB86D8A"
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "DB91E5478588818307759A988ACDA36B"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "26DAEAD34B34C6CAD4A5CF0EDF00867F"
+                    "stringValue": "DB91E5478588818307759A988ACDA36B"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
                   "key": "session.previous_id",
-                  "value": {}
+                  "value": {
+                    "stringValue": ""
+                  }
                 },
                 {
                   "key": "browser.url.full",

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "CAE84EAC0B4B44AC274D32F966D1530D"
+              "stringValue": "29388DF0EED561095B56FB8CACD0FDAD"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "5bfce699b03688a2e2e950e5e1190762",
-              "spanId": "a491a0a6f2324b90",
+              "traceId": "f9548108669a6e79d2b7288c9490e3c2",
+              "spanId": "98bb36f812262f47",
               "name": "emb-session",
               "kind": 1,
-              "startTimeUnixNano": "1776224117275000000",
-              "endTimeUnixNano": "1776224117450000000",
+              "startTimeUnixNano": "1777001939749000000",
+              "endTimeUnixNano": "1777001939898000000",
               "attributes": [
                 {
                   "key": "emb.type",
                   "value": {
-                    "stringValue": "ux.session"
+                    "stringValue": "ux.session_part"
                   }
                 },
                 {
@@ -105,9 +105,15 @@
                   }
                 },
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EA21CF1FF10CB77FBBCBFCDB915D20CA"
+                    "stringValue": "DA0311323437621647D012156BCF4D27"
+                  }
+                },
+                {
+                  "key": "emb.session_part_start_reason",
+                  "value": {
+                    "stringValue": "init"
                   }
                 },
                 {
@@ -117,27 +123,81 @@
                   }
                 },
                 {
-                  "key": "emb.session_number",
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "D753687548FF14A5BB3E89F6115AA723"
+                  }
+                },
+                {
+                  "key": "emb.user_session_number",
                   "value": {
                     "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_start_type",
+                  "key": "emb.user_session_part_number",
                   "value": {
-                    "stringValue": "init"
+                    "intValue": 1
                   }
                 },
                 {
-                  "key": "emb.session_end_type",
+                  "key": "emb.user_session_start_ts",
                   "value": {
-                    "stringValue": "manual"
+                    "intValue": 1777001939748
+                  }
+                },
+                {
+                  "key": "emb.user_session_max_duration_seconds",
+                  "value": {
+                    "intValue": 43200
+                  }
+                },
+                {
+                  "key": "emb.user_session_inactivity_timeout_seconds",
+                  "value": {
+                    "intValue": 1800
+                  }
+                },
+                {
+                  "key": "emb.session_part_end_reason",
+                  "value": {
+                    "stringValue": "user_session_ended"
                   }
                 },
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
                     "intValue": 9
+                  }
+                },
+                {
+                  "key": "emb.is_final_session_part",
+                  "value": {
+                    "intValue": 1
+                  }
+                },
+                {
+                  "key": "emb.user_session_termination_reason",
+                  "value": {
+                    "stringValue": "manual"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "D753687548FF14A5BB3E89F6115AA723"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -196,19 +256,19 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224117277-9744163991726"
+                        "stringValue": "v5-1777001939751-4414933497528"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "intValue": 2
+                        "intValue": 1
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "intValue": 2
+                        "intValue": 1
                       }
                     },
                     {
@@ -238,7 +298,7 @@
                     {
                       "key": "emb.web_vital.attribution.requestDuration",
                       "value": {
-                        "intValue": 1
+                        "intValue": 0
                       }
                     },
                     {
@@ -268,7 +328,7 @@
                     {
                       "key": "emb.web_vital.attribution.serverResponse",
                       "value": {
-                        "intValue": 1
+                        "intValue": 0
                       }
                     },
                     {
@@ -285,7 +345,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1776224117280000000",
+                  "timeUnixNano": "1777001939753000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -329,31 +389,31 @@
                     {
                       "key": "emb.web_vital.id",
                       "value": {
-                        "stringValue": "v5-1776224117277-7913014480203"
+                        "stringValue": "v5-1777001939751-7007322496874"
                       }
                     },
                     {
                       "key": "emb.web_vital.delta",
                       "value": {
-                        "intValue": 65
+                        "intValue": 46
                       }
                     },
                     {
                       "key": "emb.web_vital.value",
                       "value": {
-                        "intValue": 65
+                        "intValue": 46
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.timeToFirstByte",
                       "value": {
-                        "intValue": 2
+                        "intValue": 1
                       }
                     },
                     {
                       "key": "emb.web_vital.attribution.firstByteToFCP",
                       "value": {
-                        "intValue": 63
+                        "intValue": 45
                       }
                     },
                     {
@@ -370,7 +430,7 @@
                     }
                   ],
                   "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1776224117310000000",
+                  "timeUnixNano": "1777001939763000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -391,18 +451,18 @@
           },
           "spans": [
             {
-              "traceId": "554db5b233664861bdddaf235cc96c8f",
-              "spanId": "9b1814196adb9453",
-              "parentSpanId": "72a3de7448ecbf67",
+              "traceId": "1c47789724c17bfb84bd0746d3a4a81a",
+              "spanId": "3bef507075115bdd",
+              "parentSpanId": "5577a0a2b566193b",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224117245000000",
-              "endTimeUnixNano": "1776224117246000000",
+              "startTimeUnixNano": "1777001939717000000",
+              "endTimeUnixNano": "1777001939717000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EA21CF1FF10CB77FBBCBFCDB915D20CA"
+                    "stringValue": "DA0311323437621647D012156BCF4D27"
                   }
                 },
                 {
@@ -424,6 +484,30 @@
                   }
                 },
                 {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "D753687548FF14A5BB3E89F6115AA723"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "D753687548FF14A5BB3E89F6115AA723"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -441,55 +525,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224117245000000",
+                  "timeUnixNano": "1777001939717000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224117245000000",
+                  "timeUnixNano": "1777001939717000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224117245000000",
+                  "timeUnixNano": "1777001939717000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224117245000000",
+                  "timeUnixNano": "1777001939717000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1776224117244000000",
+                  "timeUnixNano": "1777001939716000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224117245000000",
+                  "timeUnixNano": "1777001939717000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224117245000000",
+                  "timeUnixNano": "1777001939717000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224117246000000",
+                  "timeUnixNano": "1777001939717000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224117246000000",
+                  "timeUnixNano": "1777001939717000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -502,18 +586,18 @@
               "flags": 257
             },
             {
-              "traceId": "554db5b233664861bdddaf235cc96c8f",
-              "spanId": "fd0ff9ed57499122",
-              "parentSpanId": "72a3de7448ecbf67",
+              "traceId": "1c47789724c17bfb84bd0746d3a4a81a",
+              "spanId": "351109e4b9ec6e47",
+              "parentSpanId": "5577a0a2b566193b",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1776224117251000000",
-              "endTimeUnixNano": "1776224117252000000",
+              "startTimeUnixNano": "1777001939723000000",
+              "endTimeUnixNano": "1777001939725000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EA21CF1FF10CB77FBBCBFCDB915D20CA"
+                    "stringValue": "DA0311323437621647D012156BCF4D27"
                   }
                 },
                 {
@@ -525,19 +609,19 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-B7p7wL93.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DWDXMVg7.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 374707
+                    "intValue": 392171
                   }
                 },
                 {
                   "key": "http.response_content_length_uncompressed",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
                   }
                 },
                 {
@@ -549,19 +633,43 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 374707
+                    "intValue": 392171
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 375007
+                    "intValue": 392471
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 374695
+                    "intValue": 392159
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "D753687548FF14A5BB3E89F6115AA723"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "D753687548FF14A5BB3E89F6115AA723"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
                   }
                 },
                 {
@@ -582,49 +690,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224117251000000",
+                  "timeUnixNano": "1777001939723000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1776224117251000000",
+                  "timeUnixNano": "1777001939723000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1776224117251000000",
+                  "timeUnixNano": "1777001939723000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1776224117251000000",
+                  "timeUnixNano": "1777001939723000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1776224117251000000",
+                  "timeUnixNano": "1777001939723000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1776224117251000000",
+                  "timeUnixNano": "1777001939723000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1776224117252000000",
+                  "timeUnixNano": "1777001939724000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1776224117252000000",
+                  "timeUnixNano": "1777001939725000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -637,17 +745,17 @@
               "flags": 257
             },
             {
-              "traceId": "554db5b233664861bdddaf235cc96c8f",
-              "spanId": "72a3de7448ecbf67",
+              "traceId": "1c47789724c17bfb84bd0746d3a4a81a",
+              "spanId": "5577a0a2b566193b",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1776224117245000000",
-              "endTimeUnixNano": "1776224117280000000",
+              "startTimeUnixNano": "1777001939718000000",
+              "endTimeUnixNano": "1777001939754000000",
               "attributes": [
                 {
-                  "key": "session.id",
+                  "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EA21CF1FF10CB77FBBCBFCDB915D20CA"
+                    "stringValue": "DA0311323437621647D012156BCF4D27"
                   }
                 },
                 {
@@ -669,6 +777,30 @@
                   }
                 },
                 {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "D753687548FF14A5BB3E89F6115AA723"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "D753687548FF14A5BB3E89F6115AA723"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -686,19 +818,19 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1776224117245000000",
+                  "timeUnixNano": "1777001939718000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1776224117280000000",
+                  "timeUnixNano": "1777001939754000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1776224117280000000",
+                  "timeUnixNano": "1777001939754000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/utils/run-e2e-tests.ts
+++ b/tests/integration/utils/run-e2e-tests.ts
@@ -4,7 +4,7 @@ import testWithMockApi, {
 } from './test-with-mock-api.ts';
 
 const EXPECTED_SPAN_ENDED_TEXT =
-  'EmbraceSessionBatchedSpanProcessor non-session span ended';
+  'EmbraceSessionBatchedSpanProcessor non-session-part span ended';
 
 type E2ETestFixture = {
   getCurrentSessionId: () => Promise<string>;
@@ -62,7 +62,7 @@ const testE2E = testWithMockApi.extend<E2ETestFixture>({
     await use(async (url: string, numberOfExpectedSpans: number) => {
       let autoInstrumentedSpansCount = 0;
       // This depends on the SDK logging
-      // "EmbraceSessionBatchedSpanProcessor non-session span ended"
+      // "EmbraceSessionBatchedSpanProcessor non-session-part span ended"
       // when a span ends, and it is waiting for a fixed number of auto-instrumented spans to be created on page load
       // Adding more spans or changing the number of spans may require adjusting the test expectations
       // But it's better than waiting a random amount of time for everything to settle

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -72,14 +72,25 @@ const INSTRUMENTATION_WITH_SIMPLIFIED_COMPARISON = [
 const EXCLUDED_RESOURCE_URL_PATTERNS = [/favicon\.ico$/];
 const IGNORED_ATTRIBUTES_LIST = [
   'session.id',
+  'session.previous_id',
   'log.record.uid',
   'emb.sdk_startup_duration',
   'emb.app_instance_id',
+  // UUIDs and timestamps regenerated on every run; compare key presence only.
+  'emb.session_part_id',
+  'emb.user_session_id',
+  'emb.user_session_previous_id',
+  'emb.user_session_start_ts',
   // CI runs on Linux, devs might use different OS, thus different user agent
   'user_agent.original',
   'emb.stacktrace.js',
   'emb.js_file_bundle_ids',
   'emb.web_vital.attribution.elementRenderDelay',
+  // FCP is reported when the browser delivers the PerformanceObserver entry,
+  // which can fire before or after document.readyState reaches 'complete'
+  // depending on render timing. The value oscillates between 'dom-interactive'
+  // and 'complete' across CI runs.
+  'emb.web_vital.attribution.loadState',
   'emb.web_vital.attribution.timeToFirstByte',
   'emb.web_vital.attribution.redirect',
   'emb.web_vital.attribution.domainLookup',


### PR DESCRIPTION
## What problem is this solving?

PR 2 of 3 in the EMBR-11208 stack. The session redefinition in #1289 changes the attribute shape on exported spans and logs (new ``emb.session_part_id``, ``emb.user_session_id``, ``session.previous_id``, etc.), and the new ``EmbraceSessionBatchedSpanProcessor`` log message changed from ``"non-session span ended"`` to ``"non-session-part span ended"``. The integration harness and golden files have to flip together with the SDK behavior.

## Short description of changes

- 12 golden files updated to match the new attribute set across the chromium / firefox / webkit × handle-204 / send-log / session matrix.
- ``tests/integration/utils/run-e2e-tests.ts`` — wait-for-spans log expectation updated.
- ``tests/integration/utils/test-with-mock-api.ts`` — adds ``session.previous_id``, ``emb.session_part_id``, ``emb.user_session_id``, ``emb.user_session_previous_id``, and the web-vital ``loadState`` to the ignored-for-comparison list (UUIDs and timestamps regenerated each run).
- ``tests/integration/platforms/webpack-4/src/index.js`` — replaces empty ``appID`` with placeholder ``11111`` for SDK init.

## Testing

- ``npm run test:integration`` from repo root.