### PR TITLE
EMBR-11208 chore(deps): drop unused @opentelemetry/web-common dependency 3/3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3866,23 +3866,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@opentelemetry/web-common": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/web-common/-/web-common-0.214.0.tgz",
-      "integrity": "sha512-WiUMy1NNloFRUShsv8rR67b3FXWt9lPXoCo2Kf5LP8jAPQ0CRYKE1mez2syEcSYCkiV/E8kK78XEIotz4HkMQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/sdk-logs": "0.214.0",
-        "@opentelemetry/sdk-trace-base": "2.6.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
     "node_modules/@oxc-project/types": {
       "version": "0.126.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
@@ -13801,7 +13784,6 @@
         "@opentelemetry/sdk-logs": "^0.214.0",
         "@opentelemetry/sdk-trace-web": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@opentelemetry/web-common": "^0.214.0",
         "hoist-non-react-statics": "^3.3.2",
         "web-vitals": "^5.2.0"
       },

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -90,7 +90,6 @@
     "@opentelemetry/sdk-logs": "^0.214.0",
     "@opentelemetry/sdk-trace-web": "^2.6.1",
     "@opentelemetry/semantic-conventions": "^1.40.0",
-    "@opentelemetry/web-common": "^0.214.0",
     "hoist-non-react-statics": "^3.3.2",
     "web-vitals": "^5.2.0"
   },


### PR DESCRIPTION
## What problem is this solving?

PR 3 of 3 in the EMBR-11208 stack. The ``@opentelemetry/web-common`` package was only used by the old span-session wiring in ``initSDK``. After the redefinition in #1289, nothing imports it.

## Short description of changes

- Removes ``@opentelemetry/web-common`` from ``packages/web-sdk/package.json`` dependencies.
- Regenerates ``package-lock.json`` to reflect the removal.

## Testing

- ``npm run check``
- Confirm package is not in ``node_modules`` after ``npm install``.