### PR TITLE
fix(config): preserve default config when refreshing remote config

### DIFF
--- a/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.test.ts
@@ -153,6 +153,7 @@ describe('EmbraceDynamicConfigManager', () => {
 
     expect(config).to.deep.equal({
       samplingPct: 80,
+      networkSpansForwardingThreshold: 0,
     });
     expect(fakeFetchGetUrl()).to.equal(
       'https://a-test-app.config.emb-api.com/v2/config?appId=test-app&osVersion=1&appVersion=1.0.0&deviceId=test-device',
@@ -255,6 +256,7 @@ describe('EmbraceDynamicConfigManager', () => {
 
     expect(config).to.deep.equal({
       samplingPct: 80,
+      networkSpansForwardingThreshold: 0,
     });
     expect(fakeFetchGetRequestHeaders()).to.deep.equal({
       'If-None-Match': 'stored-etag',
@@ -338,6 +340,7 @@ describe('EmbraceDynamicConfigManager', () => {
 
     expect(config).to.deep.equal({
       samplingPct: 90,
+      networkSpansForwardingThreshold: 0,
     });
     expect(fakeFetchGetUrl()).to.equal(
       `https://custom-config-url.com/config/v2/config?appId=test-app&osVersion=1&appVersion=1.0.0&deviceId=test-device`,

--- a/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.ts
@@ -33,6 +33,7 @@ export class EmbraceDynamicConfigManager implements DynamicConfigManager {
   private readonly _remoteConfigURL: string | null = null;
   private readonly _diag: DiagLogger;
   private readonly _storage: Storage;
+  private readonly _baseConfig: DynamicSDKConfig;
 
   private _sdkConfig: DynamicSDKConfig;
   private _etag: string | null = null;
@@ -71,11 +72,15 @@ export class EmbraceDynamicConfigManager implements DynamicConfigManager {
       this._etag = storedRemoteConfig.etag;
     }
 
-    this._sdkConfig = {
-      // Merge the default config with any user-provided defaults
-      // making sure user-provided values take precedence
+    // Default config merged with any user-provided defaults; user-provided values take precedence.
+    // Kept around so refreshRemoteConfig can re-merge against it instead of dropping defaults.
+    this._baseConfig = {
       ...DEFAULT_CONFIG,
       ...defaultConfig,
+    };
+
+    this._sdkConfig = {
+      ...this._baseConfig,
       // Stored remote config values will override both defaults and user-provided defaults
       ...(storedRemoteConfig
         ? parseRemoteConfig(storedRemoteConfig.config)
@@ -119,7 +124,10 @@ export class EmbraceDynamicConfigManager implements DynamicConfigManager {
         } as StoredRemoteConfig),
       );
 
-      this._sdkConfig = parseRemoteConfig(remoteConfig);
+      this._sdkConfig = {
+        ...this._baseConfig,
+        ...parseRemoteConfig(remoteConfig),
+      };
       this._etag = etag;
     } catch (error: unknown) {
       this._diag.warn(


### PR DESCRIPTION
## What problem is this solving?

`EmbraceDynamicConfigManager.refreshRemoteConfig` overwrote `_sdkConfig` with raw `parseRemoteConfig(...)` output, dropping the `DEFAULT_CONFIG` and user-provided defaults that the constructor merged in. Today only `samplingPct` survives a refresh because it's always set; any optional default field (e.g. `networkSpansForwardingThreshold`) silently reverts to `undefined` after the first refresh.

This is a pre-existing bug. Stacked on #1292 because that PR is touching the same area; the fix is independent of the empty-session-avoidance removal and could equally apply on `main`.

## Short description of changes

- Add a `_baseConfig` field on `EmbraceDynamicConfigManager` capturing the merged `DEFAULT_CONFIG` + user defaults at construction time.
- Constructor uses `_baseConfig` as the starting point; behavior unchanged.
- `refreshRemoteConfig` merges the parsed remote config onto `_baseConfig` instead of replacing wholesale, so defaults survive a refresh.

## How has this been tested?

- `npm run check` and `npm run test` from `packages/web-sdk/` pass locally.
- Three existing refresh-path tests (fetch + parse, etag update, custom URL) updated to assert that `networkSpansForwardingThreshold: 0` survives the refresh; previously they asserted the buggy behavior.

## Checklist

- [ ] Documentation added
- [x] Tests added