### PR TITLE
EMBR-11944 chore: fork upstreamed web vitals instrumentation

### DIFF
--- a/packages/web-sdk/src/instrumentations/index.ts
+++ b/packages/web-sdk/src/instrumentations/index.ts
@@ -32,6 +32,5 @@ export {
 export {
   type WebVitalOnReport,
   WebVitalsInstrumentation,
-  type WebVitalsInstrumentationArgs,
   type WebVitalsInstrumentationConfig,
 } from './web-vitals/index.ts';

--- a/packages/web-sdk/src/instrumentations/index.ts
+++ b/packages/web-sdk/src/instrumentations/index.ts
@@ -33,4 +33,5 @@ export {
   type WebVitalOnReport,
   WebVitalsInstrumentation,
   type WebVitalsInstrumentationArgs,
+  type WebVitalsInstrumentationConfig,
 } from './web-vitals/index.ts';

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
@@ -179,7 +179,7 @@ describe('LoafInstrumentation', () => {
     expect(report?.attributes['browser.web_vital.id'])
       .to.be.a('string')
       .and.to.have.length.greaterThan(0);
-    expect(report?.attributes['browser.web_vital.name']).to.equal('TBD');
+    expect(report?.attributes['browser.web_vital.name']).to.equal('tbd');
     expect(report?.attributes['emb.tbd.loaf_total_duration']).to.equal(180);
     expect(report?.attributes['emb.tbd.loaf_count']).to.equal(2);
     expect(report?.attributes['emb.tbd.loaf_longest_duration']).to.equal(100);

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
@@ -176,10 +176,10 @@ describe('LoafInstrumentation', () => {
     expect(report?.eventName).to.equal('emb-loaf-report');
     expect(report?.severityNumber).to.equal(SeverityNumber.INFO);
     expect(report?.attributes['emb.type']).to.equal('ux.web_vital');
-    expect(report?.attributes['emb.web_vital.id'])
+    expect(report?.attributes['browser.web_vital.id'])
       .to.be.a('string')
       .and.to.have.length.greaterThan(0);
-    expect(report?.attributes['emb.web_vital.name']).to.equal('TBD');
+    expect(report?.attributes['browser.web_vital.name']).to.equal('TBD');
     expect(report?.attributes['emb.tbd.loaf_total_duration']).to.equal(180);
     expect(report?.attributes['emb.tbd.loaf_count']).to.equal(2);
     expect(report?.attributes['emb.tbd.loaf_longest_duration']).to.equal(100);
@@ -257,7 +257,7 @@ describe('LoafInstrumentation', () => {
       .getFinishedLogRecords()
       .find((l) => l.eventName === 'emb-loaf-report');
     // First entry (100) skipped, sum of 50 + 30 = 80
-    expect(report?.attributes['emb.web_vital.value']).to.equal(80);
+    expect(report?.attributes['browser.web_vital.value']).to.equal(80);
 
     instrumentation.disable();
   });
@@ -280,7 +280,7 @@ describe('LoafInstrumentation', () => {
       .getFinishedLogRecords()
       .find((l) => l.eventName === 'emb-loaf-report');
     // First skipped, third filtered (interaction), only second counted = 50
-    expect(report?.attributes['emb.web_vital.value']).to.equal(50);
+    expect(report?.attributes['browser.web_vital.value']).to.equal(50);
 
     instrumentation.disable();
   });
@@ -386,8 +386,8 @@ describe('LoafInstrumentation', () => {
     const report = memoryExporter
       .getFinishedLogRecords()
       .find((l) => l.eventName === 'emb-loaf-report');
-    expect(report?.attributes['emb.web_vital.value']).to.equal(200);
-    expect(report?.attributes['emb.web_vital.rating']).to.equal('good');
+    expect(report?.attributes['browser.web_vital.value']).to.equal(200);
+    expect(report?.attributes['browser.web_vital.rating']).to.equal('good');
 
     instrumentation.disable();
   });
@@ -408,8 +408,8 @@ describe('LoafInstrumentation', () => {
     const report = memoryExporter
       .getFinishedLogRecords()
       .find((l) => l.eventName === 'emb-loaf-report');
-    expect(report?.attributes['emb.web_vital.value']).to.equal(201);
-    expect(report?.attributes['emb.web_vital.rating']).to.equal(
+    expect(report?.attributes['browser.web_vital.value']).to.equal(201);
+    expect(report?.attributes['browser.web_vital.rating']).to.equal(
       'needs-improvement',
     );
 
@@ -432,8 +432,8 @@ describe('LoafInstrumentation', () => {
     const report = memoryExporter
       .getFinishedLogRecords()
       .find((l) => l.eventName === 'emb-loaf-report');
-    expect(report?.attributes['emb.web_vital.value']).to.equal(600);
-    expect(report?.attributes['emb.web_vital.rating']).to.equal(
+    expect(report?.attributes['browser.web_vital.value']).to.equal(600);
+    expect(report?.attributes['browser.web_vital.rating']).to.equal(
       'needs-improvement',
     );
 
@@ -456,8 +456,8 @@ describe('LoafInstrumentation', () => {
     const report = memoryExporter
       .getFinishedLogRecords()
       .find((l) => l.eventName === 'emb-loaf-report');
-    expect(report?.attributes['emb.web_vital.value']).to.equal(601);
-    expect(report?.attributes['emb.web_vital.rating']).to.equal('poor');
+    expect(report?.attributes['browser.web_vital.value']).to.equal(601);
+    expect(report?.attributes['browser.web_vital.rating']).to.equal('poor');
 
     instrumentation.disable();
   });
@@ -548,7 +548,7 @@ describe('LoafInstrumentation', () => {
     const firstReport = memoryExporter
       .getFinishedLogRecords()
       .find((l) => l.eventName === 'emb-loaf-report');
-    const firstId = firstReport?.attributes['emb.web_vital.id'];
+    const firstId = firstReport?.attributes['browser.web_vital.id'];
     expect(firstId).to.be.a('string').and.to.have.length.greaterThan(0);
 
     memoryExporter.reset();
@@ -560,7 +560,7 @@ describe('LoafInstrumentation', () => {
     const secondReport = memoryExporter
       .getFinishedLogRecords()
       .find((l) => l.eventName === 'emb-loaf-report');
-    const secondId = secondReport?.attributes['emb.web_vital.id'];
+    const secondId = secondReport?.attributes['browser.web_vital.id'];
     expect(secondId).to.be.a('string').and.to.have.length.greaterThan(0);
     expect(secondId).to.not.equal(firstId);
 
@@ -940,7 +940,7 @@ describe('LoafInstrumentation', () => {
 
       const logs = memoryExporter.getFinishedLogRecords();
       const report = logs.find((l) => l.eventName === 'emb-loaf-report');
-      expect(report?.attributes['emb.web_vital.value']).to.equal(105);
+      expect(report?.attributes['browser.web_vital.value']).to.equal(105);
       expect(report?.attributes['emb.tbd.loaf_total_duration']).to.equal(286);
 
       const summary = logs.find((l) => l.eventName === 'emb-loaf-scripts');

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
@@ -214,7 +214,7 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
     const attrs: Record<string, string | number> = {
       [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
       ['browser.web_vital.id']: generateWebVitalID(),
-      ['browser.web_vital.name']: 'TBD',
+      ['browser.web_vital.name']: 'tbd',
       ['browser.web_vital.value']: Math.round(this._totalBlockingDuration),
       ['browser.web_vital.rating']: rating,
       [ATTR_TBD_LOAF_TOTAL_DURATION]: Math.round(this._totalDuration),

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
@@ -213,10 +213,10 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
 
     const attrs: Record<string, string | number> = {
       [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
-      ['emb.web_vital.id']: generateWebVitalID(),
-      ['emb.web_vital.name']: 'TBD',
-      ['emb.web_vital.value']: Math.round(this._totalBlockingDuration),
-      ['emb.web_vital.rating']: rating,
+      ['browser.web_vital.id']: generateWebVitalID(),
+      ['browser.web_vital.name']: 'TBD',
+      ['browser.web_vital.value']: Math.round(this._totalBlockingDuration),
+      ['browser.web_vital.rating']: rating,
       [ATTR_TBD_LOAF_TOTAL_DURATION]: Math.round(this._totalDuration),
       [ATTR_TBD_LOAF_WORK_DURATION]: Math.round(this._workDuration),
       [ATTR_TBD_LOAF_STYLE_AND_LAYOUT_DURATION]: Math.round(

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -4,6 +4,8 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import type {
+  CLSMetricWithAttribution,
+  FCPMetricWithAttribution,
   INPMetricWithAttribution,
   MetricWithAttribution,
 } from 'web-vitals/attribution';
@@ -19,11 +21,14 @@ import {
   KEY_EMB_PAGE_ID,
   KEY_EMB_PAGE_PATH,
 } from '../../../constants/index.ts';
+import { EmbracePageManager } from '../../../managers/index.ts';
 import type { WebVitalListeners, WebVitalOnReport } from './types.ts';
 import { WebVitalsInstrumentation } from './WebVitalsInstrumentation.ts';
 
 chai.use(sinonChai);
 const { expect } = chai;
+
+const urlDocument = { URL: 'https://example.com' };
 
 describe('WebVitalsInstrumentation', () => {
   let memoryExporter: InMemoryLogRecordExporter;
@@ -1212,6 +1217,1027 @@ describe('WebVitalsInstrumentation', () => {
     expect(diag.getDebugLogs()).to.include(
       'WebVitalsInstrumentation disabled, pausing emission',
     );
+  });
+
+  it('should report CLS metrics with url attribution', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlDocument,
+    });
+
+    void expect(clsStub.calledTwice).to.be.true;
+    const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+    const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
+
+    clock.tick(5000);
+
+    const metric = {
+      name: 'CLS',
+      value: 22,
+      rating: 'good',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {},
+    } as MetricWithAttribution;
+
+    pageTrackFunc(metric);
+    emitFunc(metric);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
+
+    expect(record.eventName).to.equal('browser.web_vital');
+    expect(record.attributes).to.deep.include({
+      'browser.web_vital.delta': 0,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'cls',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'good',
+      'browser.web_vital.value': 22,
+      [ATTR_URL_FULL]: 'https://example.com',
+      [KEY_BROWSER_URL_FULL]: 'https://example.com',
+    });
+    expect(record.hrTime).to.deep.equal([5, 0]);
+    expect(record.body).to.equal('{}');
+  });
+
+  it('should report CLS metrics with largest shift time, loadState and url attribution', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlDocument,
+    });
+
+    const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+    const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
+
+    const metric = {
+      name: 'CLS',
+      value: 22,
+      rating: 'good',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        largestShiftTime: 3000,
+        largestShiftValue: 3.0,
+        largestShiftTarget: 'some-target',
+        loadState: 'complete',
+      },
+    } as MetricWithAttribution;
+
+    pageTrackFunc(metric);
+    emitFunc(metric);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
+
+    expect(record.attributes).to.deep.include({
+      'browser.web_vital.delta': 0,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'cls',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'good',
+      'browser.web_vital.value': 22,
+      [ATTR_URL_FULL]: 'https://example.com',
+      [KEY_BROWSER_URL_FULL]: 'https://example.com',
+    });
+    expect(record.hrTime).to.deep.equal([3, 0]);
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['largestShiftTime']).to.equal(3000);
+    expect(body['largestShiftValue']).to.equal(3.0);
+    expect(body['largestShiftTarget']).to.equal('some-target');
+    expect(body['loadState']).to.equal('complete');
+  });
+
+  it('should report FCP metrics with url attribution', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlDocument,
+    });
+
+    void expect(fcpStub.calledTwice).to.be.true;
+    const pageTrackFunc = fcpStub.getCall(0).args[0] as WebVitalOnReport;
+    const emitFunc = fcpStub.getCall(1).args[0] as WebVitalOnReport;
+
+    clock.tick(5000);
+
+    const metric = {
+      name: 'FCP',
+      value: 33,
+      rating: 'needs-improvement',
+      delta: 99,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        timeToFirstByte: 20,
+        firstByteToFCP: 40,
+        loadState: 'complete',
+      },
+    } as MetricWithAttribution;
+
+    pageTrackFunc(metric);
+    emitFunc(metric);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
+
+    expect(record.eventName).to.equal('browser.web_vital');
+    expect(record.attributes).to.deep.include({
+      'browser.web_vital.delta': 99,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'fcp',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'needs-improvement',
+      'browser.web_vital.value': 33,
+      [ATTR_URL_FULL]: 'https://example.com',
+      [KEY_BROWSER_URL_FULL]: 'https://example.com',
+    });
+    expect(record.hrTime).to.deep.equal([5, 0]);
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['timeToFirstByte']).to.equal(20);
+    expect(body['firstByteToFCP']).to.equal(40);
+    expect(body['loadState']).to.equal('complete');
+  });
+
+  it('should report LCP metrics with url attribution', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlDocument,
+    });
+
+    void expect(lcpStub.calledTwice).to.be.true;
+    const pageTrackFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
+    const emitFunc = lcpStub.getCall(1).args[0] as WebVitalOnReport;
+
+    clock.tick(5000);
+
+    const metric = {
+      name: 'LCP',
+      value: 22,
+      rating: 'poor',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        timeToFirstByte: 999,
+        resourceLoadDelay: 1000,
+        resourceLoadDuration: 2000,
+        elementRenderDelay: 3000,
+      },
+    } as MetricWithAttribution;
+
+    pageTrackFunc(metric);
+    emitFunc(metric);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
+
+    expect(record.eventName).to.equal('browser.web_vital');
+    expect(record.attributes).to.deep.include({
+      'browser.web_vital.delta': 0,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'lcp',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'poor',
+      'browser.web_vital.value': 22,
+      [ATTR_URL_FULL]: 'https://example.com',
+      [KEY_BROWSER_URL_FULL]: 'https://example.com',
+    });
+    expect(record.hrTime).to.deep.equal([5, 0]);
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['timeToFirstByte']).to.equal(999);
+    expect(body['resourceLoadDelay']).to.equal(1000);
+    expect(body['resourceLoadDuration']).to.equal(2000);
+    expect(body['elementRenderDelay']).to.equal(3000);
+  });
+
+  it('should report INP metrics with url attribution', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlDocument,
+    });
+
+    void expect(inpStub.calledTwice).to.be.true;
+    const pageTrackFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
+    const emitFunc = inpStub.getCall(1).args[0] as WebVitalOnReport;
+
+    clock.tick(5000);
+
+    const metric = {
+      name: 'INP',
+      value: 22,
+      rating: 'poor',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        interactionTarget: 'some-target',
+        interactionTargetElement: undefined,
+        interactionTime: 19000,
+        nextPaintTime: 18000,
+        interactionType: 'pointer',
+        processedEventEntries: [],
+        longAnimationFrameEntries: [],
+        inputDelay: 1000,
+        processingDuration: 2000,
+        presentationDelay: 3000,
+        loadState: 'complete',
+      },
+    } as MetricWithAttribution;
+
+    pageTrackFunc(metric);
+    emitFunc(metric);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
+
+    expect(record.eventName).to.equal('browser.web_vital');
+    expect(record.attributes).to.deep.include({
+      'browser.web_vital.delta': 0,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'inp',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'poor',
+      'browser.web_vital.value': 22,
+      [ATTR_URL_FULL]: 'https://example.com',
+      [KEY_BROWSER_URL_FULL]: 'https://example.com',
+    });
+    expect(record.hrTime).to.deep.equal([19, 0]);
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['interactionTarget']).to.equal('some-target');
+    expect(body['interactionTime']).to.equal(19000);
+    expect(body['nextPaintTime']).to.equal(18000);
+    expect(body['interactionType']).to.equal('pointer');
+    expect(body['inputDelay']).to.equal(1000);
+    expect(body['processingDuration']).to.equal(2000);
+    expect(body['presentationDelay']).to.equal(3000);
+    expect(body['loadState']).to.equal('complete');
+  });
+
+  it('should report TTFB metrics with url attribution and raw attribution in body', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlDocument,
+    });
+
+    void expect(ttfbStub.calledTwice).to.be.true;
+    const pageTrackFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
+    const emitFunc = ttfbStub.getCall(1).args[0] as WebVitalOnReport;
+
+    clock.tick(5000);
+
+    const metric = {
+      name: 'TTFB',
+      value: 33,
+      rating: 'poor',
+      delta: 99,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        waitingDuration: 20,
+        cacheDuration: 40,
+        dnsDuration: 60,
+        connectionDuration: 80,
+        requestDuration: 100,
+        navigationEntry: {
+          redirectStart: 0,
+          redirectEnd: 0,
+          domainLookupStart: 10,
+          domainLookupEnd: 20,
+          connectStart: 20,
+          connectEnd: 30,
+          secureConnectionStart: 0,
+          requestStart: 30,
+          responseStart: 50,
+          responseEnd: 60,
+          startTime: 0,
+        } as PerformanceNavigationTiming,
+      },
+    } as MetricWithAttribution;
+
+    pageTrackFunc(metric);
+    emitFunc(metric);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
+
+    expect(record.eventName).to.equal('browser.web_vital');
+    expect(record.attributes).to.deep.include({
+      'browser.web_vital.delta': 99,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'ttfb',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'poor',
+      'browser.web_vital.value': 33,
+      [ATTR_URL_FULL]: 'https://example.com',
+      [KEY_BROWSER_URL_FULL]: 'https://example.com',
+      'emb.web_vital.attribution.redirect': 0,
+      'emb.web_vital.attribution.domainLookup': 10,
+      'emb.web_vital.attribution.tcpConnection': 10,
+      'emb.web_vital.attribution.tlsNegotiation': 0,
+      'emb.web_vital.attribution.serverResponse': 20,
+      'emb.web_vital.attribution.unattributed': 20,
+    });
+    expect(record.hrTime).to.deep.equal([5, 0]);
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['waitingDuration']).to.equal(20);
+    expect(body['cacheDuration']).to.equal(40);
+    expect(body['dnsDuration']).to.equal(60);
+    expect(body['connectionDuration']).to.equal(80);
+    expect(body['requestDuration']).to.equal(100);
+  });
+
+  it('should report multiple metrics with url attribution', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlDocument,
+    });
+
+    const clsPageTrack = clsStub.getCall(0).args[0] as WebVitalOnReport;
+    const clsEmit = clsStub.getCall(1).args[0] as WebVitalOnReport;
+    const lcpPageTrack = lcpStub.getCall(0).args[0] as WebVitalOnReport;
+    const lcpEmit = lcpStub.getCall(1).args[0] as WebVitalOnReport;
+
+    clock.tick(5000);
+
+    const clsMetric = {
+      name: 'CLS',
+      value: 22,
+      rating: 'good',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {},
+    } as MetricWithAttribution;
+
+    const lcpMetric = {
+      name: 'LCP',
+      value: 22,
+      rating: 'poor',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        timeToFirstByte: 999,
+        resourceLoadDelay: 1000,
+        resourceLoadDuration: 2000,
+        elementRenderDelay: 3000,
+      },
+    } as MetricWithAttribution;
+
+    clsPageTrack(clsMetric);
+    clsEmit(clsMetric);
+    lcpPageTrack(lcpMetric);
+    lcpEmit(lcpMetric);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(2);
+
+    const clsRecord = records.find(
+      (r) => r.attributes['browser.web_vital.name'] === 'cls',
+    );
+    const lcpRecord = records.find(
+      (r) => r.attributes['browser.web_vital.name'] === 'lcp',
+    );
+
+    expect(clsRecord?.eventName).to.equal('browser.web_vital');
+    expect(lcpRecord?.eventName).to.equal('browser.web_vital');
+    expect(clsRecord?.attributes).to.deep.include({
+      [ATTR_URL_FULL]: 'https://example.com',
+    });
+    expect(lcpRecord?.attributes).to.deep.include({
+      [ATTR_URL_FULL]: 'https://example.com',
+    });
+    const lcpBody = JSON.parse(lcpRecord?.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(lcpBody['timeToFirstByte']).to.equal(999);
+    expect(lcpBody['resourceLoadDelay']).to.equal(1000);
+    expect(lcpBody['resourceLoadDuration']).to.equal(2000);
+    expect(lcpBody['elementRenderDelay']).to.equal(3000);
+  });
+
+  it('should omit non-serializable attribution values from body', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
+
+    clock.tick(5000);
+
+    metricReportFunc({
+      name: 'INP',
+      value: 100,
+      rating: 'good',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        interactionTarget: 'some-target',
+        interactionTime: 19000,
+        loadState: 'complete',
+        interactionTargetElement: document.createElement('div'),
+        processedEventEntries: [{ name: 'click' }],
+        longAnimationFrameEntries: [],
+      },
+    } as unknown as MetricWithAttribution);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    const record = records[0];
+
+    expect(record.attributes).to.deep.equal({
+      'browser.web_vital.delta': 0,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'inp',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'good',
+      'browser.web_vital.value': 100,
+    });
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['interactionTarget']).to.equal('some-target');
+    expect(body['interactionTime']).to.equal(19000);
+    expect(body['loadState']).to.equal('complete');
+  });
+
+  it('should preserve falsy primitive attribution values in body', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+
+    clock.tick(5000);
+
+    metricReportFunc({
+      name: 'CLS',
+      value: 0,
+      rating: 'good',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        largestShiftValue: 0,
+        loadState: '',
+      },
+    } as unknown as MetricWithAttribution);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    const body = JSON.parse(records[0].body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(body['largestShiftValue']).to.equal(0);
+    expect(body['loadState']).to.equal('');
+  });
+
+  it('should handle null attribution gracefully', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const metricReportFunc = fcpStub.getCall(0).args[0] as WebVitalOnReport;
+
+    clock.tick(5000);
+
+    metricReportFunc({
+      name: 'FCP',
+      value: 0,
+      rating: 'good',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: null,
+    } as unknown as MetricWithAttribution);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    const record = records[0];
+
+    expect(record.attributes).to.deep.equal({
+      'browser.web_vital.delta': 0,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'fcp',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'good',
+      'browser.web_vital.value': 0,
+    });
+    expect(record.body).to.equal('null');
+  });
+
+  it('should include boolean attribution values in body', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+
+    clock.tick(5000);
+
+    metricReportFunc({
+      name: 'CLS',
+      value: 0,
+      rating: 'good',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: {
+        largestShiftValue: 0,
+        hadRecentInput: false,
+      },
+    } as unknown as MetricWithAttribution);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    const body = JSON.parse(records[0].body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(body['largestShiftValue']).to.equal(0);
+    expect(body['hadRecentInput']).to.equal(false);
+  });
+
+  it('should not register reportAllChanges listeners when urlAttribution is false', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    expect(inpStub.callCount).to.equal(1);
+    expect(lcpStub.callCount).to.equal(1);
+    expect(clsStub.callCount).to.equal(1);
+  });
+
+  describe('SPA url attribution', () => {
+    it('should attribute the correct URL for INP metrics', () => {
+      const testDocument = { URL: 'https://first.com' };
+      const pageManager = new EmbracePageManager();
+      pageManager.setCurrentRoute({ path: '/first/:id', url: '/first/123' });
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument: testDocument,
+        pageManager,
+      });
+
+      void expect(inpStub.callCount).to.equal(2);
+      const changeFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
+      const finalFunc = inpStub.getCall(1).args[0] as WebVitalOnReport;
+
+      const inpMetric = {
+        name: 'INP',
+        value: 22,
+        rating: 'poor',
+        delta: 0,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {
+          interactionTarget: 'some-target',
+          interactionTime: 19000,
+          nextPaintTime: 18000,
+          interactionType: 'pointer',
+          processedEventEntries: [],
+          longAnimationFrameEntries: [],
+          inputDelay: 1000,
+          processingDuration: 2000,
+          presentationDelay: 3000,
+          loadState: 'complete',
+        },
+      } as MetricWithAttribution;
+
+      changeFunc(inpMetric);
+      testDocument.URL = 'https://second.com';
+      pageManager.setCurrentRoute({ path: '/second/:id', url: '/second/123' });
+      const attributedPageID = pageManager.getCurrentPageId();
+      changeFunc(inpMetric);
+      testDocument.URL = 'https://third.com';
+      pageManager.setCurrentRoute({ path: '/third/:id', url: '/third/123' });
+      finalFunc(inpMetric);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes).to.deep.include({
+        [ATTR_URL_FULL]: 'https://second.com',
+        [KEY_EMB_PAGE_PATH]: '/second/:id',
+        [KEY_EMB_PAGE_ID]: attributedPageID,
+      });
+    });
+
+    it('should attribute the correct URL for LCP metrics', () => {
+      const testDocument = { URL: 'https://first.com' };
+      const pageManager = new EmbracePageManager();
+      pageManager.setCurrentRoute({ path: '/first/:id', url: '/first/123' });
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument: testDocument,
+        pageManager,
+      });
+
+      void expect(lcpStub.callCount).to.equal(2);
+      const changeFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
+      const finalFunc = lcpStub.getCall(1).args[0] as WebVitalOnReport;
+
+      const lcpMetric = {
+        name: 'LCP',
+        value: 22,
+        rating: 'poor',
+        delta: 0,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {
+          timeToFirstByte: 999,
+          resourceLoadDelay: 1000,
+          resourceLoadDuration: 2000,
+          elementRenderDelay: 3000,
+        },
+      } as MetricWithAttribution;
+
+      changeFunc(lcpMetric);
+      testDocument.URL = 'https://second.com';
+      pageManager.setCurrentRoute({ path: '/second/:id', url: '/second/123' });
+      const attributedPageID = pageManager.getCurrentPageId();
+      changeFunc(lcpMetric);
+      testDocument.URL = 'https://third.com';
+      pageManager.setCurrentRoute({ path: '/third/:id', url: '/third/123' });
+      finalFunc(lcpMetric);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes).to.deep.include({
+        [ATTR_URL_FULL]: 'https://second.com',
+        [KEY_EMB_PAGE_PATH]: '/second/:id',
+        [KEY_EMB_PAGE_ID]: attributedPageID,
+      });
+    });
+
+    it('should attribute the correct URL for CLS metrics based on largestShiftTarget changes', () => {
+      const testDocument = { URL: 'https://first.com' };
+      const pageManager = new EmbracePageManager();
+      pageManager.setCurrentRoute({ path: '/first/:id', url: '/first/123' });
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument: testDocument,
+        pageManager,
+      });
+
+      void expect(clsStub.callCount).to.equal(2);
+      const changeFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+      const finalFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
+
+      const clsMetric = {
+        name: 'CLS',
+        value: 22,
+        rating: 'poor',
+        delta: 0,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: { largestShiftTarget: 'some-target-1' },
+      } as CLSMetricWithAttribution;
+
+      changeFunc(clsMetric);
+      clsMetric.attribution.largestShiftTarget = 'some-target-2';
+      testDocument.URL = 'https://second.com';
+      pageManager.setCurrentRoute({ path: '/second/:id', url: '/second/123' });
+      const attributedPageID = pageManager.getCurrentPageId();
+      changeFunc(clsMetric);
+      testDocument.URL = 'https://third.com';
+      pageManager.setCurrentRoute({ path: '/third/:id', url: '/third/123' });
+      changeFunc(clsMetric);
+      finalFunc(clsMetric);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes).to.deep.include({
+        [ATTR_URL_FULL]: 'https://second.com',
+        [KEY_EMB_PAGE_PATH]: '/second/:id',
+        [KEY_EMB_PAGE_ID]: attributedPageID,
+      });
+    });
+
+    it('should attribute the correct URL for FCP metrics', () => {
+      const testDocument = { URL: 'https://first.com' };
+      const pageManager = new EmbracePageManager();
+      pageManager.setCurrentRoute({ path: '/first/:id', url: '/first/123' });
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument: testDocument,
+        pageManager,
+      });
+
+      void expect(fcpStub.callCount).to.equal(2);
+      const changeFunc = fcpStub.getCall(0).args[0] as WebVitalOnReport;
+      const finalFunc = fcpStub.getCall(1).args[0] as WebVitalOnReport;
+
+      const fcpMetric = {
+        name: 'FCP',
+        value: 22,
+        rating: 'poor',
+        delta: 0,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {
+          timeToFirstByte: 0,
+          firstByteToFCP: 0,
+          loadState: 'complete',
+        },
+      } as FCPMetricWithAttribution;
+
+      changeFunc(fcpMetric);
+      testDocument.URL = 'https://second.com';
+      pageManager.setCurrentRoute({ path: '/second/:id', url: '/second/123' });
+      const attributedPageID = pageManager.getCurrentPageId();
+      changeFunc(fcpMetric);
+      testDocument.URL = 'https://third.com';
+      pageManager.setCurrentRoute({ path: '/third/:id', url: '/third/123' });
+      finalFunc(fcpMetric);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes).to.deep.include({
+        [ATTR_URL_FULL]: 'https://second.com',
+        [KEY_EMB_PAGE_PATH]: '/second/:id',
+        [KEY_EMB_PAGE_ID]: attributedPageID,
+      });
+    });
+
+    it('should attribute the correct URL for TTFB metrics', () => {
+      const testDocument = { URL: 'https://first.com' };
+      const pageManager = new EmbracePageManager();
+      pageManager.setCurrentRoute({ path: '/first/:id', url: '/first/123' });
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument: testDocument,
+        pageManager,
+      });
+
+      void expect(ttfbStub.callCount).to.equal(2);
+      const changeFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
+      const finalFunc = ttfbStub.getCall(1).args[0] as WebVitalOnReport;
+
+      const ttfbMetric = {
+        name: 'TTFB',
+        value: 33,
+        rating: 'poor',
+        delta: 99,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {
+          waitingDuration: 20,
+          cacheDuration: 40,
+          dnsDuration: 60,
+          connectionDuration: 80,
+          requestDuration: 100,
+          navigationEntry: {
+            redirectStart: 0,
+            redirectEnd: 0,
+            domainLookupStart: 10,
+            domainLookupEnd: 20,
+            connectStart: 20,
+            connectEnd: 30,
+            secureConnectionStart: 0,
+            requestStart: 30,
+            responseStart: 50,
+            responseEnd: 60,
+            startTime: 0,
+          } as PerformanceNavigationTiming,
+        },
+      } as MetricWithAttribution;
+
+      changeFunc(ttfbMetric);
+      testDocument.URL = 'https://second.com';
+      pageManager.setCurrentRoute({ path: '/second/:id', url: '/second/123' });
+      const attributedPageID = pageManager.getCurrentPageId();
+      changeFunc(ttfbMetric);
+      testDocument.URL = 'https://third.com';
+      pageManager.setCurrentRoute({ path: '/third/:id', url: '/third/123' });
+      finalFunc(ttfbMetric);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes).to.deep.include({
+        [ATTR_URL_FULL]: 'https://second.com',
+        [KEY_EMB_PAGE_PATH]: '/second/:id',
+        [KEY_EMB_PAGE_ID]: attributedPageID,
+      });
+    });
+  });
+
+  describe('page manager', () => {
+    it('should attach page attributes when route is set', () => {
+      const pageManager = new EmbracePageManager();
+      pageManager.setCurrentRoute({ path: '/test/:id', url: '/test/123' });
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument,
+        pageManager,
+      });
+
+      void expect(clsStub.calledTwice).to.be.true;
+      const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+      const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
+
+      clock.tick(5000);
+
+      const metric = {
+        name: 'CLS',
+        value: 22,
+        rating: 'good',
+        delta: 0,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {},
+      } as MetricWithAttribution;
+
+      pageTrackFunc(metric);
+      emitFunc(metric);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes).to.deep.include({
+        [KEY_EMB_PAGE_PATH]: '/test/:id',
+        [KEY_EMB_PAGE_ID]: pageManager.getCurrentPageId(),
+      });
+    });
+
+    it('should attach page label when label is set', () => {
+      const pageManager = new EmbracePageManager({
+        useDocumentTitleAsPageLabel: false,
+      });
+      pageManager.setPageLabel('MyLabel');
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument,
+        pageManager,
+      });
+
+      const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+      const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
+
+      clock.tick(5000);
+
+      const metric = {
+        name: 'CLS',
+        value: 22,
+        rating: 'good',
+        delta: 0,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {},
+      } as MetricWithAttribution;
+
+      pageTrackFunc(metric);
+      emitFunc(metric);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records[0].attributes).to.deep.include({
+        [KEY_APP_SURFACE_LABEL]: 'MyLabel',
+      });
+    });
+
+    it('should not attach page label when label is not set', () => {
+      const pageManager = new EmbracePageManager({
+        useDocumentTitleAsPageLabel: false,
+      });
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument,
+        pageManager,
+      });
+
+      const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+      const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
+
+      clock.tick(5000);
+
+      const metric = {
+        name: 'CLS',
+        value: 22,
+        rating: 'good',
+        delta: 0,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {},
+      } as MetricWithAttribution;
+
+      pageTrackFunc(metric);
+      emitFunc(metric);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      void expect(records[0].attributes[KEY_APP_SURFACE_LABEL]).to.be.undefined;
+    });
+
+    it('should not attach page attributes when route is not set', () => {
+      const pageManager = new EmbracePageManager();
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument,
+        pageManager,
+      });
+
+      const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+      const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
+
+      clock.tick(5000);
+
+      const metric = {
+        name: 'CLS',
+        value: 22,
+        rating: 'good',
+        delta: 0,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {},
+      } as MetricWithAttribution;
+
+      pageTrackFunc(metric);
+      emitFunc(metric);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      void expect(records[0].attributes[KEY_EMB_PAGE_PATH]).to.be.undefined;
+      void expect(records[0].attributes[KEY_EMB_PAGE_ID]).to.be.undefined;
+    });
   });
 
   describe('page attribution', () => {

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -15,10 +15,12 @@ import {
   setupTestWebVitalListeners,
 } from '../../../../tests/utils/index.ts';
 import {
+  EMB_TYPES,
   KEY_APP_SURFACE_LABEL,
   KEY_BROWSER_URL_FULL,
   KEY_EMB_PAGE_ID,
   KEY_EMB_PAGE_PATH,
+  KEY_EMB_TYPE,
 } from '../../../constants/index.ts';
 import { EmbracePageManager } from '../../../managers/index.ts';
 import type { WebVitalListeners, WebVitalOnReport } from './types.ts';
@@ -96,6 +98,7 @@ describe('WebVitalsInstrumentation', () => {
 
     expect(record.eventName).to.equal('browser.web_vital');
     expect(record.attributes).to.deep.equal({
+      [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
       'browser.web_vital.delta': 0,
       'browser.web_vital.id': 'm1',
       'browser.web_vital.name': 'cls',
@@ -138,6 +141,7 @@ describe('WebVitalsInstrumentation', () => {
     const record = records[0];
 
     expect(record.attributes).to.deep.equal({
+      [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
       'browser.web_vital.delta': 0,
       'browser.web_vital.id': 'm1',
       'browser.web_vital.name': 'cls',
@@ -188,6 +192,7 @@ describe('WebVitalsInstrumentation', () => {
 
     expect(record.eventName).to.equal('browser.web_vital');
     expect(record.attributes).to.deep.equal({
+      [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
       'browser.web_vital.delta': 99,
       'browser.web_vital.id': 'm1',
       'browser.web_vital.name': 'fcp',
@@ -237,6 +242,7 @@ describe('WebVitalsInstrumentation', () => {
 
     expect(record.eventName).to.equal('browser.web_vital');
     expect(record.attributes).to.deep.equal({
+      [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
       'browser.web_vital.delta': 0,
       'browser.web_vital.id': 'm1',
       'browser.web_vital.name': 'lcp',
@@ -293,6 +299,7 @@ describe('WebVitalsInstrumentation', () => {
 
     expect(record.eventName).to.equal('browser.web_vital');
     expect(record.attributes).to.deep.equal({
+      [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
       'browser.web_vital.delta': 0,
       'browser.web_vital.id': 'm1',
       'browser.web_vital.name': 'inp',
@@ -514,6 +521,7 @@ describe('WebVitalsInstrumentation', () => {
 
     expect(record.eventName).to.equal('browser.web_vital');
     expect(record.attributes).to.deep.equal({
+      [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
       'browser.web_vital.delta': 99,
       'browser.web_vital.id': 'm1',
       'browser.web_vital.name': 'ttfb',
@@ -1775,6 +1783,7 @@ describe('WebVitalsInstrumentation', () => {
     const record = records[0];
 
     expect(record.attributes).to.deep.equal({
+      [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
       'browser.web_vital.delta': 0,
       'browser.web_vital.id': 'm1',
       'browser.web_vital.name': 'inp',
@@ -1850,6 +1859,7 @@ describe('WebVitalsInstrumentation', () => {
     const record = records[0];
 
     expect(record.attributes).to.deep.equal({
+      [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
       'browser.web_vital.delta': 0,
       'browser.web_vital.id': 'm1',
       'browser.web_vital.name': 'fcp',

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -1895,6 +1895,32 @@ describe('WebVitalsInstrumentation', () => {
     expect(body['hadRecentInput']).to.equal(false);
   });
 
+  it('should omit body when includeRawAttribution is false', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+      includeRawAttribution: false,
+    });
+
+    const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+
+    metricReportFunc({
+      name: 'CLS',
+      value: 22,
+      rating: 'good',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: { largestShiftValue: 1.5 },
+    } as MetricWithAttribution);
+
+    const record = memoryExporter.getFinishedLogRecords()[0];
+    expect(record.body).to.be.undefined;
+  });
+
   it('should not register reportAllChanges listeners when urlAttribution is false', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -1,48 +1,34 @@
-import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
+import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
+import { ATTR_URL_FULL } from '@opentelemetry/semantic-conventions';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import type {
-  CLSMetricWithAttribution,
-  FCPMetricWithAttribution,
   INPMetricWithAttribution,
   MetricWithAttribution,
 } from 'web-vitals/attribution';
 import {
   InMemoryDiagLogger,
   MockPerformanceManager,
-  setupTestStorage,
-  setupTestTraceExporter,
+  setupTestLogExporter,
   setupTestWebVitalListeners,
 } from '../../../../tests/utils/index.ts';
-import { session } from '../../../api-sessions/index.ts';
-import type { URLDocument } from '../../../common/index.ts';
 import {
   KEY_APP_SURFACE_LABEL,
+  KEY_BROWSER_URL_FULL,
   KEY_EMB_PAGE_ID,
   KEY_EMB_PAGE_PATH,
 } from '../../../constants/index.ts';
-import type { UserSessionManagerInternal } from '../../../managers/index.ts';
-import {
-  DEFAULT_LIMITS,
-  EmbraceLimitManager,
-  EmbracePageManager,
-  EmbraceUserSessionManager,
-} from '../../../managers/index.ts';
 import type { WebVitalListeners, WebVitalOnReport } from './types.ts';
 import { WebVitalsInstrumentation } from './WebVitalsInstrumentation.ts';
 
 chai.use(sinonChai);
 const { expect } = chai;
-const urlDocument: URLDocument = {
-  URL: 'https://example.com',
-};
 
 describe('WebVitalsInstrumentation', () => {
-  let memoryExporter: InMemorySpanExporter;
+  let memoryExporter: InMemoryLogRecordExporter;
   let instrumentation: WebVitalsInstrumentation;
   let diag: InMemoryDiagLogger;
-  let userSessionManager: UserSessionManagerInternal;
   let perf: MockPerformanceManager;
   let clock: sinon.SinonFakeTimers;
   let mockWebVitalListeners: WebVitalListeners;
@@ -53,7 +39,7 @@ describe('WebVitalsInstrumentation', () => {
   let ttfbStub: sinon.SinonStub;
 
   before(() => {
-    memoryExporter = setupTestTraceExporter();
+    memoryExporter = setupTestLogExporter();
   });
 
   beforeEach(() => {
@@ -61,14 +47,6 @@ describe('WebVitalsInstrumentation', () => {
     clock = sinon.useFakeTimers();
     perf = new MockPerformanceManager(clock);
     diag = new InMemoryDiagLogger();
-    userSessionManager = new EmbraceUserSessionManager({
-      limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
-      perf,
-      storage: setupTestStorage(),
-      visibilityDoc: window.document,
-    });
-    session.setGlobalUserSessionManager(userSessionManager);
-    userSessionManager.startSessionPartInternal('init');
     const testWebVitalListeners = setupTestWebVitalListeners();
 
     mockWebVitalListeners = testWebVitalListeners.listeners;
@@ -84,17 +62,16 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation.disable();
   });
 
-  it('should report CLS metrics', () => {
+  it('should report CLS metrics as a log record', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    void expect(clsStub.calledTwice).to.be.true;
-    const { args } = clsStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    void expect(clsStub.calledOnce).to.be.true;
+    const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
     clock.tick(5000);
 
@@ -109,41 +86,32 @@ describe('WebVitalsInstrumentation', () => {
       attribution: {},
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-    const clsEvent = sessionSpan.events[0];
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
 
-    expect(clsEvent.name).to.be.equal('emb-web-vitals-report-CLS');
-
-    expect(clsEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 0,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'CLS',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 22,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
+    expect(record.eventName).to.equal('browser.web_vital');
+    expect(record.attributes).to.deep.equal({
+      'browser.web_vital.delta': 0,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'cls',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'good',
+      'browser.web_vital.value': 22,
     });
-
-    expect(clsEvent.time).to.deep.equal([5, 0]);
+    expect(record.hrTime).to.deep.equal([5, 0]);
+    expect(record.body).to.equal('{}');
   });
 
-  it('should report CLS metrics with largest shift time and loadState', () => {
+  it('should use largestShiftTime as timestamp for CLS', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    void expect(clsStub.calledTwice).to.be.true;
-    const { args } = clsStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
     metricReportFunc({
       name: 'CLS',
@@ -161,46 +129,36 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-    const clsEvent = sessionSpan.events[0];
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
 
-    expect(clsEvent.name).to.be.equal('emb-web-vitals-report-CLS');
-
-    expect(clsEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 0,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'CLS',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 22,
-      'emb.web_vital.attribution.largestShiftTarget': 'some-target',
-      'emb.web_vital.attribution.largestShiftTime': 3000,
-      'emb.web_vital.attribution.largestShiftValue': 3.0,
-      'emb.web_vital.attribution.loadState': 'complete',
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
+    expect(record.attributes).to.deep.equal({
+      'browser.web_vital.delta': 0,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'cls',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'good',
+      'browser.web_vital.value': 22,
     });
-
-    // Since we have a largestShiftTime attribution time should be based on that
-    expect(clsEvent.time).to.deep.equal([3, 0]);
+    // largestShiftTime drives the timestamp
+    expect(record.hrTime).to.deep.equal([3, 0]);
+    // Attribution data is in the body
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['largestShiftTime']).to.equal(3000);
+    expect(body['largestShiftValue']).to.equal(3.0);
+    expect(body['largestShiftTarget']).to.equal('some-target');
   });
 
-  it('should report FCP metrics', () => {
+  it('should report FCP metrics as a log record', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    void expect(fcpStub.calledTwice).to.be.true;
-    const { args } = fcpStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = fcpStub.getCall(0).args[0] as WebVitalOnReport;
 
     clock.tick(5000);
 
@@ -219,44 +177,35 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-    const fcpEvent = sessionSpan.events[0];
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
 
-    expect(fcpEvent.name).to.be.equal('emb-web-vitals-report-FCP');
-
-    expect(fcpEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 99,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'FCP',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'needs-improvement',
-      'emb.web_vital.value': 33,
-      'emb.web_vital.attribution.timeToFirstByte': 20,
-      'emb.web_vital.attribution.firstByteToFCP': 40,
-      'emb.web_vital.attribution.loadState': 'complete',
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
+    expect(record.eventName).to.equal('browser.web_vital');
+    expect(record.attributes).to.deep.equal({
+      'browser.web_vital.delta': 99,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'fcp',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'needs-improvement',
+      'browser.web_vital.value': 33,
     });
-
-    expect(fcpEvent.time).to.deep.equal([5, 0]);
+    expect(record.hrTime).to.deep.equal([5, 0]);
+    // Attribution primitives are in the body
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['timeToFirstByte']).to.equal(20);
+    expect(body['firstByteToFCP']).to.equal(40);
   });
 
-  it('should report LCP metrics', () => {
+  it('should report LCP metrics as a log record', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    void expect(lcpStub.calledTwice).to.be.true;
-    const { args } = lcpStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
 
     clock.tick(5000);
 
@@ -276,45 +225,31 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-    const lcpEvent = sessionSpan.events[0];
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
 
-    expect(lcpEvent.name).to.be.equal('emb-web-vitals-report-LCP');
-
-    expect(lcpEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 0,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'LCP',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'poor',
-      'emb.web_vital.value': 22,
-      'emb.web_vital.attribution.timeToFirstByte': 999,
-      'emb.web_vital.attribution.resourceLoadDelay': 1000,
-      'emb.web_vital.attribution.resourceLoadDuration': 2000,
-      'emb.web_vital.attribution.elementRenderDelay': 3000,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
+    expect(record.eventName).to.equal('browser.web_vital');
+    expect(record.attributes).to.deep.equal({
+      'browser.web_vital.delta': 0,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'lcp',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'poor',
+      'browser.web_vital.value': 22,
     });
-
-    expect(lcpEvent.time).to.deep.equal([5, 0]);
+    expect(record.hrTime).to.deep.equal([5, 0]);
   });
 
-  it('should report INP metrics', () => {
+  it('should report INP metrics as a log record', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    void expect(inpStub.calledTwice).to.be.true;
-    const { args } = inpStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
     clock.tick(5000);
 
@@ -341,37 +276,21 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-    const inpEvent = sessionSpan.events[0];
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
 
-    expect(inpEvent.name).to.be.equal('emb-web-vitals-report-INP');
-
-    expect(inpEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 0,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'INP',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'poor',
-      'emb.web_vital.value': 22,
-      'emb.web_vital.attribution.inputDelay': 1000,
-      'emb.web_vital.attribution.interactionTarget': 'some-target',
-      'emb.web_vital.attribution.interactionTime': 19000,
-      'emb.web_vital.attribution.interactionType': 'pointer',
-      'emb.web_vital.attribution.loadState': 'complete',
-      'emb.web_vital.attribution.nextPaintTime': 18000,
-      'emb.web_vital.attribution.presentationDelay': 3000,
-      'emb.web_vital.attribution.processingDuration': 2000,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
+    expect(record.eventName).to.equal('browser.web_vital');
+    expect(record.attributes).to.deep.equal({
+      'browser.web_vital.delta': 0,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'inp',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'poor',
+      'browser.web_vital.value': 22,
     });
-
     // Time should be based on interactionTime from attribution
-    expect(inpEvent.time).to.deep.equal([19, 0]);
+    expect(record.hrTime).to.deep.equal([19, 0]);
   });
 
   describe('loaf_scripts attribution', () => {
@@ -417,17 +336,15 @@ describe('WebVitalsInstrumentation', () => {
       } as INPMetricWithAttribution);
     };
 
-    it('should include loaf_scripts in INP event', () => {
+    it('should include loaf_scripts in INP log record', () => {
       instrumentation = new WebVitalsInstrumentation({
         diag,
         perf,
-        urlDocument,
         listeners: mockWebVitalListeners,
+        urlAttribution: false,
       });
 
-      void expect(inpStub.calledTwice).to.be.true;
-      const { args } = inpStub.callsArg(0);
-      const metricReportFunc = args[0][0] as WebVitalOnReport;
+      const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
       fireINP(metricReportFunc, [
         {
@@ -446,11 +363,10 @@ describe('WebVitalsInstrumentation', () => {
         } as PerformanceLongAnimationFrameTiming,
       ]);
 
-      userSessionManager.endSessionPartInternal('inactivity');
-      const sessionSpan = memoryExporter.getFinishedSpans()[0];
-      expect(sessionSpan.events).to.have.lengthOf(1);
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
       const loafScripts = JSON.parse(
-        sessionSpan.events[0].attributes?.[
+        records[0].attributes[
           'emb.web_vital.attribution.loaf_scripts'
         ] as string,
       ) as Record<string, unknown>;
@@ -471,12 +387,11 @@ describe('WebVitalsInstrumentation', () => {
       instrumentation = new WebVitalsInstrumentation({
         diag,
         perf,
-        urlDocument,
         listeners: mockWebVitalListeners,
+        urlAttribution: false,
       });
 
-      const { args } = inpStub.callsArg(0);
-      const metricReportFunc = args[0][0] as WebVitalOnReport;
+      const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
       fireINP(metricReportFunc, [
         {
@@ -499,10 +414,9 @@ describe('WebVitalsInstrumentation', () => {
         } as PerformanceLongAnimationFrameTiming,
       ]);
 
-      userSessionManager.endSessionPartInternal('inactivity');
-      const sessionSpan = memoryExporter.getFinishedSpans()[0];
+      const records = memoryExporter.getFinishedLogRecords();
       const loafScripts = JSON.parse(
-        sessionSpan.events[0].attributes?.[
+        records[0].attributes[
           'emb.web_vital.attribution.loaf_scripts'
         ] as string,
       ) as Record<string, unknown>;
@@ -518,36 +432,29 @@ describe('WebVitalsInstrumentation', () => {
       instrumentation = new WebVitalsInstrumentation({
         diag,
         perf,
-        urlDocument,
         listeners: mockWebVitalListeners,
+        urlAttribution: false,
       });
 
-      const { args } = inpStub.callsArg(0);
-      const metricReportFunc = args[0][0] as WebVitalOnReport;
+      const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
       fireINP(metricReportFunc, []);
 
-      userSessionManager.endSessionPartInternal('inactivity');
-      const sessionSpan = memoryExporter.getFinishedSpans()[0];
-      expect(
-        sessionSpan.events[0].attributes?.[
-          'emb.web_vital.attribution.loaf_scripts'
-        ],
-      ).to.be.undefined;
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records[0].attributes['emb.web_vital.attribution.loaf_scripts']).to
+        .be.undefined;
     });
   });
 
-  it('should report TTFB metrics', () => {
+  it('should report TTFB metrics with sub-part attributes', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    void expect(ttfbStub.calledTwice).to.be.true;
-    const { args } = ttfbStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
     clock.tick(5000);
 
@@ -581,30 +488,18 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-    const ttfbEvent = sessionSpan.events[0];
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const record = records[0];
 
-    expect(ttfbEvent.name).to.be.equal('emb-web-vitals-report-TTFB');
-
-    expect(ttfbEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 99,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'TTFB',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'poor',
-      'emb.web_vital.value': 33,
-      'emb.web_vital.attribution.waitingDuration': 20,
-      'emb.web_vital.attribution.cacheDuration': 40,
-      'emb.web_vital.attribution.dnsDuration': 60,
-      'emb.web_vital.attribution.connectionDuration': 80,
-      'emb.web_vital.attribution.requestDuration': 100,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
+    expect(record.eventName).to.equal('browser.web_vital');
+    expect(record.attributes).to.deep.equal({
+      'browser.web_vital.delta': 99,
+      'browser.web_vital.id': 'm1',
+      'browser.web_vital.name': 'ttfb',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'poor',
+      'browser.web_vital.value': 33,
       'emb.web_vital.attribution.redirect': 0,
       'emb.web_vital.attribution.domainLookup': 10,
       'emb.web_vital.attribution.tcpConnection': 10,
@@ -612,20 +507,18 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.serverResponse': 20,
       'emb.web_vital.attribution.unattributed': 20,
     });
-
-    expect(ttfbEvent.time).to.deep.equal([5, 0]);
+    expect(record.hrTime).to.deep.equal([5, 0]);
   });
 
   it('should omit TTFB sub-parts when navigationEntry is absent', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = ttfbStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
     metricReportFunc({
       name: 'TTFB',
@@ -644,25 +537,16 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const sessionSpan = memoryExporter.getFinishedSpans()[0];
-    const ttfbEvent = sessionSpan.events[0];
+    const records = memoryExporter.getFinishedLogRecords();
+    const record = records[0];
 
-    expect(ttfbEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 33,
-      'emb.web_vital.id': 'm2',
-      'emb.web_vital.name': 'TTFB',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 33,
-      'emb.web_vital.attribution.waitingDuration': 20,
-      'emb.web_vital.attribution.cacheDuration': 0,
-      'emb.web_vital.attribution.dnsDuration': 0,
-      'emb.web_vital.attribution.connectionDuration': 0,
-      'emb.web_vital.attribution.requestDuration': 33,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
+    expect(record.attributes).to.deep.equal({
+      'browser.web_vital.delta': 33,
+      'browser.web_vital.id': 'm2',
+      'browser.web_vital.name': 'ttfb',
+      'browser.web_vital.navigation_type': 'navigate',
+      'browser.web_vital.rating': 'good',
+      'browser.web_vital.value': 33,
     });
   });
 
@@ -670,12 +554,11 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = ttfbStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
     metricReportFunc({
       name: 'TTFB',
@@ -707,29 +590,13 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const sessionSpan = memoryExporter.getFinishedSpans()[0];
-    const ttfbEvent = sessionSpan.events[0];
+    const record = memoryExporter.getFinishedLogRecords()[0];
 
     // TLS: tcpConnection = secureConnectionStart - connectStart = 40 - 20 = 20
     //      tlsNegotiation = connectEnd - secureConnectionStart = 50 - 40 = 10
     // serverResponse = responseStart - requestStart = 70 - 50 = 20
     // other = 90 - 0 - 0 - 10 - 20 - 10 - 20 = 30
-    expect(ttfbEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 80,
-      'emb.web_vital.id': 'm3',
-      'emb.web_vital.name': 'TTFB',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 80,
-      'emb.web_vital.attribution.waitingDuration': 0,
-      'emb.web_vital.attribution.cacheDuration': 0,
-      'emb.web_vital.attribution.dnsDuration': 10,
-      'emb.web_vital.attribution.connectionDuration': 20,
-      'emb.web_vital.attribution.requestDuration': 30,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
+    expect(record.attributes).to.deep.include({
       'emb.web_vital.attribution.redirect': 0,
       'emb.web_vital.attribution.domainLookup': 10,
       'emb.web_vital.attribution.tcpConnection': 20,
@@ -743,12 +610,11 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = ttfbStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
     metricReportFunc({
       name: 'TTFB',
@@ -783,31 +649,11 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const sessionSpan = memoryExporter.getFinishedSpans()[0];
-    const ttfbEvent = sessionSpan.events[0];
+    const record = memoryExporter.getFinishedLogRecords()[0];
 
     // finalResponseHeadersStart (70) > responseStart (50), so serverResponse = 70 - 10 = 60
     // other = max(0, 80 - 0 - 0 - 0 - 0 - 0 - 60) = 20
-    expect(ttfbEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 80,
-      'emb.web_vital.id': 'm4',
-      'emb.web_vital.name': 'TTFB',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 80,
-      'emb.web_vital.attribution.waitingDuration': 0,
-      'emb.web_vital.attribution.cacheDuration': 0,
-      'emb.web_vital.attribution.connectionDuration': 0,
-      'emb.web_vital.attribution.dnsDuration': 0,
-      'emb.web_vital.attribution.requestDuration': 50,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
-      'emb.web_vital.attribution.redirect': 0,
-      'emb.web_vital.attribution.domainLookup': 0,
-      'emb.web_vital.attribution.tcpConnection': 0,
-      'emb.web_vital.attribution.tlsNegotiation': 0,
+    expect(record.attributes).to.deep.include({
       'emb.web_vital.attribution.serverResponse': 60,
       'emb.web_vital.attribution.unattributed': 20,
     });
@@ -817,12 +663,11 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = ttfbStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
     metricReportFunc({
       name: 'TTFB',
@@ -857,32 +702,11 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const sessionSpan = memoryExporter.getFinishedSpans()[0];
-    const ttfbEvent = sessionSpan.events[0];
+    const record = memoryExporter.getFinishedLogRecords()[0];
 
     // finalResponseHeadersStart (30) < responseStart (50), falls back to responseStart
     // serverResponse = responseStart - requestStart = 50 - 10 = 40
-    // other = max(0, 80 - 0 - 0 - 0 - 0 - 0 - 40) = 40
-    expect(ttfbEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 80,
-      'emb.web_vital.id': 'm4',
-      'emb.web_vital.name': 'TTFB',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 80,
-      'emb.web_vital.attribution.waitingDuration': 0,
-      'emb.web_vital.attribution.cacheDuration': 0,
-      'emb.web_vital.attribution.connectionDuration': 0,
-      'emb.web_vital.attribution.dnsDuration': 0,
-      'emb.web_vital.attribution.requestDuration': 40,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
-      'emb.web_vital.attribution.redirect': 0,
-      'emb.web_vital.attribution.domainLookup': 0,
-      'emb.web_vital.attribution.tcpConnection': 0,
-      'emb.web_vital.attribution.tlsNegotiation': 0,
+    expect(record.attributes).to.deep.include({
       'emb.web_vital.attribution.serverResponse': 40,
       'emb.web_vital.attribution.unattributed': 40,
     });
@@ -892,12 +716,11 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = ttfbStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
     metricReportFunc({
       name: 'TTFB',
@@ -929,31 +752,10 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const sessionSpan = memoryExporter.getFinishedSpans()[0];
-    const ttfbEvent = sessionSpan.events[0];
+    const record = memoryExporter.getFinishedLogRecords()[0];
 
-    // redirect: 25 - 5 = 20
-    // dns: 35 - 25 = 10
-    // tcp: 45 - 35 = 10 (no TLS)
-    // tls: 0
-    // server: 75 - 45 = 30
-    // other: 100 - 0 - 20 - 10 - 10 - 0 - 30 = 30
-    expect(ttfbEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 100,
-      'emb.web_vital.id': 'm5',
-      'emb.web_vital.name': 'TTFB',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'needs-improvement',
-      'emb.web_vital.value': 100,
-      'emb.web_vital.attribution.waitingDuration': 0,
-      'emb.web_vital.attribution.cacheDuration': 0,
-      'emb.web_vital.attribution.dnsDuration': 10,
-      'emb.web_vital.attribution.connectionDuration': 10,
-      'emb.web_vital.attribution.requestDuration': 30,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
+    // redirect: 25 - 5 = 20, dns: 10, tcp: 10 (no TLS), server: 30, other: 30
+    expect(record.attributes).to.deep.include({
       'emb.web_vital.attribution.redirect': 20,
       'emb.web_vital.attribution.domainLookup': 10,
       'emb.web_vital.attribution.tcpConnection': 10,
@@ -967,12 +769,11 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = ttfbStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
     metricReportFunc({
       name: 'TTFB',
@@ -1004,16 +805,14 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const sessionSpan = memoryExporter.getFinishedSpans()[0];
-    const ttfbEvent = sessionSpan.events[0];
+    const record = memoryExporter.getFinishedLogRecords()[0];
 
     // total: round(7.3 - 5.123) = round(2.177) = 2
     // dns: round(5.6 - 5.2) = round(0.4) = 0
     // tcp: round(6.1 - 5.6) = round(0.5) = 1
     // server: round(6.8 - 6.1) = round(0.7) = 1
     // unattributed: 2 - 0 - 0 - 1 - 0 - 1 = 0
-    expect(ttfbEvent.attributes).to.deep.include({
+    expect(record.attributes).to.deep.include({
       'emb.web_vital.attribution.redirect': 0,
       'emb.web_vital.attribution.domainLookup': 0,
       'emb.web_vital.attribution.tcpConnection': 1,
@@ -1027,12 +826,11 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = ttfbStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
     metricReportFunc({
       name: 'TTFB',
@@ -1064,17 +862,9 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const sessionSpan = memoryExporter.getFinishedSpans()[0];
-    const ttfbEvent = sessionSpan.events[0];
+    const record = memoryExporter.getFinishedLogRecords()[0];
 
-    // redirect: 5 - 10 = -5 -> clamped to 0
-    // dns: 15 - 20 = -5 -> clamped to 0
-    // tcp: 25 - 30 = -5 -> clamped to 0
-    // tls: 0 (no secure connection)
-    // server: 35 - 40 = -5 -> clamped to 0
-    // other: 50 - 0 - 0 - 0 - 0 - 0 - 0 = 50
-    expect(ttfbEvent.attributes).to.deep.include({
+    expect(record.attributes).to.deep.include({
       'emb.web_vital.attribution.redirect': 0,
       'emb.web_vital.attribution.domainLookup': 0,
       'emb.web_vital.attribution.tcpConnection': 0,
@@ -1088,12 +878,11 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = ttfbStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
     metricReportFunc({
       name: 'TTFB',
@@ -1125,17 +914,9 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const sessionSpan = memoryExporter.getFinishedSpans()[0];
-    const ttfbEvent = sessionSpan.events[0];
+    const record = memoryExporter.getFinishedLogRecords()[0];
 
-    // redirect: 9.7 - 10 = -0.3 -> clamped to 0
-    // dns: 19.4 - 20 = -0.6 -> clamped to 0
-    // tcp: 29.8 - 30 = -0.2 -> clamped to 0
-    // tls: 0 (no secure connection)
-    // server: 39.3 - 40 = -0.7 -> clamped to 0
-    // unattributed: 50 - 0 - 0 - 0 - 0 - 0 = 50
-    expect(ttfbEvent.attributes).to.deep.include({
+    expect(record.attributes).to.deep.include({
       'emb.web_vital.attribution.redirect': 0,
       'emb.web_vital.attribution.domainLookup': 0,
       'emb.web_vital.attribution.tcpConnection': 0,
@@ -1149,14 +930,12 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = ttfbStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
-    // Fractional values chosen so independent rounding would overshoot the total
     metricReportFunc({
       name: 'TTFB',
       value: 10,
@@ -1187,11 +966,8 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const sessionSpan = memoryExporter.getFinishedSpans()[0];
-    const ttfbEvent = sessionSpan.events[0];
-
-    const attrs = ttfbEvent.attributes as Record<string, number>;
+    const attrs = memoryExporter.getFinishedLogRecords()[0]
+      .attributes as Record<string, number>;
     const redirect = attrs['emb.web_vital.attribution.redirect'];
     const domainLookup = attrs['emb.web_vital.attribution.domainLookup'];
     const tcpConnection = attrs['emb.web_vital.attribution.tcpConnection'];
@@ -1200,11 +976,7 @@ describe('WebVitalsInstrumentation', () => {
     const unattributed = attrs['emb.web_vital.attribution.unattributed'];
 
     // total: round(8.7 - 0.2) = round(8.5) = 9
-    // dns: round(1.6 - 1.1) = round(0.5) = 1
-    // tcp: round(2.1 - 1.6) = round(0.5) = 1
-    // tls: round(3.8 - 2.1) = round(1.7) = 2
-    // server: round(6.3 - 3.8) = round(2.5) = 3
-    // unattributed: 9 - 0 - 1 - 1 - 2 - 3 = 2
+    // dns: 1, tcp: 1, tls: 2, server: 3, unattributed: 2
     expect(redirect).to.equal(0);
     expect(domainLookup).to.equal(1);
     expect(tcpConnection).to.equal(1);
@@ -1226,12 +998,11 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = ttfbStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
     metricReportFunc({
       name: 'TTFB',
@@ -1263,29 +1034,10 @@ describe('WebVitalsInstrumentation', () => {
       },
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const sessionSpan = memoryExporter.getFinishedSpans()[0];
-    const ttfbEvent = sessionSpan.events[0];
+    const record = memoryExporter.getFinishedLogRecords()[0];
 
-    // dns: 30 - 20 = 10
-    // tcp: 40 - 30 = 10
-    // server: 60 - 40 = 20
-    // other: 80 - 10 - 0 - 10 - 10 - 0 - 20 = 30
-    expect(ttfbEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 80,
-      'emb.web_vital.id': 'm7',
-      'emb.web_vital.name': 'TTFB',
-      'emb.web_vital.navigation_type': 'back-forward',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 80,
-      'emb.web_vital.attribution.waitingDuration': 0,
-      'emb.web_vital.attribution.cacheDuration': 0,
-      'emb.web_vital.attribution.dnsDuration': 10,
-      'emb.web_vital.attribution.connectionDuration': 10,
-      'emb.web_vital.attribution.requestDuration': 20,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
+    // dns: 10, tcp: 10, server: 20, other: 80 - 10 - 0 - 10 - 10 - 0 - 20 = 30
+    expect(record.attributes).to.deep.include({
       'emb.web_vital.attribution.redirect': 0,
       'emb.web_vital.attribution.domainLookup': 10,
       'emb.web_vital.attribution.tcpConnection': 10,
@@ -1295,21 +1047,16 @@ describe('WebVitalsInstrumentation', () => {
     });
   });
 
-  it('should be able to report multiple metrics', () => {
+  it('should report multiple metrics as separate log records', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    void expect(clsStub.calledTwice).to.be.true;
-    const { args: clsArgs } = clsStub.callsArg(0);
-    const clsReportFunc = clsArgs[0][0] as WebVitalOnReport;
-
-    void expect(lcpStub.calledTwice).to.be.true;
-    const { args: lcpArgs } = lcpStub.callsArg(0);
-    const lcpReportFunc = lcpArgs[0][0] as WebVitalOnReport;
+    const clsReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+    const lcpReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
 
     clock.tick(5000);
 
@@ -1333,611 +1080,50 @@ describe('WebVitalsInstrumentation', () => {
       entries: [],
       navigationType: 'navigate',
       attribution: {
-        timeToFirstByte: 999,
-        resourceLoadDelay: 1000,
-        resourceLoadDuration: 2000,
-        elementRenderDelay: 3000,
-      },
-    } as MetricWithAttribution);
-
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(2);
-    const clsEvent = sessionSpan.events[0];
-    const lcpEvent = sessionSpan.events[1];
-
-    expect(clsEvent.name).to.be.equal('emb-web-vitals-report-CLS');
-    expect(lcpEvent.name).to.be.equal('emb-web-vitals-report-LCP');
-
-    expect(clsEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 0,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'CLS',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 22,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
-    });
-    expect(lcpEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 0,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'LCP',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'poor',
-      'emb.web_vital.value': 22,
-      'emb.web_vital.attribution.timeToFirstByte': 999,
-      'emb.web_vital.attribution.resourceLoadDelay': 1000,
-      'emb.web_vital.attribution.resourceLoadDuration': 2000,
-      'emb.web_vital.attribution.elementRenderDelay': 3000,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
-    });
-
-    expect(clsEvent.time).to.deep.equal([5, 0]);
-    expect(lcpEvent.time).to.deep.equal([5, 0]);
-  });
-
-  it('should attribute the correct URL for INP metrics', () => {
-    const testDocument: URLDocument = {
-      URL: 'https://first.com',
-    };
-    const pageManager = new EmbracePageManager();
-    pageManager.setCurrentRoute({
-      path: '/first/:id',
-      url: '/first/123',
-    });
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      urlDocument: testDocument,
-      pageManager,
-      listeners: mockWebVitalListeners,
-      urlAttribution: true,
-    });
-
-    void expect(inpStub.callCount).to.equal(2);
-    const inpFinalReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
-    const inpChangeReportFunc = inpStub.getCall(1).args[0] as WebVitalOnReport;
-
-    const inpMetric = {
-      name: 'INP',
-      value: 22,
-      rating: 'poor',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {
-        interactionTarget: 'some-target',
-        interactionTime: 19000,
-        nextPaintTime: 18000,
-        interactionType: 'pointer',
-        processedEventEntries: [],
-        longAnimationFrameEntries: [],
-        inputDelay: 1000,
-        processingDuration: 2000,
-        presentationDelay: 3000,
-        loadState: 'complete',
-      },
-    } as MetricWithAttribution;
-
-    inpChangeReportFunc(inpMetric);
-    // should be attributed to this URL since that is when the last change to the metric occurred
-    testDocument.URL = 'https://second.com';
-    pageManager.setCurrentRoute({
-      path: '/second/:id',
-      url: '/second/123',
-    });
-    const attributedPageID = pageManager.getCurrentPageId();
-    inpChangeReportFunc(inpMetric);
-    testDocument.URL = 'https://third.com';
-    pageManager.setCurrentRoute({
-      path: '/third/:id',
-      url: '/third/123',
-    });
-    inpFinalReportFunc(inpMetric);
-
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-
-    const inpEvent = sessionSpan.events[0];
-
-    expect(inpEvent.name).to.be.equal('emb-web-vitals-report-INP');
-    expect(inpEvent.attributes).to.containSubset({
-      'url.full': 'https://second.com',
-      'app.surface.name': '/second/:id',
-      'app.surface.id': attributedPageID,
-    });
-  });
-
-  it('should attribute the correct URL for LCP metrics', () => {
-    const testDocument: URLDocument = {
-      URL: 'https://first.com',
-    };
-    const pageManager = new EmbracePageManager();
-    pageManager.setCurrentRoute({
-      path: '/first/:id',
-      url: '/first/123',
-    });
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      pageManager,
-      urlDocument: testDocument,
-      listeners: mockWebVitalListeners,
-      urlAttribution: true,
-    });
-
-    void expect(lcpStub.callCount).to.equal(2);
-    const lcpFinalReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
-    const lcpChangeReportFunc = lcpStub.getCall(1).args[0] as WebVitalOnReport;
-
-    const lcpMetric = {
-      name: 'LCP',
-      value: 22,
-      rating: 'poor',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {
-        timeToFirstByte: 999,
-        resourceLoadDelay: 1000,
-        resourceLoadDuration: 2000,
-        elementRenderDelay: 3000,
-      },
-    } as MetricWithAttribution;
-
-    lcpChangeReportFunc(lcpMetric);
-    // should be attributed to this URL since that is when the last change to the metric occurred
-    testDocument.URL = 'https://second.com';
-    pageManager.setCurrentRoute({
-      path: '/second/:id',
-      url: '/second/123',
-    });
-    const attributedPageID = pageManager.getCurrentPageId();
-    lcpChangeReportFunc(lcpMetric);
-    testDocument.URL = 'https://third.com';
-    pageManager.setCurrentRoute({
-      path: '/third/:id',
-      url: '/third/123',
-    });
-    lcpFinalReportFunc(lcpMetric);
-
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-
-    const lcpEvent = sessionSpan.events[0];
-
-    expect(lcpEvent.name).to.be.equal('emb-web-vitals-report-LCP');
-    expect(lcpEvent.attributes).to.containSubset({
-      'url.full': 'https://second.com',
-      'app.surface.name': '/second/:id',
-      'app.surface.id': attributedPageID,
-    });
-  });
-
-  it('should attribute the correct URL for CLS metrics', () => {
-    const testDocument: URLDocument = {
-      URL: 'https://first.com',
-    };
-    const pageManager = new EmbracePageManager();
-    pageManager.setCurrentRoute({
-      path: '/first/:id',
-      url: '/first/123',
-    });
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      pageManager,
-      urlDocument: testDocument,
-      listeners: mockWebVitalListeners,
-      urlAttribution: true,
-    });
-
-    void expect(clsStub.callCount).to.equal(2);
-    const clsFinalReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
-    const clsChangeReportFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
-
-    const clsMetric = {
-      name: 'CLS',
-      value: 22,
-      rating: 'poor',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {
-        largestShiftTarget: 'some-target-1',
-      },
-    } as CLSMetricWithAttribution;
-
-    clsChangeReportFunc(clsMetric);
-    // should be attributed to this URL since that is when the last change to the metric occurred and largestShiftTarget
-    // was changed
-    clsMetric.attribution.largestShiftTarget = 'some-target-2';
-    testDocument.URL = 'https://second.com';
-    pageManager.setCurrentRoute({
-      path: '/second/:id',
-      url: '/second/123',
-    });
-    const attributedPageID = pageManager.getCurrentPageId();
-    clsChangeReportFunc(clsMetric);
-    // should NOT be attributed to this URL since the largestShiftTarget didn't change
-    testDocument.URL = 'https://third.com';
-    pageManager.setCurrentRoute({
-      path: '/third/:id',
-      url: '/third/123',
-    });
-    clsChangeReportFunc(clsMetric);
-    clsFinalReportFunc(clsMetric);
-
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-
-    const clsEvent = sessionSpan.events[0];
-
-    expect(clsEvent.name).to.be.equal('emb-web-vitals-report-CLS');
-    expect(clsEvent.attributes).to.containSubset({
-      'url.full': 'https://second.com',
-      'app.surface.name': '/second/:id',
-      'app.surface.id': attributedPageID,
-    });
-  });
-
-  it('should attribute the correct URL for FCP metrics', () => {
-    const testDocument: URLDocument = {
-      URL: 'https://first.com',
-    };
-    const pageManager = new EmbracePageManager();
-    pageManager.setCurrentRoute({
-      path: '/first/:id',
-      url: '/first/123',
-    });
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      pageManager,
-      urlDocument: testDocument,
-      listeners: mockWebVitalListeners,
-      urlAttribution: true,
-    });
-
-    void expect(fcpStub.callCount).to.equal(2);
-    const fcpFinalReportFunc = fcpStub.getCall(0).args[0] as WebVitalOnReport;
-    const fcpChangeReportFunc = fcpStub.getCall(1).args[0] as WebVitalOnReport;
-
-    const fcpMetric = {
-      name: 'FCP',
-      value: 22,
-      rating: 'poor',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {
         timeToFirstByte: 0,
-        firstByteToFCP: 0,
-        loadState: 'complete',
+        resourceLoadDelay: 0,
+        resourceLoadDuration: 0,
+        elementRenderDelay: 0,
       },
-    } as FCPMetricWithAttribution;
-
-    fcpChangeReportFunc(fcpMetric);
-
-    testDocument.URL = 'https://second.com';
-    pageManager.setCurrentRoute({
-      path: '/second/:id',
-      url: '/second/123',
-    });
-    const attributedPageID = pageManager.getCurrentPageId();
-    fcpChangeReportFunc(fcpMetric);
-    // should NOT be attributed to this URL since the metric hasn't changed
-    testDocument.URL = 'https://third.com';
-    pageManager.setCurrentRoute({
-      path: '/third/:id',
-      url: '/third/123',
-    });
-    fcpFinalReportFunc(fcpMetric);
-
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-
-    const fcpEvent = sessionSpan.events[0];
-
-    expect(fcpEvent.name).to.be.equal('emb-web-vitals-report-FCP');
-    expect(fcpEvent.attributes).to.containSubset({
-      'url.full': 'https://second.com',
-      'app.surface.name': '/second/:id',
-      'app.surface.id': attributedPageID,
-    });
-  });
-
-  it('should attribute the correct URL for TTFB metrics', () => {
-    const testDocument: URLDocument = {
-      URL: 'https://first.com',
-    };
-    const pageManager = new EmbracePageManager();
-    pageManager.setCurrentRoute({
-      path: '/first/:id',
-      url: '/first/123',
-    });
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      pageManager,
-      urlDocument: testDocument,
-      listeners: mockWebVitalListeners,
-      urlAttribution: true,
-    });
-
-    void expect(ttfbStub.callCount).to.equal(2);
-    const ttfbFinalReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
-    const ttfbChangeReportFunc = ttfbStub.getCall(1)
-      .args[0] as WebVitalOnReport;
-
-    const ttfbMetric = {
-      name: 'TTFB',
-      value: 33,
-      rating: 'poor',
-      delta: 99,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {
-        waitingDuration: 20,
-        cacheDuration: 40,
-        dnsDuration: 60,
-        connectionDuration: 80,
-        requestDuration: 100,
-        navigationEntry: {
-          redirectStart: 0,
-          redirectEnd: 0,
-          domainLookupStart: 10,
-          domainLookupEnd: 20,
-          connectStart: 20,
-          connectEnd: 30,
-          secureConnectionStart: 0,
-          requestStart: 30,
-          responseStart: 50,
-          responseEnd: 60,
-          startTime: 0,
-        } as PerformanceNavigationTiming,
-      },
-    } as MetricWithAttribution;
-
-    ttfbChangeReportFunc(ttfbMetric);
-    // should be attributed to this URL since that is when the last change to the metric occurred
-    testDocument.URL = 'https://second.com';
-    pageManager.setCurrentRoute({
-      path: '/second/:id',
-      url: '/second/123',
-    });
-    const attributedPageID = pageManager.getCurrentPageId();
-    ttfbChangeReportFunc(ttfbMetric);
-    testDocument.URL = 'https://third.com';
-    pageManager.setCurrentRoute({
-      path: '/third/:id',
-      url: '/third/123',
-    });
-    ttfbFinalReportFunc(ttfbMetric);
-
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-
-    const ttfbEvent = sessionSpan.events[0];
-
-    expect(ttfbEvent.name).to.be.equal('emb-web-vitals-report-TTFB');
-    expect(ttfbEvent.attributes).to.containSubset({
-      'url.full': 'https://second.com',
-      'app.surface.name': '/second/:id',
-      'app.surface.id': attributedPageID,
-    });
-  });
-
-  it('should attach page attributes when route is set', () => {
-    const pageManager = new EmbracePageManager();
-    pageManager.setCurrentRoute({
-      path: '/test/:id',
-      url: '/test/123',
-    });
-
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      urlDocument,
-      listeners: mockWebVitalListeners,
-      pageManager,
-    });
-
-    void expect(clsStub.calledTwice).to.be.true;
-    const { args } = clsStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
-
-    clock.tick(5000);
-
-    metricReportFunc({
-      name: 'CLS',
-      value: 22,
-      rating: 'good',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {},
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-    const clsEvent = sessionSpan.events[0];
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(2);
 
-    expect(clsEvent.attributes).to.containSubset({
-      [KEY_EMB_PAGE_PATH]: '/test/:id',
-      [KEY_EMB_PAGE_ID]: pageManager.getCurrentPageId(),
-    });
-  });
+    const clsRecord = records.find(
+      (r) => r.attributes['browser.web_vital.name'] === 'cls',
+    );
+    const lcpRecord = records.find(
+      (r) => r.attributes['browser.web_vital.name'] === 'lcp',
+    );
 
-  it('should attach page label when label is set', () => {
-    const pageManager = new EmbracePageManager({
-      useDocumentTitleAsPageLabel: false,
-    });
-    pageManager.setPageLabel('MyLabel');
-
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      urlDocument,
-      listeners: mockWebVitalListeners,
-      pageManager,
-    });
-
-    void expect(clsStub.calledTwice).to.be.true;
-    const { args } = clsStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
-
-    clock.tick(5000);
-
-    metricReportFunc({
-      name: 'CLS',
-      value: 22,
-      rating: 'good',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {},
-    } as MetricWithAttribution);
-
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    const sessionSpan = finishedSpans[0];
-    const clsEvent = sessionSpan.events[0];
-
-    expect(clsEvent.attributes).to.containSubset({
-      [KEY_APP_SURFACE_LABEL]: 'MyLabel',
-    });
-  });
-
-  it('should not attach page label when label is not set', () => {
-    const pageManager = new EmbracePageManager({
-      useDocumentTitleAsPageLabel: false,
-    });
-
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      urlDocument,
-      listeners: mockWebVitalListeners,
-      pageManager,
-    });
-
-    void expect(clsStub.calledTwice).to.be.true;
-    const { args } = clsStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
-
-    clock.tick(5000);
-
-    metricReportFunc({
-      name: 'CLS',
-      value: 22,
-      rating: 'good',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {},
-    } as MetricWithAttribution);
-
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    const sessionSpan = finishedSpans[0];
-    const clsEvent = sessionSpan.events[0];
-
-    void expect(clsEvent.attributes?.[KEY_APP_SURFACE_LABEL]).to.be.undefined;
-  });
-
-  it('should not attach page attributes when route is not set', () => {
-    const pageManager = new EmbracePageManager();
-
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      urlDocument,
-      listeners: mockWebVitalListeners,
-      pageManager,
-    });
-
-    void expect(clsStub.calledTwice).to.be.true;
-    const { args } = clsStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
-
-    clock.tick(5000);
-
-    metricReportFunc({
-      name: 'CLS',
-      value: 22,
-      rating: 'good',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {},
-    } as MetricWithAttribution);
-
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-    const clsEvent = sessionSpan.events[0];
-
-    void expect(clsEvent.attributes?.[KEY_EMB_PAGE_PATH]).to.be.undefined;
-    void expect(clsEvent.attributes?.[KEY_EMB_PAGE_ID]).to.be.undefined;
+    expect(clsRecord?.eventName).to.equal('browser.web_vital');
+    expect(lcpRecord?.eventName).to.equal('browser.web_vital');
+    expect(clsRecord?.hrTime).to.deep.equal([5, 0]);
+    expect(lcpRecord?.hrTime).to.deep.equal([5, 0]);
   });
 
   it('should not register duplicate callbacks when enable() is called multiple times', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
     // Call enable() multiple times
     instrumentation.enable();
     instrumentation.enable();
 
-    expect(clsStub.callCount).to.equal(2);
+    expect(clsStub.callCount).to.equal(1);
   });
 
   it('should log debug message when enable() is called on already registered listeners', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
     instrumentation.enable();
@@ -1951,14 +1137,12 @@ describe('WebVitalsInstrumentation', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = clsStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
-    // First metric should be recorded
     metricReportFunc({
       name: 'CLS',
       value: 22,
@@ -1970,7 +1154,6 @@ describe('WebVitalsInstrumentation', () => {
       attribution: {},
     } as MetricWithAttribution);
 
-    // Disable and try to record another metric
     instrumentation.disable();
 
     metricReportFunc({
@@ -1984,27 +1167,20 @@ describe('WebVitalsInstrumentation', () => {
       attribution: {},
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    const sessionSpan = finishedSpans[0];
-
-    // Only the first metric should be recorded
-    expect(sessionSpan.events).to.have.lengthOf(1);
-    expect(sessionSpan.events[0].attributes?.['emb.web_vital.id']).to.equal(
-      'm1',
-    );
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    expect(records[0].attributes['browser.web_vital.id']).to.equal('m1');
   });
 
   it('should resume emission when enable() is called after disable()', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
-    const { args } = clsStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
     instrumentation.disable();
     instrumentation.enable();
@@ -2020,19 +1196,15 @@ describe('WebVitalsInstrumentation', () => {
       attribution: {},
     } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    const sessionSpan = finishedSpans[0];
-
-    expect(sessionSpan.events).to.have.lengthOf(1);
+    expect(memoryExporter.getFinishedLogRecords()).to.have.lengthOf(1);
   });
 
   it('should log debug message when disable() is called', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
       perf,
-      urlDocument,
       listeners: mockWebVitalListeners,
+      urlAttribution: false,
     });
 
     instrumentation.disable();
@@ -2042,205 +1214,187 @@ describe('WebVitalsInstrumentation', () => {
     );
   });
 
-  it('should filter out non-primitive attribution values', () => {
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      urlDocument,
-      listeners: mockWebVitalListeners,
+  describe('page attribution', () => {
+    it('should include page URL in log record when urlAttribution is true', () => {
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument: { URL: 'https://example.com/page-a' },
+      });
+
+      // reportAllChanges listener registered first, emission listener second
+      void expect(clsStub.calledTwice).to.be.true;
+      const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+      const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
+
+      const metric = {
+        name: 'CLS',
+        value: 0.1,
+        rating: 'good',
+        delta: 0.1,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {},
+      } as MetricWithAttribution;
+
+      pageTrackFunc(metric);
+      emitFunc(metric);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes[ATTR_URL_FULL]).to.equal(
+        'https://example.com/page-a',
+      );
+      expect(records[0].attributes[KEY_BROWSER_URL_FULL]).to.equal(
+        'https://example.com/page-a',
+      );
     });
 
-    const { args } = inpStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    it('should capture page URL at measurement time, not emission time', () => {
+      const urlDocument = { URL: 'https://example.com/page-a' };
 
-    clock.tick(5000);
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument,
+      });
 
-    metricReportFunc({
-      name: 'INP',
-      value: 100,
-      rating: 'good',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {
-        interactionTarget: 'some-target',
-        interactionTime: 19000,
-        loadState: 'complete',
-        interactionTargetElement: document.createElement('div'),
-        processedEventEntries: [{ name: 'click' }],
-        longAnimationFrameEntries: [],
-      },
-    } as unknown as MetricWithAttribution);
+      const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+      const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    const sessionSpan = finishedSpans[0];
-    const inpEvent = sessionSpan.events[0];
+      const metric = {
+        name: 'CLS',
+        value: 0.1,
+        rating: 'good',
+        delta: 0.1,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {},
+      } as MetricWithAttribution;
 
-    expect(inpEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 0,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'INP',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 100,
-      'emb.web_vital.attribution.interactionTarget': 'some-target',
-      'emb.web_vital.attribution.interactionTime': 19000,
-      'emb.web_vital.attribution.loadState': 'complete',
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
-    });
-  });
+      // Track page while on page-a
+      pageTrackFunc(metric);
 
-  it('should preserve falsy primitive attribution values', () => {
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      urlDocument,
-      listeners: mockWebVitalListeners,
+      // Simulate SPA navigation before emission
+      urlDocument.URL = 'https://example.com/page-b';
+
+      // Emit — should still use page-a (captured at measurement time)
+      emitFunc(metric);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes[ATTR_URL_FULL]).to.equal(
+        'https://example.com/page-a',
+      );
     });
 
-    const { args } = clsStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    it('should include page route path and label from pageManager', () => {
+      const mockPageManager = {
+        setCurrentRoute: sinon.stub(),
+        getCurrentRoute: sinon
+          .stub()
+          .returns({ path: '/products/:id', url: '/products/123' }),
+        getCurrentPageId: sinon.stub().returns('page-id-123'),
+        setPageLabel: sinon.stub(),
+        getPageLabel: sinon.stub().returns('Product Page'),
+        clearCurrentRoute: sinon.stub(),
+      };
 
-    clock.tick(5000);
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument: { URL: 'https://example.com/products/123' },
+        pageManager: mockPageManager,
+      });
 
-    metricReportFunc({
-      name: 'CLS',
-      value: 0,
-      rating: 'good',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {
-        largestShiftValue: 0,
-        loadState: '',
-      },
-    } as unknown as MetricWithAttribution);
+      const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+      const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    const sessionSpan = finishedSpans[0];
-    const clsEvent = sessionSpan.events[0];
+      const metric = {
+        name: 'CLS',
+        value: 0.1,
+        rating: 'good',
+        delta: 0.1,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {},
+      } as MetricWithAttribution;
 
-    expect(clsEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 0,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'CLS',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 0,
-      'emb.web_vital.attribution.largestShiftValue': 0,
-      'emb.web_vital.attribution.loadState': '',
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
-    });
-  });
+      pageTrackFunc(metric);
+      emitFunc(metric);
 
-  it('should handle null attribution gracefully', () => {
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      urlDocument,
-      listeners: mockWebVitalListeners,
-    });
-
-    const { args } = fcpStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
-
-    clock.tick(5000);
-
-    metricReportFunc({
-      name: 'FCP',
-      value: 0,
-      rating: 'good',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: null,
-    } as unknown as MetricWithAttribution);
-
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    const sessionSpan = finishedSpans[0];
-    const fcpEvent = sessionSpan.events[0];
-
-    expect(fcpEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 0,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'FCP',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 0,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
-    });
-  });
-
-  it('should include boolean attribution values', () => {
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      urlDocument,
-      listeners: mockWebVitalListeners,
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes[KEY_EMB_PAGE_PATH]).to.equal(
+        '/products/:id',
+      );
+      expect(records[0].attributes[KEY_EMB_PAGE_ID]).to.equal('page-id-123');
+      expect(records[0].attributes[KEY_APP_SURFACE_LABEL]).to.equal(
+        'Product Page',
+      );
     });
 
-    const { args } = clsStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    it('should not include page attributes when urlAttribution is false', () => {
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlAttribution: false,
+        urlDocument: { URL: 'https://example.com/page-a' },
+      });
 
-    clock.tick(5000);
+      void expect(clsStub.calledOnce).to.be.true;
+      const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
-    metricReportFunc({
-      name: 'CLS',
-      value: 0,
-      rating: 'good',
-      delta: 0,
-      id: 'm1',
-      entries: [],
-      navigationType: 'navigate',
-      attribution: {
-        largestShiftValue: 0,
-        hadRecentInput: false,
-      },
-    } as unknown as MetricWithAttribution);
+      emitFunc({
+        name: 'CLS',
+        value: 0.1,
+        rating: 'good',
+        delta: 0.1,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {},
+      } as MetricWithAttribution);
 
-    userSessionManager.endSessionPartInternal('inactivity');
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    const sessionSpan = finishedSpans[0];
-    const clsEvent = sessionSpan.events[0];
-
-    expect(clsEvent.attributes).to.deep.equal({
-      'emb.type': 'ux.web_vital',
-      'emb.web_vital.delta': 0,
-      'emb.web_vital.id': 'm1',
-      'emb.web_vital.name': 'CLS',
-      'emb.web_vital.navigation_type': 'navigate',
-      'emb.web_vital.rating': 'good',
-      'emb.web_vital.value': 0,
-      'emb.web_vital.attribution.largestShiftValue': 0,
-      'emb.web_vital.attribution.hadRecentInput': false,
-      'url.full': 'https://example.com',
-      'browser.url.full': 'https://example.com',
-    });
-  });
-
-  it('should not register reportAllChanges listeners when urlAttribution is false', () => {
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      urlDocument,
-      listeners: mockWebVitalListeners,
-      urlAttribution: false,
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes[ATTR_URL_FULL]).to.be.undefined;
+      expect(records[0].attributes[KEY_BROWSER_URL_FULL]).to.be.undefined;
     });
 
-    expect(inpStub.callCount).to.equal(1);
-    expect(lcpStub.callCount).to.equal(1);
-    expect(clsStub.callCount).to.equal(1);
+    it('should not include page attributes when no reportAllChanges callback has fired', () => {
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlDocument: { URL: 'https://example.com/page-a' },
+      });
+
+      // Only call the emission listener, skip the reportAllChanges listener
+      const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
+
+      emitFunc({
+        name: 'CLS',
+        value: 0.1,
+        rating: 'good',
+        delta: 0.1,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {},
+      } as MetricWithAttribution);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      // No _attributedPage set yet → no page attrs
+      expect(records[0].attributes[ATTR_URL_FULL]).to.be.undefined;
+    });
   });
 });

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -1,5 +1,4 @@
 import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
-import { ATTR_URL_FULL } from '@opentelemetry/semantic-conventions';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
@@ -581,7 +580,6 @@ describe('WebVitalsInstrumentation', () => {
       'browser.web_vital.navigation_type': 'navigate',
       'browser.web_vital.rating': 'good',
       'browser.web_vital.value': 33,
-      [ATTR_URL_FULL]: 'https://example.com',
       [KEY_BROWSER_URL_FULL]: 'https://example.com',
     });
     expect(record.attributes).to.not.have.any.keys([
@@ -1361,7 +1359,6 @@ describe('WebVitalsInstrumentation', () => {
       'browser.web_vital.navigation_type': 'navigate',
       'browser.web_vital.rating': 'good',
       'browser.web_vital.value': 22,
-      [ATTR_URL_FULL]: 'https://example.com',
       [KEY_BROWSER_URL_FULL]: 'https://example.com',
     });
     expect(record.hrTime).to.deep.equal([5, 0]);
@@ -1409,7 +1406,6 @@ describe('WebVitalsInstrumentation', () => {
       'browser.web_vital.navigation_type': 'navigate',
       'browser.web_vital.rating': 'good',
       'browser.web_vital.value': 22,
-      [ATTR_URL_FULL]: 'https://example.com',
       [KEY_BROWSER_URL_FULL]: 'https://example.com',
     });
     expect(record.hrTime).to.deep.equal([3, 0]);
@@ -1464,7 +1460,6 @@ describe('WebVitalsInstrumentation', () => {
       'browser.web_vital.navigation_type': 'navigate',
       'browser.web_vital.rating': 'needs-improvement',
       'browser.web_vital.value': 33,
-      [ATTR_URL_FULL]: 'https://example.com',
       [KEY_BROWSER_URL_FULL]: 'https://example.com',
     });
     expect(record.hrTime).to.deep.equal([5, 0]);
@@ -1519,7 +1514,6 @@ describe('WebVitalsInstrumentation', () => {
       'browser.web_vital.navigation_type': 'navigate',
       'browser.web_vital.rating': 'poor',
       'browser.web_vital.value': 22,
-      [ATTR_URL_FULL]: 'https://example.com',
       [KEY_BROWSER_URL_FULL]: 'https://example.com',
     });
     expect(record.hrTime).to.deep.equal([5, 0]);
@@ -1582,7 +1576,6 @@ describe('WebVitalsInstrumentation', () => {
       'browser.web_vital.navigation_type': 'navigate',
       'browser.web_vital.rating': 'poor',
       'browser.web_vital.value': 22,
-      [ATTR_URL_FULL]: 'https://example.com',
       [KEY_BROWSER_URL_FULL]: 'https://example.com',
     });
     expect(record.hrTime).to.deep.equal([19, 0]);
@@ -1656,7 +1649,6 @@ describe('WebVitalsInstrumentation', () => {
       'browser.web_vital.navigation_type': 'navigate',
       'browser.web_vital.rating': 'poor',
       'browser.web_vital.value': 33,
-      [ATTR_URL_FULL]: 'https://example.com',
       [KEY_BROWSER_URL_FULL]: 'https://example.com',
       'emb.web_vital.attribution.redirect': 0,
       'emb.web_vital.attribution.domainLookup': 10,
@@ -1734,10 +1726,10 @@ describe('WebVitalsInstrumentation', () => {
     expect(clsRecord?.eventName).to.equal('browser.web_vital');
     expect(lcpRecord?.eventName).to.equal('browser.web_vital');
     expect(clsRecord?.attributes).to.deep.include({
-      [ATTR_URL_FULL]: 'https://example.com',
+      [KEY_BROWSER_URL_FULL]: 'https://example.com',
     });
     expect(lcpRecord?.attributes).to.deep.include({
-      [ATTR_URL_FULL]: 'https://example.com',
+      [KEY_BROWSER_URL_FULL]: 'https://example.com',
     });
     const lcpBody = JSON.parse(lcpRecord?.body as string) as Record<
       string,
@@ -1968,7 +1960,6 @@ describe('WebVitalsInstrumentation', () => {
       const records = memoryExporter.getFinishedLogRecords();
       expect(records).to.have.lengthOf(1);
       expect(records[0].attributes).to.deep.include({
-        [ATTR_URL_FULL]: 'https://second.com',
         [KEY_EMB_PAGE_PATH]: '/second/:id',
         [KEY_EMB_PAGE_ID]: attributedPageID,
       });
@@ -2029,7 +2020,6 @@ describe('WebVitalsInstrumentation', () => {
       const records = memoryExporter.getFinishedLogRecords();
       expect(records).to.have.lengthOf(1);
       expect(records[0].attributes).to.deep.include({
-        [ATTR_URL_FULL]: 'https://second.com',
         [KEY_EMB_PAGE_PATH]: '/second/:id',
         [KEY_EMB_PAGE_ID]: attributedPageID,
       });
@@ -2085,7 +2075,6 @@ describe('WebVitalsInstrumentation', () => {
       const records = memoryExporter.getFinishedLogRecords();
       expect(records).to.have.lengthOf(1);
       expect(records[0].attributes).to.deep.include({
-        [ATTR_URL_FULL]: 'https://second.com',
         [KEY_EMB_PAGE_PATH]: '/second/:id',
         [KEY_EMB_PAGE_ID]: attributedPageID,
       });
@@ -2140,7 +2129,6 @@ describe('WebVitalsInstrumentation', () => {
       const records = memoryExporter.getFinishedLogRecords();
       expect(records).to.have.lengthOf(1);
       expect(records[0].attributes).to.deep.include({
-        [ATTR_URL_FULL]: 'https://second.com',
         [KEY_EMB_PAGE_PATH]: '/second/:id',
         [KEY_EMB_PAGE_ID]: attributedPageID,
       });
@@ -2212,7 +2200,6 @@ describe('WebVitalsInstrumentation', () => {
       const records = memoryExporter.getFinishedLogRecords();
       expect(records).to.have.lengthOf(1);
       expect(records[0].attributes).to.deep.include({
-        [ATTR_URL_FULL]: 'https://second.com',
         [KEY_EMB_PAGE_PATH]: '/second/:id',
         [KEY_EMB_PAGE_ID]: attributedPageID,
       });
@@ -2411,9 +2398,6 @@ describe('WebVitalsInstrumentation', () => {
 
       const records = memoryExporter.getFinishedLogRecords();
       expect(records).to.have.lengthOf(1);
-      expect(records[0].attributes[ATTR_URL_FULL]).to.equal(
-        'https://example.com/page-a',
-      );
       expect(records[0].attributes[KEY_BROWSER_URL_FULL]).to.equal(
         'https://example.com/page-a',
       );
@@ -2454,7 +2438,7 @@ describe('WebVitalsInstrumentation', () => {
 
       const records = memoryExporter.getFinishedLogRecords();
       expect(records).to.have.lengthOf(1);
-      expect(records[0].attributes[ATTR_URL_FULL]).to.equal(
+      expect(records[0].attributes[KEY_BROWSER_URL_FULL]).to.equal(
         'https://example.com/page-a',
       );
     });
@@ -2532,7 +2516,6 @@ describe('WebVitalsInstrumentation', () => {
 
       const records = memoryExporter.getFinishedLogRecords();
       expect(records).to.have.lengthOf(1);
-      expect(records[0].attributes[ATTR_URL_FULL]).to.be.undefined;
       expect(records[0].attributes[KEY_BROWSER_URL_FULL]).to.be.undefined;
     });
 
@@ -2561,7 +2544,7 @@ describe('WebVitalsInstrumentation', () => {
       const records = memoryExporter.getFinishedLogRecords();
       expect(records).to.have.lengthOf(1);
       // No _attributedPage set yet → no page attrs
-      expect(records[0].attributes[ATTR_URL_FULL]).to.be.undefined;
+      expect(records[0].attributes[KEY_BROWSER_URL_FULL]).to.be.undefined;
     });
   });
 });

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -1867,7 +1867,7 @@ describe('WebVitalsInstrumentation', () => {
       'browser.web_vital.rating': 'good',
       'browser.web_vital.value': 0,
     });
-    expect(record.body).to.equal('null');
+    expect(record.body).to.be.undefined;
   });
 
   it('should include boolean attribution values in body', () => {

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -2583,4 +2583,136 @@ describe('WebVitalsInstrumentation', () => {
       expect(records[0].attributes[KEY_BROWSER_URL_FULL]).to.be.undefined;
     });
   });
+
+  describe('PerformanceObserver unavailable', () => {
+    let originalPerformanceObserver: typeof globalThis.PerformanceObserver;
+
+    beforeEach(() => {
+      originalPerformanceObserver = globalThis.PerformanceObserver;
+      (globalThis as Record<string, unknown>)['PerformanceObserver'] =
+        undefined;
+    });
+
+    afterEach(() => {
+      (globalThis as Record<string, unknown>)['PerformanceObserver'] =
+        originalPerformanceObserver;
+    });
+
+    it('should log debug and not register listeners when PerformanceObserver is undefined', () => {
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlAttribution: false,
+      });
+
+      expect(clsStub.callCount).to.equal(0);
+      expect(diag.getDebugLogs()).to.include(
+        'PerformanceObserver not supported, web vitals will not be collected',
+      );
+    });
+  });
+
+  it('should not track page when urlAttribution listener fires while disabled', () => {
+    const urlDocument = { URL: 'https://example.com/page-a' };
+
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlDocument,
+    });
+
+    const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+    const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
+
+    instrumentation.disable();
+
+    const metric = {
+      name: 'CLS',
+      value: 0.1,
+      rating: 'good',
+      delta: 0.1,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      attribution: { largestShiftTarget: 'el' },
+    } as MetricWithAttribution;
+
+    // fires while disabled — should not update attributed page
+    pageTrackFunc(metric);
+
+    instrumentation.enable();
+    emitFunc(metric);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    // attributed page was never captured (guard returned early) → no URL attr
+    expect(records[0].attributes[KEY_BROWSER_URL_FULL]).to.be.undefined;
+  });
+
+  describe('applyCustomLogRecordData hook', () => {
+    it('should call the hook and allow modifying the log record', () => {
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlAttribution: false,
+        applyCustomLogRecordData: (logRecord) => {
+          logRecord.attributes = {
+            ...logRecord.attributes,
+            'custom.attr': 'custom-value',
+          };
+        },
+      });
+
+      const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+
+      emitFunc({
+        name: 'CLS',
+        value: 0.1,
+        rating: 'good',
+        delta: 0.1,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {},
+      } as MetricWithAttribution);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes['custom.attr']).to.equal('custom-value');
+    });
+
+    it('should log an error when the hook throws', () => {
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlAttribution: false,
+        applyCustomLogRecordData: () => {
+          throw new Error('hook error');
+        },
+      });
+
+      const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+
+      emitFunc({
+        name: 'CLS',
+        value: 0.1,
+        rating: 'good',
+        delta: 0.1,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        attribution: {},
+      } as MetricWithAttribution);
+
+      // record is still emitted despite hook failure
+      expect(memoryExporter.getFinishedLogRecords()).to.have.lengthOf(1);
+      expect(diag.getErrorLogs()).to.include(
+        'applyCustomLogRecordData hook failed',
+      );
+    });
+  });
 });

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -153,6 +153,7 @@ describe('WebVitalsInstrumentation', () => {
     expect(body['largestShiftTime']).to.equal(3000);
     expect(body['largestShiftValue']).to.equal(3.0);
     expect(body['largestShiftTarget']).to.equal('some-target');
+    expect(body['loadState']).to.equal('complete');
   });
 
   it('should report FCP metrics as a log record', () => {
@@ -200,6 +201,7 @@ describe('WebVitalsInstrumentation', () => {
     const body = JSON.parse(record.body as string) as Record<string, unknown>;
     expect(body['timeToFirstByte']).to.equal(20);
     expect(body['firstByteToFCP']).to.equal(40);
+    expect(body['loadState']).to.equal('complete');
   });
 
   it('should report LCP metrics as a log record', () => {
@@ -244,6 +246,11 @@ describe('WebVitalsInstrumentation', () => {
       'browser.web_vital.value': 22,
     });
     expect(record.hrTime).to.deep.equal([5, 0]);
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['timeToFirstByte']).to.equal(999);
+    expect(body['resourceLoadDelay']).to.equal(1000);
+    expect(body['resourceLoadDuration']).to.equal(2000);
+    expect(body['elementRenderDelay']).to.equal(3000);
   });
 
   it('should report INP metrics as a log record', () => {
@@ -296,6 +303,15 @@ describe('WebVitalsInstrumentation', () => {
     });
     // Time should be based on interactionTime from attribution
     expect(record.hrTime).to.deep.equal([19, 0]);
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['interactionTarget']).to.equal('some-target');
+    expect(body['interactionTime']).to.equal(19000);
+    expect(body['nextPaintTime']).to.equal(18000);
+    expect(body['interactionType']).to.equal('pointer');
+    expect(body['inputDelay']).to.equal(1000);
+    expect(body['processingDuration']).to.equal(2000);
+    expect(body['presentationDelay']).to.equal(3000);
+    expect(body['loadState']).to.equal('complete');
   });
 
   describe('loaf_scripts attribution', () => {
@@ -513,6 +529,15 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.unattributed': 20,
     });
     expect(record.hrTime).to.deep.equal([5, 0]);
+    const ttfbBody = JSON.parse(record.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(ttfbBody['waitingDuration']).to.equal(20);
+    expect(ttfbBody['cacheDuration']).to.equal(40);
+    expect(ttfbBody['dnsDuration']).to.equal(60);
+    expect(ttfbBody['connectionDuration']).to.equal(80);
+    expect(ttfbBody['requestDuration']).to.equal(100);
   });
 
   it('should omit TTFB sub-parts when navigationEntry is absent', () => {
@@ -520,12 +545,13 @@ describe('WebVitalsInstrumentation', () => {
       diag,
       perf,
       listeners: mockWebVitalListeners,
-      urlAttribution: false,
+      urlDocument,
     });
 
-    const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
+    const pageTrackFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
+    const emitFunc = ttfbStub.getCall(1).args[0] as WebVitalOnReport;
 
-    metricReportFunc({
+    const metric = {
       name: 'TTFB',
       value: 33,
       rating: 'good',
@@ -540,19 +566,38 @@ describe('WebVitalsInstrumentation', () => {
         connectionDuration: 0,
         requestDuration: 33,
       },
-    } as MetricWithAttribution);
+    } as MetricWithAttribution;
+
+    pageTrackFunc(metric);
+    emitFunc(metric);
 
     const records = memoryExporter.getFinishedLogRecords();
     const record = records[0];
 
-    expect(record.attributes).to.deep.equal({
+    expect(record.attributes).to.deep.include({
       'browser.web_vital.delta': 33,
       'browser.web_vital.id': 'm2',
       'browser.web_vital.name': 'ttfb',
       'browser.web_vital.navigation_type': 'navigate',
       'browser.web_vital.rating': 'good',
       'browser.web_vital.value': 33,
+      [ATTR_URL_FULL]: 'https://example.com',
+      [KEY_BROWSER_URL_FULL]: 'https://example.com',
     });
+    expect(record.attributes).to.not.have.any.keys([
+      'emb.web_vital.attribution.redirect',
+      'emb.web_vital.attribution.domainLookup',
+      'emb.web_vital.attribution.tcpConnection',
+      'emb.web_vital.attribution.tlsNegotiation',
+      'emb.web_vital.attribution.serverResponse',
+      'emb.web_vital.attribution.unattributed',
+    ]);
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['waitingDuration']).to.equal(20);
+    expect(body['cacheDuration']).to.equal(0);
+    expect(body['dnsDuration']).to.equal(0);
+    expect(body['connectionDuration']).to.equal(0);
+    expect(body['requestDuration']).to.equal(33);
   });
 
   it('should compute TTFB sub-parts correctly with TLS', () => {
@@ -609,6 +654,12 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.serverResponse': 20,
       'emb.web_vital.attribution.unattributed': 30,
     });
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['waitingDuration']).to.equal(0);
+    expect(body['cacheDuration']).to.equal(0);
+    expect(body['dnsDuration']).to.equal(10);
+    expect(body['connectionDuration']).to.equal(20);
+    expect(body['requestDuration']).to.equal(30);
   });
 
   it('should use finalResponseHeadersStart for serverResponse when greater than responseStart', () => {
@@ -662,6 +713,12 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.serverResponse': 60,
       'emb.web_vital.attribution.unattributed': 20,
     });
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['waitingDuration']).to.equal(0);
+    expect(body['cacheDuration']).to.equal(0);
+    expect(body['dnsDuration']).to.equal(0);
+    expect(body['connectionDuration']).to.equal(0);
+    expect(body['requestDuration']).to.equal(50);
   });
 
   it('should fall back to responseStart when finalResponseHeadersStart is less than responseStart', () => {
@@ -715,6 +772,12 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.serverResponse': 40,
       'emb.web_vital.attribution.unattributed': 40,
     });
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['waitingDuration']).to.equal(0);
+    expect(body['cacheDuration']).to.equal(0);
+    expect(body['dnsDuration']).to.equal(0);
+    expect(body['connectionDuration']).to.equal(0);
+    expect(body['requestDuration']).to.equal(40);
   });
 
   it('should compute TTFB sub-parts correctly with non-zero redirect', () => {
@@ -768,6 +831,12 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.serverResponse': 30,
       'emb.web_vital.attribution.unattributed': 30,
     });
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['waitingDuration']).to.equal(0);
+    expect(body['cacheDuration']).to.equal(0);
+    expect(body['dnsDuration']).to.equal(10);
+    expect(body['connectionDuration']).to.equal(10);
+    expect(body['requestDuration']).to.equal(30);
   });
 
   it('should round fractional TTFB sub-part values to nearest millisecond', () => {
@@ -825,6 +894,12 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.serverResponse': 1,
       'emb.web_vital.attribution.unattributed': 0,
     });
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['waitingDuration']).to.equal(0);
+    expect(body['cacheDuration']).to.equal(0);
+    expect(body['dnsDuration']).to.equal(0);
+    expect(body['connectionDuration']).to.equal(1);
+    expect(body['requestDuration']).to.equal(1);
   });
 
   it('should clamp negative TTFB sub-part durations to 0', () => {
@@ -877,6 +952,12 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.serverResponse': 0,
       'emb.web_vital.attribution.unattributed': 50,
     });
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['waitingDuration']).to.equal(0);
+    expect(body['cacheDuration']).to.equal(0);
+    expect(body['dnsDuration']).to.equal(0);
+    expect(body['connectionDuration']).to.equal(0);
+    expect(body['requestDuration']).to.equal(0);
   });
 
   it('should round fractional negative TTFB sub-part durations to 0', () => {
@@ -929,6 +1010,12 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.serverResponse': 0,
       'emb.web_vital.attribution.unattributed': 50,
     });
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['waitingDuration']).to.equal(0);
+    expect(body['cacheDuration']).to.equal(0);
+    expect(body['dnsDuration']).to.equal(0);
+    expect(body['connectionDuration']).to.equal(0);
+    expect(body['requestDuration']).to.equal(0);
   });
 
   it('should ensure TTFB sub-parts sum to rounded total', () => {
@@ -997,6 +1084,15 @@ describe('WebVitalsInstrumentation', () => {
       serverResponse +
       unattributed;
     expect(sum).to.equal(Math.round(8.7 - 0.2));
+
+    const body = JSON.parse(
+      memoryExporter.getFinishedLogRecords()[0].body as string,
+    ) as Record<string, unknown>;
+    expect(body['waitingDuration']).to.equal(0);
+    expect(body['cacheDuration']).to.equal(0);
+    expect(body['dnsDuration']).to.equal(0);
+    expect(body['connectionDuration']).to.equal(0);
+    expect(body['requestDuration']).to.equal(0);
   });
 
   it('should compute TTFB other correctly with non-zero startTime', () => {
@@ -1050,6 +1146,12 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.serverResponse': 20,
       'emb.web_vital.attribution.unattributed': 30,
     });
+    const body = JSON.parse(record.body as string) as Record<string, unknown>;
+    expect(body['waitingDuration']).to.equal(0);
+    expect(body['cacheDuration']).to.equal(0);
+    expect(body['dnsDuration']).to.equal(10);
+    expect(body['connectionDuration']).to.equal(10);
+    expect(body['requestDuration']).to.equal(20);
   });
 
   it('should report multiple metrics as separate log records', () => {
@@ -1870,6 +1972,16 @@ describe('WebVitalsInstrumentation', () => {
         [KEY_EMB_PAGE_PATH]: '/second/:id',
         [KEY_EMB_PAGE_ID]: attributedPageID,
       });
+      const inpBody = JSON.parse(records[0].body as string) as Record<
+        string,
+        unknown
+      >;
+      expect(inpBody['interactionTarget']).to.equal('some-target');
+      expect(inpBody['interactionTime']).to.equal(19000);
+      expect(inpBody['inputDelay']).to.equal(1000);
+      expect(inpBody['processingDuration']).to.equal(2000);
+      expect(inpBody['presentationDelay']).to.equal(3000);
+      expect(inpBody['loadState']).to.equal('complete');
     });
 
     it('should attribute the correct URL for LCP metrics', () => {
@@ -1921,6 +2033,14 @@ describe('WebVitalsInstrumentation', () => {
         [KEY_EMB_PAGE_PATH]: '/second/:id',
         [KEY_EMB_PAGE_ID]: attributedPageID,
       });
+      const lcpBody = JSON.parse(records[0].body as string) as Record<
+        string,
+        unknown
+      >;
+      expect(lcpBody['timeToFirstByte']).to.equal(999);
+      expect(lcpBody['resourceLoadDelay']).to.equal(1000);
+      expect(lcpBody['resourceLoadDuration']).to.equal(2000);
+      expect(lcpBody['elementRenderDelay']).to.equal(3000);
     });
 
     it('should attribute the correct URL for CLS metrics based on largestShiftTarget changes', () => {
@@ -1969,6 +2089,11 @@ describe('WebVitalsInstrumentation', () => {
         [KEY_EMB_PAGE_PATH]: '/second/:id',
         [KEY_EMB_PAGE_ID]: attributedPageID,
       });
+      const clsBody = JSON.parse(records[0].body as string) as Record<
+        string,
+        unknown
+      >;
+      expect(clsBody['largestShiftTarget']).to.equal('some-target-2');
     });
 
     it('should attribute the correct URL for FCP metrics', () => {
@@ -2019,6 +2144,13 @@ describe('WebVitalsInstrumentation', () => {
         [KEY_EMB_PAGE_PATH]: '/second/:id',
         [KEY_EMB_PAGE_ID]: attributedPageID,
       });
+      const fcpBody = JSON.parse(records[0].body as string) as Record<
+        string,
+        unknown
+      >;
+      expect(fcpBody['timeToFirstByte']).to.equal(0);
+      expect(fcpBody['firstByteToFCP']).to.equal(0);
+      expect(fcpBody['loadState']).to.equal('complete');
     });
 
     it('should attribute the correct URL for TTFB metrics', () => {
@@ -2084,6 +2216,15 @@ describe('WebVitalsInstrumentation', () => {
         [KEY_EMB_PAGE_PATH]: '/second/:id',
         [KEY_EMB_PAGE_ID]: attributedPageID,
       });
+      const ttfbBody = JSON.parse(records[0].body as string) as Record<
+        string,
+        unknown
+      >;
+      expect(ttfbBody['waitingDuration']).to.equal(20);
+      expect(ttfbBody['cacheDuration']).to.equal(40);
+      expect(ttfbBody['dnsDuration']).to.equal(60);
+      expect(ttfbBody['connectionDuration']).to.equal(80);
+      expect(ttfbBody['requestDuration']).to.equal(100);
     });
   });
 

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -14,10 +14,12 @@ import type { PageManager } from '../../../api-page/index.ts';
 import { page } from '../../../api-page/index.ts';
 import type { URLDocument } from '../../../common/index.ts';
 import {
+  EMB_TYPES,
   KEY_APP_SURFACE_LABEL,
   KEY_BROWSER_URL_FULL,
   KEY_EMB_PAGE_ID,
   KEY_EMB_PAGE_PATH,
+  KEY_EMB_TYPE,
 } from '../../../constants/index.ts';
 import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
 import {
@@ -325,6 +327,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
       eventName: WEB_VITAL_EVENT_NAME,
       severityNumber: SeverityNumber.INFO,
       attributes: {
+        [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
         [KEY_BROWSER_WEB_VITAL_NAME]: metric.name.toLowerCase(),
         [KEY_BROWSER_WEB_VITAL_VALUE]: metric.value,
         [KEY_BROWSER_WEB_VITAL_DELTA]: metric.delta,

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -52,6 +52,13 @@ type AttributedPage = {
 
 const roundClamp = (value: number): number => Math.round(Math.max(0, value));
 
+const isPrimitiveValue = (
+  value: unknown,
+): value is string | number | boolean => {
+  const type = typeof value;
+  return type === 'number' || type === 'string' || type === 'boolean';
+};
+
 const loafScriptsAttribution = (
   metric: MetricWithAttribution,
   diag: DiagLogger,
@@ -349,9 +356,16 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
           ? ttfbSubPartsAttribution(metric, this._diag)
           : {}),
       },
-      body: this._includeRawAttribution
-        ? JSON.stringify(metric.attribution)
-        : undefined,
+      body:
+        this._includeRawAttribution && metric.attribution != null
+          ? JSON.stringify(
+              Object.fromEntries(
+                Object.entries(metric.attribution).filter(([, v]) =>
+                  isPrimitiveValue(v),
+                ),
+              ),
+            )
+          : undefined,
       timestamp: millisToHrTime(this._getTimeForMetric(metric)),
     };
 

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -1,8 +1,8 @@
-import type {
-  Attributes,
-  AttributeValue,
-  DiagLogger,
-} from '@opentelemetry/api';
+import type { Attributes, DiagLogger } from '@opentelemetry/api';
+import type { LogRecord } from '@opentelemetry/api-logs';
+import { SeverityNumber } from '@opentelemetry/api-logs';
+import { millisToHrTime } from '@opentelemetry/core';
+import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
 import { ATTR_URL_FULL } from '@opentelemetry/semantic-conventions';
 import type {
   CLSMetricWithAttribution,
@@ -15,33 +15,31 @@ import type { PageManager } from '../../../api-page/index.ts';
 import { page } from '../../../api-page/index.ts';
 import type { URLDocument } from '../../../common/index.ts';
 import {
-  EMB_TYPES,
   KEY_APP_SURFACE_LABEL,
   KEY_BROWSER_URL_FULL,
   KEY_EMB_PAGE_ID,
   KEY_EMB_PAGE_PATH,
-  KEY_EMB_TYPE,
 } from '../../../constants/index.ts';
 import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
 import {
+  KEY_BROWSER_WEB_VITAL_DELTA,
+  KEY_BROWSER_WEB_VITAL_ID,
+  KEY_BROWSER_WEB_VITAL_NAME,
+  KEY_BROWSER_WEB_VITAL_NAVIGATION_TYPE,
+  KEY_BROWSER_WEB_VITAL_RATING,
+  KEY_BROWSER_WEB_VITAL_VALUE,
   KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX,
-  KEY_EMB_WEB_VITAL_DELTA,
-  KEY_EMB_WEB_VITAL_ID,
-  KEY_EMB_WEB_VITAL_NAME,
-  KEY_EMB_WEB_VITAL_NAVIGATION_TYPE,
-  KEY_EMB_WEB_VITAL_RATING,
-  KEY_EMB_WEB_VITAL_VALUE,
 } from './attributes.ts';
 import {
   ALL_WEB_VITALS,
-  EMB_WEB_VITALS_PREFIX,
   MAX_LOAF_SCRIPT_ENTRIES,
   MAX_LOAF_SCRIPT_URL_LENGTH,
+  WEB_VITAL_EVENT_NAME,
   WEB_VITALS_ID_TO_LISTENER,
 } from './constants.ts';
 import type {
   WebVitalListeners,
-  WebVitalsInstrumentationArgs,
+  WebVitalsInstrumentationConfig,
 } from './types.ts';
 
 type AttributedPage = {
@@ -51,31 +49,7 @@ type AttributedPage = {
   label?: string;
 };
 
-const isPrimitiveValue = (value: unknown): value is AttributeValue => {
-  const type = typeof value;
-  return type === 'number' || type === 'string' || type === 'boolean';
-};
-
 const roundClamp = (value: number): number => Math.round(Math.max(0, value));
-
-const webVitalAttributionToReport = (
-  metric: MetricWithAttribution,
-): Attributes => {
-  const attributes: Attributes = {};
-  const attribution = metric.attribution;
-
-  if (!attribution || typeof attribution !== 'object') {
-    return attributes;
-  }
-
-  for (const [key, value] of Object.entries(attribution)) {
-    if (isPrimitiveValue(value)) {
-      attributes[`${KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX}${key}`] = value;
-    }
-  }
-
-  return attributes;
-};
 
 const loafScriptsAttribution = (
   metric: MetricWithAttribution,
@@ -222,32 +196,35 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     FCP: undefined,
     TTFB: undefined,
   };
-  private _largestShiftTargetForCLS: string | undefined;
+  private _largestShiftTargetForCLS: string | undefined | null = null;
+  private _applyCustomLogRecordData?: (logRecord: LogRecord) => void;
   private _listenersRegistered = false;
   private _isEnabled = false;
 
-  // instrumentation that adds an event to the session span for each web vital report
   public constructor({
     diag,
     perf,
     listeners = WEB_VITALS_ID_TO_LISTENER,
-    urlDocument = window.document,
+    urlDocument,
     urlAttribution = true,
     pageManager,
-  }: WebVitalsInstrumentationArgs = {}) {
+    applyCustomLogRecordData,
+    ...config
+  }: WebVitalsInstrumentationConfig = {}) {
     super({
-      instrumentationName: 'WebVitalsInstrumentation',
+      instrumentationName: '@opentelemetry/browser-instrumentation/web-vitals',
       instrumentationVersion: '1.0.0',
       diag,
       perf,
-      config: {},
+      config,
     });
     this._listeners = listeners;
-    this._urlDocument = urlDocument;
+    this._urlDocument = urlDocument ?? window.document;
     this._urlAttribution = urlAttribution;
     this._pageManager = pageManager ?? page.getPageManager();
+    this._applyCustomLogRecordData = applyCustomLogRecordData;
 
-    if (this._config.enabled) {
+    if (this._config.enabled !== false) {
       this.enable();
     }
   }
@@ -259,7 +236,14 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     this._diag.debug('WebVitalsInstrumentation disabled, pausing emission');
   }
 
-  public enable(): void {
+  public override enable(): void {
+    if (typeof PerformanceObserver === 'undefined') {
+      this._diag.debug(
+        'PerformanceObserver not supported, web vitals will not be collected',
+      );
+      return;
+    }
+
     this._isEnabled = true;
 
     // web-vitals library doesn't support removing listeners, so only register once
@@ -272,114 +256,49 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     this._listenersRegistered = true;
 
     ALL_WEB_VITALS.forEach((name) => {
+      if (this._urlAttribution) {
+        this._listeners[name]?.(
+          (metric) => {
+            if (!this._isEnabled) {
+              return;
+            }
+            if (metric.name === 'CLS') {
+              const clsMetric = metric as CLSMetricWithAttribution;
+              // CLS is cumulative — the rating can update without the shift target changing pages.
+              // Only update the attributed page when largestShiftTarget changes so the URL reflects
+              // the page where the dominant shift element actually appeared.
+              if (
+                this._largestShiftTargetForCLS !==
+                clsMetric.attribution.largestShiftTarget
+              ) {
+                this._largestShiftTargetForCLS =
+                  clsMetric.attribution.largestShiftTarget;
+                this._attributedPage.CLS = this._currentAttributedPage();
+              }
+            } else {
+              this._attributedPage[metric.name] = this._currentAttributedPage();
+            }
+          },
+          { reportAllChanges: true },
+        );
+      }
+
       this._listeners[name]?.((metric) => {
         if (!this._isEnabled) {
           return;
         }
-
-        const currentSessionPartSpan =
-          this.userSessionManager.getSessionPartSpan();
-
-        if (!currentSessionPartSpan) {
-          return;
-        }
-
-        // first thing record the time when this cb was invoked
-        const metricTime = this._getTimeForMetric(metric);
-
-        const attributedPage = this._getAttributedPageForMetric(metric);
-
-        const attrs: Attributes = {
-          [KEY_EMB_TYPE]: EMB_TYPES.WebVital,
-          [ATTR_URL_FULL]: attributedPage.fullURL,
-          [KEY_BROWSER_URL_FULL]: attributedPage.fullURL,
-          [KEY_EMB_WEB_VITAL_NAVIGATION_TYPE]: metric.navigationType,
-          [KEY_EMB_WEB_VITAL_NAME]: metric.name,
-          [KEY_EMB_WEB_VITAL_RATING]: metric.rating,
-          [KEY_EMB_WEB_VITAL_ID]: metric.id,
-          [KEY_EMB_WEB_VITAL_DELTA]: metric.delta,
-          [KEY_EMB_WEB_VITAL_VALUE]: metric.value,
-          ...webVitalAttributionToReport(metric),
-          ...(name === 'INP' ? loafScriptsAttribution(metric, this._diag) : {}),
-          ...(name === 'TTFB'
-            ? ttfbSubPartsAttribution(metric, this._diag)
-            : {}),
-        };
-
-        // Add page attributes if route and page ID exist
-        if (attributedPage.path && attributedPage.pageID) {
-          attrs[KEY_EMB_PAGE_PATH] = attributedPage.path;
-          attrs[KEY_EMB_PAGE_ID] = attributedPage.pageID;
-        }
-
-        if (attributedPage.label) {
-          attrs[KEY_APP_SURFACE_LABEL] = attributedPage.label;
-        }
-
-        currentSessionPartSpan.addEvent(
-          `${EMB_WEB_VITALS_PREFIX}-report-${name}`,
-          attrs,
-          metricTime,
-        );
+        this._emitWebVital(metric);
       });
     });
+  }
 
-    if (this._urlAttribution) {
-      // When these web vitals make their final report (e.g. when the listeners w/ reportAllChanges=false trigger) the
-      // document's URL at that time may not match what it was at the time the scores were last updated. Instead, listen
-      // for updates to the scores and keep track of the Page information to attribute for each
-      this._listeners.TTFB?.(
-        () => {
-          this._attributedPage.TTFB = this._currentAttributedPage();
-        },
-        {
-          reportAllChanges: true,
-        },
-      );
-      this._listeners.FCP?.(
-        () => {
-          this._attributedPage.FCP = this._currentAttributedPage();
-        },
-        {
-          reportAllChanges: true,
-        },
-      );
-      this._listeners.INP?.(
-        () => {
-          this._attributedPage.INP = this._currentAttributedPage();
-        },
-        {
-          reportAllChanges: true,
-        },
-      );
-      this._listeners.LCP?.(
-        () => {
-          this._attributedPage.LCP = this._currentAttributedPage();
-        },
-        {
-          reportAllChanges: true,
-        },
-      );
-      this._listeners.CLS?.(
-        (metric: MetricWithAttribution) => {
-          const clsMetric = metric as CLSMetricWithAttribution;
-          // A layout shift could cause CLS to change its rating but because the score is cumulative this might not
-          // correspond with an updated `largestShiftTarget`. Since we want to tie the attributed URL to the page that
-          // the `largestShiftTarget` was on we only update the attributed URL if that target has changed
-          if (
-            this._largestShiftTargetForCLS !==
-            clsMetric.attribution.largestShiftTarget
-          ) {
-            this._largestShiftTargetForCLS =
-              clsMetric.attribution.largestShiftTarget;
-            this._attributedPage.CLS = this._currentAttributedPage();
-          }
-        },
-        {
-          reportAllChanges: true,
-        },
-      );
-    }
+  private _currentAttributedPage(): AttributedPage {
+    return {
+      fullURL: this._urlDocument.URL,
+      path: this._pageManager.getCurrentRoute()?.path,
+      pageID: this._pageManager.getCurrentPageId() ?? undefined,
+      label: this._pageManager.getPageLabel() ?? undefined,
+    };
   }
 
   private _getTimeForMetric(metric: MetricWithAttribution): number {
@@ -398,53 +317,50 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     return this.perf.getNowMillis();
   }
 
-  private _currentAttributedPage(): AttributedPage {
-    const attributed: AttributedPage = {
-      fullURL: this._urlDocument.URL,
+  private _emitWebVital(metric: MetricWithAttribution): void {
+    const attributedPage = this._attributedPage[metric.name];
+    const logRecord: LogRecord = {
+      eventName: WEB_VITAL_EVENT_NAME,
+      severityNumber: SeverityNumber.INFO,
+      attributes: {
+        [KEY_BROWSER_WEB_VITAL_NAME]: metric.name.toLowerCase(),
+        [KEY_BROWSER_WEB_VITAL_VALUE]: metric.value,
+        [KEY_BROWSER_WEB_VITAL_DELTA]: metric.delta,
+        [KEY_BROWSER_WEB_VITAL_RATING]: metric.rating,
+        [KEY_BROWSER_WEB_VITAL_ID]: metric.id,
+        [KEY_BROWSER_WEB_VITAL_NAVIGATION_TYPE]: metric.navigationType,
+        ...(attributedPage
+          ? {
+              [ATTR_URL_FULL]: attributedPage.fullURL,
+              [KEY_BROWSER_URL_FULL]: attributedPage.fullURL,
+              [KEY_EMB_PAGE_PATH]: attributedPage.path,
+              [KEY_EMB_PAGE_ID]: attributedPage.pageID,
+              [KEY_APP_SURFACE_LABEL]: attributedPage.label,
+            }
+          : {}),
+        ...(metric.name === 'INP'
+          ? loafScriptsAttribution(metric, this._diag)
+          : {}),
+        ...(metric.name === 'TTFB'
+          ? ttfbSubPartsAttribution(metric, this._diag)
+          : {}),
+      },
+      body: JSON.stringify(metric.attribution),
+      timestamp: millisToHrTime(this._getTimeForMetric(metric)),
     };
 
-    const currentRoute = this._pageManager.getCurrentRoute();
-    const currentPageId = this._pageManager.getCurrentPageId();
-    if (currentRoute && currentPageId) {
-      attributed.path = currentRoute.path;
-      attributed.pageID = currentPageId;
+    if (this._applyCustomLogRecordData) {
+      safeExecuteInTheMiddle(
+        () => this._applyCustomLogRecordData?.(logRecord),
+        (error) => {
+          if (error) {
+            this._diag.error('applyCustomLogRecordData hook failed', error);
+          }
+        },
+        true,
+      );
     }
 
-    const pageLabel = this._pageManager.getPageLabel();
-    if (pageLabel) {
-      attributed.label = pageLabel;
-    }
-
-    return attributed;
-  }
-
-  private _getAttributedPageForMetric(
-    metric: MetricWithAttribution,
-  ): AttributedPage {
-    if (metric.name === 'FCP' && this._attributedPage.FCP) {
-      return this._attributedPage.FCP;
-    }
-
-    if (metric.name === 'TTFB' && this._attributedPage.TTFB) {
-      return this._attributedPage.TTFB;
-    }
-
-    if (metric.name === 'INP' && this._attributedPage.INP) {
-      return this._attributedPage.INP;
-    }
-
-    if (metric.name === 'LCP' && this._attributedPage.LCP) {
-      return this._attributedPage.LCP;
-    }
-
-    if (
-      metric.name === 'CLS' &&
-      this._attributedPage.CLS &&
-      metric.attribution.largestShiftTarget === this._largestShiftTargetForCLS
-    ) {
-      return this._attributedPage.CLS;
-    }
-
-    return this._currentAttributedPage();
+    this.logger.emit(logRecord);
   }
 }

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -3,7 +3,6 @@ import type { LogRecord } from '@opentelemetry/api-logs';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { millisToHrTime } from '@opentelemetry/core';
 import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
-import { ATTR_URL_FULL } from '@opentelemetry/semantic-conventions';
 import type {
   CLSMetricWithAttribution,
   INPAttribution,
@@ -334,7 +333,6 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
         [KEY_BROWSER_WEB_VITAL_NAVIGATION_TYPE]: metric.navigationType,
         ...(attributedPage
           ? {
-              [ATTR_URL_FULL]: attributedPage.fullURL,
               [KEY_BROWSER_URL_FULL]: attributedPage.fullURL,
               [KEY_EMB_PAGE_PATH]: attributedPage.path,
               [KEY_EMB_PAGE_ID]: attributedPage.pageID,

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -185,6 +185,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
   private readonly _listeners: WebVitalListeners;
   private readonly _urlDocument: URLDocument;
   private readonly _urlAttribution: boolean;
+  private readonly _includeRawAttribution: boolean;
   private readonly _pageManager: PageManager;
   private readonly _attributedPage: Record<
     Metric['name'],
@@ -207,12 +208,13 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     listeners = WEB_VITALS_ID_TO_LISTENER,
     urlDocument,
     urlAttribution = true,
+    includeRawAttribution = true,
     pageManager,
     applyCustomLogRecordData,
     ...config
   }: WebVitalsInstrumentationConfig = {}) {
     super({
-      instrumentationName: '@opentelemetry/browser-instrumentation/web-vitals',
+      instrumentationName: 'WebVitalsInstrumentation',
       instrumentationVersion: '1.0.0',
       diag,
       perf,
@@ -221,6 +223,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     this._listeners = listeners;
     this._urlDocument = urlDocument ?? window.document;
     this._urlAttribution = urlAttribution;
+    this._includeRawAttribution = includeRawAttribution;
     this._pageManager = pageManager ?? page.getPageManager();
     this._applyCustomLogRecordData = applyCustomLogRecordData;
 
@@ -345,7 +348,9 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
           ? ttfbSubPartsAttribution(metric, this._diag)
           : {}),
       },
-      body: JSON.stringify(metric.attribution),
+      body: this._includeRawAttribution
+        ? JSON.stringify(metric.attribution)
+        : undefined,
       timestamp: millisToHrTime(this._getTimeForMetric(metric)),
     };
 

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/attributes.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/attributes.ts
@@ -1,9 +1,10 @@
-export const KEY_EMB_WEB_VITAL_NAME = 'emb.web_vital.name';
-export const KEY_EMB_WEB_VITAL_VALUE = 'emb.web_vital.value';
-export const KEY_EMB_WEB_VITAL_RATING = 'emb.web_vital.rating';
-export const KEY_EMB_WEB_VITAL_DELTA = 'emb.web_vital.delta';
-export const KEY_EMB_WEB_VITAL_ID = 'emb.web_vital.id';
-export const KEY_EMB_WEB_VITAL_NAVIGATION_TYPE =
-  'emb.web_vital.navigation_type';
+export const KEY_BROWSER_WEB_VITAL_NAME = 'browser.web_vital.name';
+export const KEY_BROWSER_WEB_VITAL_VALUE = 'browser.web_vital.value';
+export const KEY_BROWSER_WEB_VITAL_RATING = 'browser.web_vital.rating';
+export const KEY_BROWSER_WEB_VITAL_DELTA = 'browser.web_vital.delta';
+export const KEY_BROWSER_WEB_VITAL_ID = 'browser.web_vital.id';
+export const KEY_BROWSER_WEB_VITAL_NAVIGATION_TYPE =
+  'browser.web_vital.navigation_type';
+
 export const KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX =
   'emb.web_vital.attribution.';

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/constants.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/constants.ts
@@ -1,9 +1,8 @@
 import { onCLS, onFCP, onINP, onLCP, onTTFB } from 'web-vitals/attribution';
 
-export const EMB_WEB_VITALS_PREFIX = 'emb-web-vitals';
+export const WEB_VITAL_EVENT_NAME = 'browser.web_vital';
 export const MAX_LOAF_SCRIPT_URL_LENGTH = 2048;
 export const MAX_LOAF_SCRIPT_ENTRIES = 250;
-export const CORE_WEB_VITALS = ['CLS', 'INP', 'LCP'] as const;
 export const ALL_WEB_VITALS = ['CLS', 'INP', 'LCP', 'FCP', 'TTFB'] as const;
 export const WEB_VITALS_ID_TO_LISTENER = {
   /**

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/index.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/index.ts
@@ -1,2 +1,6 @@
-export type { WebVitalOnReport } from './types.ts';
+export type {
+  WebVitalOnReport,
+  WebVitalsInstrumentationArgs,
+  WebVitalsInstrumentationConfig,
+} from './types.ts';
 export { WebVitalsInstrumentation } from './WebVitalsInstrumentation.ts';

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/index.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/index.ts
@@ -1,6 +1,5 @@
 export type {
   WebVitalOnReport,
-  WebVitalsInstrumentationArgs,
   WebVitalsInstrumentationConfig,
 } from './types.ts';
 export { WebVitalsInstrumentation } from './WebVitalsInstrumentation.ts';

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
@@ -1,3 +1,6 @@
+import type { DiagLogger } from '@opentelemetry/api';
+import type { LogRecord } from '@opentelemetry/api-logs';
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import type {
   Metric,
   MetricWithAttribution,
@@ -5,9 +8,7 @@ import type {
 } from 'web-vitals/attribution';
 import type { PageManager } from '../../../api-page/index.ts';
 import type { URLDocument } from '../../../common/index.ts';
-import type { EmbraceInstrumentationBaseArgs } from '../../EmbraceInstrumentationBase/index.ts';
-
-export type TrackingLevel = 'core' | 'all';
+import type { PerformanceManager } from '../../../utils/index.ts';
 
 export type WebVitalOnReport = (metric: MetricWithAttribution) => void;
 
@@ -16,11 +17,18 @@ export type WebVitalListeners = Record<
   ((onReport: WebVitalOnReport, opts?: ReportOpts) => void) | undefined
 >;
 
-export type WebVitalsInstrumentationArgs = {
-  /** @deprecated All vitals metrics are tracked by default */
-  trackingLevel?: TrackingLevel;
+export interface WebVitalsInstrumentationConfig extends InstrumentationConfig {
+  // OTel upstream options
+  applyCustomLogRecordData?: (logRecord: LogRecord) => void;
+
+  // Embrace-specific (testability + SPA page attribution)
   listeners?: WebVitalListeners;
   urlDocument?: URLDocument;
   urlAttribution?: boolean;
   pageManager?: PageManager;
-} & Pick<EmbraceInstrumentationBaseArgs, 'diag' | 'perf'>;
+  diag?: DiagLogger;
+  perf?: PerformanceManager;
+}
+
+// Backward-compat alias
+export type WebVitalsInstrumentationArgs = WebVitalsInstrumentationConfig;

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
@@ -10,6 +10,7 @@ import type { PageManager } from '../../../api-page/index.ts';
 import type { URLDocument } from '../../../common/index.ts';
 import type { PerformanceManager } from '../../../utils/index.ts';
 
+/** @deprecated All vitals metrics are tracked by default */
 export type TrackingLevel = 'core' | 'all';
 
 export type WebVitalOnReport = (metric: MetricWithAttribution) => void;

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
@@ -10,7 +10,7 @@ import type { PageManager } from '../../../api-page/index.ts';
 import type { URLDocument } from '../../../common/index.ts';
 import type { PerformanceManager } from '../../../utils/index.ts';
 
-/** @deprecated All vitals metrics are tracked by default */
+/** @deprecated All vitals metrics are tracked */
 export type TrackingLevel = 'core' | 'all';
 
 export type WebVitalOnReport = (metric: MetricWithAttribution) => void;
@@ -41,6 +41,6 @@ export interface WebVitalsInstrumentationConfig extends InstrumentationConfig {
   diag?: DiagLogger;
   perf?: PerformanceManager;
 
-  /** @deprecated All vitals metrics are tracked by default */
+  /** @deprecated All vitals metrics are tracked */
   trackingLevel?: TrackingLevel;
 }

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
@@ -10,6 +10,8 @@ import type { PageManager } from '../../../api-page/index.ts';
 import type { URLDocument } from '../../../common/index.ts';
 import type { PerformanceManager } from '../../../utils/index.ts';
 
+export type TrackingLevel = 'core' | 'all';
+
 export type WebVitalOnReport = (metric: MetricWithAttribution) => void;
 
 export type WebVitalListeners = Record<
@@ -19,6 +21,15 @@ export type WebVitalListeners = Record<
 
 export interface WebVitalsInstrumentationConfig extends InstrumentationConfig {
   // OTel upstream options
+  /**
+   * @experimental
+   * When true, sets the log record body to the JSON-stringified
+   * `web-vitals` attribution object for the metric.
+   *
+   * Note: `applyCustomLogRecordData` runs after the body is set.
+   * If the hook assigns a new `body`, it will overwrite the attribution data.
+   */
+  includeRawAttribution?: boolean;
   applyCustomLogRecordData?: (logRecord: LogRecord) => void;
 
   // Embrace-specific (testability + SPA page attribution)
@@ -28,7 +39,7 @@ export interface WebVitalsInstrumentationConfig extends InstrumentationConfig {
   pageManager?: PageManager;
   diag?: DiagLogger;
   perf?: PerformanceManager;
-}
 
-// Backward-compat alias
-export type WebVitalsInstrumentationArgs = WebVitalsInstrumentationConfig;
+  /** @deprecated All vitals metrics are tracked by default */
+  trackingLevel?: TrackingLevel;
+}

--- a/packages/web-sdk/src/instrumentations/web-vitals/index.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/index.ts
@@ -1,6 +1,5 @@
 export {
   type WebVitalOnReport,
   WebVitalsInstrumentation,
-  type WebVitalsInstrumentationArgs,
   type WebVitalsInstrumentationConfig,
 } from './WebVitalsInstrumentation/index.ts';

--- a/packages/web-sdk/src/instrumentations/web-vitals/index.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/index.ts
@@ -1,5 +1,6 @@
-export { WebVitalsInstrumentation } from './WebVitalsInstrumentation/index.ts';
-export type {
-  WebVitalOnReport,
-  WebVitalsInstrumentationArgs,
-} from './WebVitalsInstrumentation/types.ts';
+export {
+  type WebVitalOnReport,
+  WebVitalsInstrumentation,
+  type WebVitalsInstrumentationArgs,
+  type WebVitalsInstrumentationConfig,
+} from './WebVitalsInstrumentation/index.ts';

--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -342,6 +342,7 @@ describe('initSDK', () => {
       logExporters: [logExporter],
       spanExporters: [spanExporter],
       instrumentations: [instrumentation],
+      defaultInstrumentationConfig: { omit: new Set(['web-vital']) },
     });
     void expect(result).not.to.be.false;
 
@@ -368,6 +369,7 @@ describe('initSDK', () => {
       logProcessors: [new FakeLogRecordProcessor()],
       spanProcessors: [new FakeSpanProcessor()],
       instrumentations: [instrumentation],
+      defaultInstrumentationConfig: { omit: new Set(['web-vital']) },
     });
     void expect(result).not.to.be.false;
 
@@ -401,12 +403,14 @@ describe('initSDK', () => {
       },
     });
     void expect(result).not.to.be.false;
-    // Called twice, one for the actual reports and one for the urlAttribution
+    // Called twice: first for urlAttribution (reportAllChanges), second for emission
     void expect(testWebVitalListeners.clsStub.calledTwice).to.be.true;
-    const { args } = testWebVitalListeners.clsStub.callsArg(0);
-    const metricReportFunc = args[0][0] as WebVitalOnReport;
+    const pageTrackFunc = testWebVitalListeners.clsStub.getCall(0)
+      .args[0] as WebVitalOnReport;
+    const emitFunc = testWebVitalListeners.clsStub.getCall(1)
+      .args[0] as WebVitalOnReport;
 
-    metricReportFunc({
+    const clsMetric = {
       name: 'CLS',
       value: 22,
       rating: 'good',
@@ -415,19 +419,21 @@ describe('initSDK', () => {
       entries: [],
       navigationType: 'navigate',
       attribution: {},
-    } as MetricWithAttribution);
+    } as MetricWithAttribution;
 
-    session.getUserSessionManager().endSessionPartInternal('inactivity');
+    pageTrackFunc(clsMetric);
+    emitFunc(clsMetric);
+
     if (result) {
-      await result.flush();
+      await logExporter.forceFlush();
     }
 
-    const finishedSpans = spanExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(1);
-    const sessionSpan = finishedSpans[0];
-    expect(sessionSpan.events).to.have.lengthOf(1);
-    const clsEvent = sessionSpan.events[0];
-    expect(clsEvent.name).to.be.equal('emb-web-vitals-report-CLS');
+    const finishedLogRecords = logExporter.getFinishedLogRecords();
+    const clsRecord = finishedLogRecords.find(
+      (r) => r.attributes['browser.web_vital.name'] === 'cls',
+    );
+    void expect(clsRecord).not.to.be.undefined;
+    void expect(clsRecord?.eventName).to.equal('browser.web_vital');
   });
 
   it('should allow omitting optional instrumentations', () => {
@@ -451,6 +457,7 @@ describe('initSDK', () => {
       appID: 'abc12',
       logExporters: [logExporter],
       spanExporters: [spanExporter],
+      defaultInstrumentationConfig: { omit: new Set(['web-vital']) },
     });
     void expect(result).not.to.be.false;
 
@@ -1062,6 +1069,7 @@ describe('initSDK', () => {
             // These instrumentations generate entries in the test environment that interfere with assertions
             'document-load',
             'loaf',
+            'web-vital',
           ]),
         },
       });
@@ -1138,6 +1146,7 @@ describe('initSDK', () => {
             // These instrumentations generate entries in the test environment that interfere with assertions
             'document-load',
             'loaf',
+            'web-vital',
           ]),
         },
       });
@@ -1217,6 +1226,7 @@ describe('initSDK', () => {
             // These instrumentations generate entries in the test environment that interfere with assertions
             'document-load',
             'loaf',
+            'web-vital',
           ]),
         },
       });
@@ -1897,7 +1907,7 @@ describe('isolated instances', () => {
       registerGlobally: false,
       // Disable as it was creating too many spans making it harder to test
       defaultInstrumentationConfig: {
-        omit: new Set(['document-load', 'loaf']),
+        omit: new Set(['document-load', 'loaf', 'web-vital']),
       },
     });
 
@@ -1910,7 +1920,7 @@ describe('isolated instances', () => {
       instrumentations: [secondSDKInstrumentation],
       registerGlobally: false,
       defaultInstrumentationConfig: {
-        omit: new Set(['document-load', 'loaf']),
+        omit: new Set(['document-load', 'loaf', 'web-vital']),
       },
     });
 

--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -425,7 +425,7 @@ describe('initSDK', () => {
     emitFunc(clsMetric);
 
     if (result) {
-      await logExporter.forceFlush();
+      await result.flush();
     }
 
     const finishedLogRecords = logExporter.getFinishedLogRecords();

--- a/packages/web-sdk/src/sdk/types.ts
+++ b/packages/web-sdk/src/sdk/types.ts
@@ -32,7 +32,7 @@ import type {
   LoafInstrumentationArgs,
   ServerTimingInstrumentationArgs,
   UserTimingInstrumentationArgs,
-  WebVitalsInstrumentationArgs,
+  WebVitalsInstrumentationConfig,
 } from '../instrumentations/index.ts';
 import type {
   LimitManagerInternal,
@@ -393,7 +393,7 @@ export interface DefaultInstrumentationConfig {
   omit?: Set<OptionalInstrumentations>;
   exception?: GlobalExceptionInstrumentationArgs;
   click?: ClicksInstrumentationArgs;
-  'web-vital'?: WebVitalsInstrumentationArgs;
+  'web-vital'?: WebVitalsInstrumentationConfig;
   loaf?: LoafInstrumentationArgs;
   'user-timing'?: UserTimingInstrumentationArgs;
   'element-timing'?: ElementTimingInstrumentationArgs;

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -11,6 +11,12 @@ if ! podman ps -q --filter "name=${SERVE_CONTAINER}" | grep -q .; then
   exit 1
 fi
 
+# Mount test source directories from the host so changes are picked up without
+# rebuilding the image. The built artifacts (platforms/, node_modules/) are
+# intentionally left from the image, which is why we mount subdirs rather than
+# the whole tests/integration tree.
 run_with_golden_copy "npx playwright test --config playwright.config.prebuilt.ts" \
   --network "container:${SERVE_CONTAINER}" \
-  -w /workspace/tests/integration
+  -w /workspace/tests/integration \
+  -v "${WORKSPACE}/tests/integration/tests:/workspace/tests/integration/tests" \
+  -v "${WORKSPACE}/tests/integration/utils:/workspace/tests/integration/utils"

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
@@ -81,7 +81,7 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "name": "WebVitalsInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "41F9EB7D161ED909D82CFB785175D6DA"
+              "stringValue": "050484AAD45180814B30CDA4B32A8F8D"
             }
           },
           {
@@ -86,14 +86,20 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889230946899902",
-              "observedTimeUnixNano": "1779889230946000000",
+              "timeUnixNano": "1779891714757800049",
+              "observedTimeUnixNano": "1779891714757000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0.10000000894069672,\"cacheDuration\":0.699999988079071,\"dnsDuration\":0,\"connectionDuration\":0.20000000298023224,\"requestDuration\":0.4000000059604645,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":38.400000005960464,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0.10000000894069672,\"domainLookupStart\":0.7999999970197678,\"domainLookupEnd\":0.7999999970197678,\"connectStart\":0.7999999970197678,\"secureConnectionStart\":0,\"connectEnd\":1,\"requestStart\":1,\"responseStart\":1.4000000059604645,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":1.4000000059604645,\"responseEnd\":1.6000000089406967,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":4.100000008940697,\"domContentLoadedEventStart\":38.29999999701977,\"domContentLoadedEventEnd\":38.29999999701977,\"domComplete\":38.29999999701977,\"loadEventStart\":38.29999999701977,\"loadEventEnd\":38.400000005960464,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}}}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":0.7999999970197678,\"dnsDuration\":0,\"connectionDuration\":0.20000000298023224,\"requestDuration\":0.7000000029802322}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -103,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 1.4000000059604645
+                    "doubleValue": 1.7000000029802322
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 1.4000000059604645
+                    "doubleValue": 1.7000000029802322
                   }
                 },
                 {
@@ -121,19 +127,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889230942-9755095624822"
+                    "stringValue": "v5-1779891714754-5718795311361"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 0
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 2
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "B0A2BB790DBB252C93BD444B72BCF9E7"
+                    "stringValue": "44F74C8D0D51EF663DA82D18CA3D4A5F"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                    "stringValue": "630825E7EDBD03A49B2C6EB79FDCDE83"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                    "stringValue": "630825E7EDBD03A49B2C6EB79FDCDE83"
                   }
                 },
                 {
@@ -225,27 +225,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AD59292F0C92386B5C11763742691EB7"
+                    "stringValue": "B3EB24531E88614CF3BE3785E1388A94"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889230962300049",
-              "observedTimeUnixNano": "1779889230962000000",
+              "timeUnixNano": "1779891714772199951",
+              "observedTimeUnixNano": "1779891714772000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":1.4000000059604645,\"firstByteToFCP\":50.599999994039536,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":38.400000005960464,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0.10000000894069672,\"domainLookupStart\":0.7999999970197678,\"domainLookupEnd\":0.7999999970197678,\"connectStart\":0.7999999970197678,\"secureConnectionStart\":0,\"connectEnd\":1,\"requestStart\":1,\"responseStart\":1.4000000059604645,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":1.4000000059604645,\"responseEnd\":1.6000000089406967,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":4.100000008940697,\"domContentLoadedEventStart\":38.29999999701977,\"domContentLoadedEventEnd\":38.29999999701977,\"domComplete\":38.29999999701977,\"loadEventStart\":38.29999999701977,\"loadEventEnd\":38.400000005960464,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":52,\"duration\":0,\"paintTime\":47.20000000298023,\"presentationTime\":52}}"
+                "stringValue": "{\"timeToFirstByte\":1.7000000029802322,\"firstByteToFCP\":46.29999999701977,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -255,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 52
+                    "intValue": 48
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 52
+                    "intValue": 48
                   }
                 },
                 {
@@ -273,19 +279,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889230942-1826298348219"
+                    "stringValue": "v5-1779891714754-8381846990986"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "D83FC7F248BCE8646BBD21CF259A0D7E"
+                    "stringValue": "7F761B87F7F6037E26BCDBBA44F15889"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                    "stringValue": "630825E7EDBD03A49B2C6EB79FDCDE83"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                    "stringValue": "630825E7EDBD03A49B2C6EB79FDCDE83"
                   }
                 },
                 {
@@ -341,27 +341,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AD59292F0C92386B5C11763742691EB7"
+                    "stringValue": "B3EB24531E88614CF3BE3785E1388A94"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889231079000000",
-              "observedTimeUnixNano": "1779889231079000000",
+              "timeUnixNano": "1779891714889100098",
+              "observedTimeUnixNano": "1779891714889000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":1.4000000059604645,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":50.599999994039536,\"target\":\"#root>h1\",\"lcpEntry\":{\"name\":\"\",\"entryType\":\"largest-contentful-paint\",\"startTime\":52,\"duration\":0,\"paintTime\":47.20000000298023,\"presentationTime\":52,\"size\":19203,\"renderTime\":52,\"loadTime\":0,\"id\":\"\",\"url\":\"\"},\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":38.400000005960464,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0.10000000894069672,\"domainLookupStart\":0.7999999970197678,\"domainLookupEnd\":0.7999999970197678,\"connectStart\":0.7999999970197678,\"secureConnectionStart\":0,\"connectEnd\":1,\"requestStart\":1,\"responseStart\":1.4000000059604645,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":1.4000000059604645,\"responseEnd\":1.6000000089406967,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":4.100000008940697,\"domContentLoadedEventStart\":38.29999999701977,\"domContentLoadedEventEnd\":38.29999999701977,\"domComplete\":38.29999999701977,\"loadEventStart\":38.29999999701977,\"loadEventEnd\":38.400000005960464,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}}}"
+                "stringValue": "{\"timeToFirstByte\":1.7000000029802322,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":46.29999999701977,\"target\":\"#root>h1\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -371,13 +377,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 52
+                    "intValue": 48
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 52
+                    "intValue": 48
                   }
                 },
                 {
@@ -389,19 +395,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889230942-5709105625265"
+                    "stringValue": "v5-1779891714754-2821955512084"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -427,13 +427,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "8924AA7882F141C8D77F43B7858B6C09"
+                    "stringValue": "F68DFFB315B3AF0BE609C3B23423F4EE"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                    "stringValue": "630825E7EDBD03A49B2C6EB79FDCDE83"
                   }
                 },
                 {
@@ -445,7 +445,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                    "stringValue": "630825E7EDBD03A49B2C6EB79FDCDE83"
                   }
                 },
                 {
@@ -457,13 +457,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AD59292F0C92386B5C11763742691EB7"
+                    "stringValue": "B3EB24531E88614CF3BE3785E1388A94"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
@@ -477,8 +477,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889231498599854",
-              "observedTimeUnixNano": "1779889231498000000",
+              "timeUnixNano": "1779891715306800049",
+              "observedTimeUnixNano": "1779891715307000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -494,13 +494,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at nf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115001)\n    at Ry.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231013\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:230985)\n    at eg (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127510)"
+                    "stringValue": "Error\n    at nf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:115001)\n    at Ry.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231311\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231283)\n    at eg (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127510)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:126\":\"befe0c236b73acf40d3eccdcd08328e6\"}"
                   }
                 },
                 {
@@ -512,13 +512,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "6A04C1C46EB7A1B5EBFA705AC4BB1FF6"
+                    "stringValue": "34022054566466AB866BBB9820BF5360"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                    "stringValue": "630825E7EDBD03A49B2C6EB79FDCDE83"
                   }
                 },
                 {
@@ -530,7 +530,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                    "stringValue": "630825E7EDBD03A49B2C6EB79FDCDE83"
                   }
                 },
                 {
@@ -542,7 +542,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AD59292F0C92386B5C11763742691EB7"
+                    "stringValue": "B3EB24531E88614CF3BE3785E1388A94"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "F2241F7002AB2C6B5FDE28CFC03F75FC"
+              "stringValue": "41F9EB7D161ED909D82CFB785175D6DA"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
             }
           },
           {
@@ -81,12 +81,404 @@
       "scopeLogs": [
         {
           "scope": {
+            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "version": "1.0.0"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1779889230946899902",
+              "observedTimeUnixNano": "1779889230946000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"waitingDuration\":0.10000000894069672,\"cacheDuration\":0.699999988079071,\"dnsDuration\":0,\"connectionDuration\":0.20000000298023224,\"requestDuration\":0.4000000059604645,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":38.400000005960464,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0.10000000894069672,\"domainLookupStart\":0.7999999970197678,\"domainLookupEnd\":0.7999999970197678,\"connectStart\":0.7999999970197678,\"secureConnectionStart\":0,\"connectEnd\":1,\"requestStart\":1,\"responseStart\":1.4000000059604645,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":1.4000000059604645,\"responseEnd\":1.6000000089406967,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":4.100000008940697,\"domContentLoadedEventStart\":38.29999999701977,\"domContentLoadedEventEnd\":38.29999999701977,\"domComplete\":38.29999999701977,\"loadEventStart\":38.29999999701977,\"loadEventEnd\":38.400000005960464,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "ttfb"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "doubleValue": 1.4000000059604645
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "doubleValue": 1.4000000059604645
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889230942-9755095624822"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.redirect",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.domainLookup",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.tcpConnection",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.tlsNegotiation",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.serverResponse",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.unattributed",
+                  "value": {
+                    "intValue": 2
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "B0A2BB790DBB252C93BD444B72BCF9E7"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "AD59292F0C92386B5C11763742691EB7"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1779889230962300049",
+              "observedTimeUnixNano": "1779889230962000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":1.4000000059604645,\"firstByteToFCP\":50.599999994039536,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":38.400000005960464,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0.10000000894069672,\"domainLookupStart\":0.7999999970197678,\"domainLookupEnd\":0.7999999970197678,\"connectStart\":0.7999999970197678,\"secureConnectionStart\":0,\"connectEnd\":1,\"requestStart\":1,\"responseStart\":1.4000000059604645,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":1.4000000059604645,\"responseEnd\":1.6000000089406967,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":4.100000008940697,\"domContentLoadedEventStart\":38.29999999701977,\"domContentLoadedEventEnd\":38.29999999701977,\"domComplete\":38.29999999701977,\"loadEventStart\":38.29999999701977,\"loadEventEnd\":38.400000005960464,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":52,\"duration\":0,\"paintTime\":47.20000000298023,\"presentationTime\":52}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "fcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 52
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 52
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889230942-1826298348219"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "D83FC7F248BCE8646BBD21CF259A0D7E"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "AD59292F0C92386B5C11763742691EB7"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1779889231079000000",
+              "observedTimeUnixNano": "1779889231079000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":1.4000000059604645,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":50.599999994039536,\"target\":\"#root>h1\",\"lcpEntry\":{\"name\":\"\",\"entryType\":\"largest-contentful-paint\",\"startTime\":52,\"duration\":0,\"paintTime\":47.20000000298023,\"presentationTime\":52,\"size\":19203,\"renderTime\":52,\"loadTime\":0,\"id\":\"\",\"url\":\"\"},\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":38.400000005960464,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0.10000000894069672,\"domainLookupStart\":0.7999999970197678,\"domainLookupEnd\":0.7999999970197678,\"connectStart\":0.7999999970197678,\"secureConnectionStart\":0,\"connectEnd\":1,\"requestStart\":1,\"responseStart\":1.4000000059604645,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":1.4000000059604645,\"responseEnd\":1.6000000089406967,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":4.100000008940697,\"domContentLoadedEventStart\":38.29999999701977,\"domContentLoadedEventEnd\":38.29999999701977,\"domComplete\":38.29999999701977,\"loadEventStart\":38.29999999701977,\"loadEventEnd\":38.400000005960464,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "lcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 52
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 52
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889230942-5709105625265"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "8924AA7882F141C8D77F43B7858B6C09"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "AD59292F0C92386B5C11763742691EB7"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            }
+          ]
+        },
+        {
+          "scope": {
             "name": "embrace-web-sdk-logs"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1778792198720000000",
-              "observedTimeUnixNano": "1778792198720000000",
+              "timeUnixNano": "1779889231498599854",
+              "observedTimeUnixNano": "1779889231498000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -102,13 +494,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at ef.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:97695)\n    at Ay.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231094\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231066)\n    at ng (http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:127510)"
+                    "stringValue": "Error\n    at nf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115001)\n    at Ry.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231013\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:230985)\n    at eg (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127510)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:11:126\":\"05d1173f5302f5d00f1464789fc7459c\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
                   }
                 },
                 {
@@ -120,13 +512,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "D766716940465D8DA79ED0E67ACC875F"
+                    "stringValue": "6A04C1C46EB7A1B5EBFA705AC4BB1FF6"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "BBA577F4EDC8D09F7301BAC146699DA0"
+                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
                   }
                 },
                 {
@@ -138,7 +530,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "BBA577F4EDC8D09F7301BAC146699DA0"
+                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
                   }
                 },
                 {
@@ -150,7 +542,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "39DF30900DC98EC32B5DA09B8576005B"
+                    "stringValue": "AD59292F0C92386B5C11763742691EB7"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "B8184F1E9D1DDDF52B2CAAD7ABFA08FC"
+              "stringValue": "41F9EB7D161ED909D82CFB785175D6DA"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "d5baa383135065ff9abceccb2c9ddf83",
-              "spanId": "12cb629194ea945a",
+              "traceId": "125f77d3e2b3a236ce3e3a73d107e199",
+              "spanId": "d837c9f4fed9d7f0",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1779311818316000000",
-              "endTimeUnixNano": "1779311818882600098",
+              "startTimeUnixNano": "1779889230941000000",
+              "endTimeUnixNano": "1779889231522399902",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "49C7D02E876AEF49B89E4973621CD0CA"
+                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "49C7D02E876AEF49B89E4973621CD0CA"
+                    "stringValue": "70B6894F3540C087EA4D153828082C0B"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "doubleValue": 1779311818315.8
+                    "doubleValue": 1779889230941.2
                   }
                 },
                 {
@@ -167,7 +167,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "FE94793FDCF26F36DCB4B12C93F59480"
+                    "stringValue": "AD59292F0C92386B5C11763742691EB7"
                   }
                 },
                 {
@@ -226,224 +226,6 @@
                     {
                       "key": "emb.type",
                       "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "TTFB"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1779311818317-9364720122267"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "doubleValue": 1.0999999940395355
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "doubleValue": 1.0999999940395355
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.waitingDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.cacheDuration",
-                      "value": {
-                        "doubleValue": 0.5999999940395355
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.dnsDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.connectionDuration",
-                      "value": {
-                        "doubleValue": 0.20000001788139343
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.requestDuration",
-                      "value": {
-                        "doubleValue": 0.29999998211860657
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.redirect",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.domainLookup",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tcpConnection",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tlsNegotiation",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.serverResponse",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.unattributed",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1779311818321000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "FCP"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1779311818317-2250450130703"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "intValue": 44
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "intValue": 44
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.timeToFirstByte",
-                      "value": {
-                        "doubleValue": 1.0999999940395355
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.firstByteToFCP",
-                      "value": {
-                        "doubleValue": 42.900000005960464
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.loadState",
-                      "value": {
-                        "stringValue": "complete"
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1779311818330800049",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
                         "stringValue": "ux.tap"
                       }
                     },
@@ -461,104 +243,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1779311818440399902",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "LCP"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1779311818317-5514687145792"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "intValue": 44
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "intValue": 44
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.timeToFirstByte",
-                      "value": {
-                        "doubleValue": 1.0999999940395355
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.resourceLoadDelay",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.resourceLoadDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.elementRenderDelay",
-                      "value": {
-                        "doubleValue": 42.900000005960464
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.target",
-                      "value": {
-                        "stringValue": "#root>h1"
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-LCP",
-                  "timeUnixNano": "1779311818447699951",
+                  "timeUnixNano": "1779889231072300049",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -583,7 +268,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1779311818856399902",
+                  "timeUnixNano": "1779889231497899902",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -604,13 +289,13 @@
           },
           "spans": [
             {
-              "traceId": "38df4a62110f2280133eaa6362ee4b32",
-              "spanId": "4670245d6d5aeacd",
-              "parentSpanId": "7cc938360622d675",
+              "traceId": "1270abc3b9acf46ac6a786bfd07de9ce",
+              "spanId": "973810863f00a493",
+              "parentSpanId": "e2cb26e2efb59093",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1779311818285100098",
-              "endTimeUnixNano": "1779311818286300098",
+              "startTimeUnixNano": "1779889230905700097",
+              "endTimeUnixNano": "1779889230907200097",
               "attributes": [
                 {
                   "key": "url.full",
@@ -642,55 +327,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1779311818285100098",
+                  "timeUnixNano": "1779889230905700097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1779311818285700098",
+                  "timeUnixNano": "1779889230906400097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1779311818285700098",
+                  "timeUnixNano": "1779889230906400097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1779311818285700098",
+                  "timeUnixNano": "1779889230906400097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1779311818285100098",
+                  "timeUnixNano": "1779889230905600097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1779311818285900098",
+                  "timeUnixNano": "1779889230906600097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1779311818285900098",
+                  "timeUnixNano": "1779889230906600097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1779311818286200098",
+                  "timeUnixNano": "1779889230907000097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1779311818286300098",
+                  "timeUnixNano": "1779889230907200097",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -703,13 +388,13 @@
               "flags": 257
             },
             {
-              "traceId": "38df4a62110f2280133eaa6362ee4b32",
-              "spanId": "22c1f4111b3245fe",
-              "parentSpanId": "7cc938360622d675",
+              "traceId": "1270abc3b9acf46ac6a786bfd07de9ce",
+              "spanId": "49296867c2a191d4",
+              "parentSpanId": "e2cb26e2efb59093",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1779311818286900000",
-              "endTimeUnixNano": "1779311818289200000",
+              "startTimeUnixNano": "1779889230908700000",
+              "endTimeUnixNano": "1779889230911300000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -720,13 +405,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-D5XYgRNU.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 389343
+                    "intValue": 389097
                   }
                 },
                 {
@@ -750,19 +435,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 389343
+                    "intValue": 389097
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 389643
+                    "intValue": 389397
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 389343
+                    "intValue": 389097
                   }
                 },
                 {
@@ -783,49 +468,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1779311818286900000",
+                  "timeUnixNano": "1779889230908700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1779311818286900000",
+                  "timeUnixNano": "1779889230908700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1779311818286900000",
+                  "timeUnixNano": "1779889230908700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1779311818286900000",
+                  "timeUnixNano": "1779889230908700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1779311818286900000",
+                  "timeUnixNano": "1779889230908700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1779311818288300000",
+                  "timeUnixNano": "1779889230910200000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1779311818288700000",
+                  "timeUnixNano": "1779889230910700000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1779311818289200000",
+                  "timeUnixNano": "1779889230911300000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -838,12 +523,12 @@
               "flags": 257
             },
             {
-              "traceId": "38df4a62110f2280133eaa6362ee4b32",
-              "spanId": "7cc938360622d675",
+              "traceId": "1270abc3b9acf46ac6a786bfd07de9ce",
+              "spanId": "e2cb26e2efb59093",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1779311818285199951",
-              "endTimeUnixNano": "1779311818318599951",
+              "startTimeUnixNano": "1779889230905700097",
+              "endTimeUnixNano": "1779889230944000097",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -880,38 +565,44 @@
               "events": [
                 {
                   "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1779889230905700097",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1779311818288799951",
+                  "timeUnixNano": "1779889230909700097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1779311818318499951",
+                  "timeUnixNano": "1779889230943900097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1779311818318499951",
+                  "timeUnixNano": "1779889230943900097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1779311818318499951",
+                  "timeUnixNano": "1779889230943900097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1779311818318499951",
+                  "timeUnixNano": "1779889230943900097",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1779311818318599951",
+                  "timeUnixNano": "1779889230944000097",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -932,12 +623,12 @@
           },
           "spans": [
             {
-              "traceId": "cedc1c4c69c6f82d5ac8b1883b1e3205",
-              "spanId": "0b7f481d7a0908bd",
+              "traceId": "80c2a85daf7de229fcba92691c754157",
+              "spanId": "2ea2ba70b1f8bbda",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1779311818441000000",
-              "endTimeUnixNano": "1779311818447000000",
+              "startTimeUnixNano": "1779889231073000000",
+              "endTimeUnixNano": "1779889231078000000",
               "attributes": [
                 {
                   "key": "component",
@@ -1045,49 +736,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1779311818441499951",
+                  "timeUnixNano": "1779889231073600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1779311818441499951",
+                  "timeUnixNano": "1779889231073600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1779311818441499951",
+                  "timeUnixNano": "1779889231073600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1779311818441499951",
+                  "timeUnixNano": "1779889231073600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1779311818441499951",
+                  "timeUnixNano": "1779889231073600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1779311818441499951",
+                  "timeUnixNano": "1779889231073600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1779311818442399951",
+                  "timeUnixNano": "1779889231077000049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1779311818442399951",
+                  "timeUnixNano": "1779889231077000049",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "3B2D72CBC2A6148E4879E32F1AF4B142"
+              "stringValue": "52FE496E4B85D6F47CAFCA84A68808A1"
             }
           },
           {
@@ -86,14 +86,20 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889227981899902",
-              "observedTimeUnixNano": "1779889227981000000",
+              "timeUnixNano": "1779891711576899902",
+              "observedTimeUnixNano": "1779891711576000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0.10000000894069672,\"cacheDuration\":1.0999999940395355,\"dnsDuration\":0,\"connectionDuration\":0.10000000894069672,\"requestDuration\":3.2999999970197678,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":48.70000000298023,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0.10000000894069672,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.300000011920929,\"requestStart\":1.4000000059604645,\"responseStart\":4.600000008940697,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.600000008940697,\"responseEnd\":5,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.600000008940697,\"domContentLoadedEventStart\":48.6000000089407,\"domContentLoadedEventEnd\":48.6000000089407,\"domComplete\":48.6000000089407,\"loadEventStart\":48.6000000089407,\"loadEventEnd\":48.70000000298023,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"high\"}}}"
+                "stringValue": "{\"waitingDuration\":0.09999999403953552,\"cacheDuration\":2.2000000029802322,\"dnsDuration\":0.10000000894069672,\"connectionDuration\":0.09999999403953552,\"requestDuration\":1.7999999970197678}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -103,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 4.600000008940697
+                    "doubleValue": 4.299999997019768
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 4.600000008940697
+                    "doubleValue": 4.299999997019768
                   }
                 },
                 {
@@ -121,19 +127,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889227977-5973487376339"
+                    "stringValue": "v5-1779891711573-7391903867984"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 3
+                    "intValue": 2
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 2
+                    "intValue": 3
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "6ADD104B3A4148E438A532A4DC6F990E"
+                    "stringValue": "536AF37831E5D57685E8B6753A7A103E"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "3E1B45D882B31DFAE7619782070721C5"
+                    "stringValue": "3FB9C2B4BBBB06B8385DECEB08446E1E"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "3E1B45D882B31DFAE7619782070721C5"
+                    "stringValue": "3FB9C2B4BBBB06B8385DECEB08446E1E"
                   }
                 },
                 {
@@ -225,27 +225,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "F0B08A0B39B57A6FF6CD82B604A64BF9"
+                    "stringValue": "1E9DD0F68990DC2F15EAF8D3C70D1372"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889228004500000",
-              "observedTimeUnixNano": "1779889228004000000",
+              "timeUnixNano": "1779891711588800049",
+              "observedTimeUnixNano": "1779891711588000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":4.600000008940697,\"firstByteToFCP\":67.3999999910593,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":48.70000000298023,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0.10000000894069672,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.300000011920929,\"requestStart\":1.4000000059604645,\"responseStart\":4.600000008940697,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.600000008940697,\"responseEnd\":5,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.600000008940697,\"domContentLoadedEventStart\":48.6000000089407,\"domContentLoadedEventEnd\":48.6000000089407,\"domComplete\":48.6000000089407,\"loadEventStart\":48.6000000089407,\"loadEventEnd\":48.70000000298023,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"high\"}},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":72,\"duration\":0,\"paintTime\":69.80000001192093,\"presentationTime\":72}}"
+                "stringValue": "{\"timeToFirstByte\":4.299999997019768,\"firstByteToFCP\":51.70000000298023,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -255,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 72
+                    "intValue": 56
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 72
+                    "intValue": 56
                   }
                 },
                 {
@@ -273,19 +279,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889227977-4454366717035"
+                    "stringValue": "v5-1779891711573-5276296097903"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "76EEC8F22B323DB5653E440E083D2D22"
+                    "stringValue": "60F09EBFB69DA01B13D12D9999AF454B"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "3E1B45D882B31DFAE7619782070721C5"
+                    "stringValue": "3FB9C2B4BBBB06B8385DECEB08446E1E"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "3E1B45D882B31DFAE7619782070721C5"
+                    "stringValue": "3FB9C2B4BBBB06B8385DECEB08446E1E"
                   }
                 },
                 {
@@ -341,13 +341,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "F0B08A0B39B57A6FF6CD82B604A64BF9"
+                    "stringValue": "1E9DD0F68990DC2F15EAF8D3C70D1372"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-log.json
@@ -81,7 +81,7 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "name": "WebVitalsInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "57EA43C93BE035FD40FA4B1A78B46E8C"
+              "stringValue": "3B2D72CBC2A6148E4879E32F1AF4B142"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889228391900146",
-              "observedTimeUnixNano": "1779889228392000000",
+              "timeUnixNano": "1779889227981899902",
+              "observedTimeUnixNano": "1779889227981000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":1.2000000029802322,\"dnsDuration\":0,\"connectionDuration\":0.29999999701976776,\"requestDuration\":3.2000000029802322,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":49.1000000089407,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.5,\"requestStart\":1.5,\"responseStart\":4.700000002980232,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.700000002980232,\"responseEnd\":4.799999997019768,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.700000002980232,\"domContentLoadedEventStart\":49,\"domContentLoadedEventEnd\":49,\"domComplete\":49,\"loadEventStart\":49,\"loadEventEnd\":49.1000000089407,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}}}"
+                "stringValue": "{\"waitingDuration\":0.10000000894069672,\"cacheDuration\":1.0999999940395355,\"dnsDuration\":0,\"connectionDuration\":0.10000000894069672,\"requestDuration\":3.2999999970197678,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":48.70000000298023,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0.10000000894069672,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.300000011920929,\"requestStart\":1.4000000059604645,\"responseStart\":4.600000008940697,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.600000008940697,\"responseEnd\":5,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.600000008940697,\"domContentLoadedEventStart\":48.6000000089407,\"domContentLoadedEventEnd\":48.6000000089407,\"domComplete\":48.6000000089407,\"loadEventStart\":48.6000000089407,\"loadEventEnd\":48.70000000298023,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"high\"}}}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -103,13 +103,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 4.700000002980232
+                    "doubleValue": 4.600000008940697
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 4.700000002980232
+                    "doubleValue": 4.600000008940697
                   }
                 },
                 {
@@ -121,7 +121,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889228388-2417159675947"
+                    "stringValue": "v5-1779889227977-5973487376339"
                   }
                 },
                 {
@@ -195,13 +195,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0CC0A105A1C4F656948BA3AEFD0DC967"
+                    "stringValue": "6ADD104B3A4148E438A532A4DC6F990E"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "3E1B45D882B31DFAE7619782070721C5"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "3E1B45D882B31DFAE7619782070721C5"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
+                    "stringValue": "F0B08A0B39B57A6FF6CD82B604A64BF9"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889228405700195",
-              "observedTimeUnixNano": "1779889228405000000",
+              "timeUnixNano": "1779889228004500000",
+              "observedTimeUnixNano": "1779889228004000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":4.700000002980232,\"firstByteToFCP\":59.29999999701977,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":49.1000000089407,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.5,\"requestStart\":1.5,\"responseStart\":4.700000002980232,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.700000002980232,\"responseEnd\":4.799999997019768,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.700000002980232,\"domContentLoadedEventStart\":49,\"domContentLoadedEventEnd\":49,\"domComplete\":49,\"loadEventStart\":49,\"loadEventEnd\":49.1000000089407,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":64,\"duration\":0,\"paintTime\":58.20000000298023,\"presentationTime\":64}}"
+                "stringValue": "{\"timeToFirstByte\":4.600000008940697,\"firstByteToFCP\":67.3999999910593,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":48.70000000298023,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0.10000000894069672,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.300000011920929,\"requestStart\":1.4000000059604645,\"responseStart\":4.600000008940697,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.600000008940697,\"responseEnd\":5,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.600000008940697,\"domContentLoadedEventStart\":48.6000000089407,\"domContentLoadedEventEnd\":48.6000000089407,\"domComplete\":48.6000000089407,\"loadEventStart\":48.6000000089407,\"loadEventEnd\":48.70000000298023,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"high\"}},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":72,\"duration\":0,\"paintTime\":69.80000001192093,\"presentationTime\":72}}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -255,13 +255,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 64
+                    "intValue": 72
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 64
+                    "intValue": 72
                   }
                 },
                 {
@@ -273,7 +273,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889228388-7792731886832"
+                    "stringValue": "v5-1779889227977-4454366717035"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "3262555AC105DAE77EB9844486EDFD40"
+                    "stringValue": "76EEC8F22B323DB5653E440E083D2D22"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "3E1B45D882B31DFAE7619782070721C5"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "3E1B45D882B31DFAE7619782070721C5"
                   }
                 },
                 {
@@ -341,110 +341,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
+                    "stringValue": "F0B08A0B39B57A6FF6CD82B604A64BF9"
                   }
                 },
                 {
                   "key": "emb.type",
                   "value": {
                     "stringValue": "sys.log"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            }
-          ]
-        },
-        {
-          "scope": {
-            "name": "embrace-web-sdk-logs"
-          },
-          "logRecords": [
-            {
-              "timeUnixNano": "1779889228516300049",
-              "observedTimeUnixNano": "1779889228516000000",
-              "severityNumber": 13,
-              "severityText": "WARNING",
-              "body": {
-                "stringValue": "This is a test log message"
-              },
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "sys.log"
-                  }
-                },
-                {
-                  "key": "emb.stacktrace.js",
-                  "value": {
-                    "stringValue": "Error\n    at nf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115001)\n    at Ry.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231013\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:230985)\n    at eg (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127510)"
-                  }
-                },
-                {
-                  "key": "emb.js_file_bundle_ids",
-                  "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
-                  }
-                },
-                {
-                  "key": "emb.state",
-                  "value": {
-                    "stringValue": "foreground"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "C1D1700FB1CB39D702C62A740A01D6FD"
-                  }
-                },
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
-                  }
-                },
-                {
-                  "key": "session.previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
                   }
                 }
               ],

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
@@ -81,7 +81,7 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "name": "WebVitalsInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "57EA43C93BE035FD40FA4B1A78B46E8C"
+              "stringValue": "ADF9DCBF0433CF3D728BC37CB5E423D4"
             }
           },
           {
@@ -86,14 +86,20 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889228391900146",
-              "observedTimeUnixNano": "1779889228392000000",
+              "timeUnixNano": "1779891712053899902",
+              "observedTimeUnixNano": "1779891712054000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":1.2000000029802322,\"dnsDuration\":0,\"connectionDuration\":0.29999999701976776,\"requestDuration\":3.2000000029802322,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":49.1000000089407,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.5,\"requestStart\":1.5,\"responseStart\":4.700000002980232,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.700000002980232,\"responseEnd\":4.799999997019768,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.700000002980232,\"domContentLoadedEventStart\":49,\"domContentLoadedEventEnd\":49,\"domComplete\":49,\"loadEventStart\":49,\"loadEventEnd\":49.1000000089407,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}}}"
+                "stringValue": "{\"waitingDuration\":0.09999999403953552,\"cacheDuration\":1.7999999970197678,\"dnsDuration\":0,\"connectionDuration\":0.29999999701976776,\"requestDuration\":1}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -103,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 4.700000002980232
+                    "doubleValue": 3.199999988079071
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 4.700000002980232
+                    "doubleValue": 3.199999988079071
                   }
                 },
                 {
@@ -121,19 +127,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889228388-2417159675947"
+                    "stringValue": "v5-1779891712050-8546629562828"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 3
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 2
+                    "intValue": 3
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0CC0A105A1C4F656948BA3AEFD0DC967"
+                    "stringValue": "5F650AB5B1C4416DAC087A9FEBFFE205"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "424ECD84B5E3676E831CEB1ECB494985"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "424ECD84B5E3676E831CEB1ECB494985"
                   }
                 },
                 {
@@ -225,27 +225,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
+                    "stringValue": "E62008C4CD8604F767F1DABF8E1A3FF5"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889228405700195",
-              "observedTimeUnixNano": "1779889228405000000",
+              "timeUnixNano": "1779891712067599854",
+              "observedTimeUnixNano": "1779891712067000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":4.700000002980232,\"firstByteToFCP\":59.29999999701977,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":49.1000000089407,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.5,\"requestStart\":1.5,\"responseStart\":4.700000002980232,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.700000002980232,\"responseEnd\":4.799999997019768,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.700000002980232,\"domContentLoadedEventStart\":49,\"domContentLoadedEventEnd\":49,\"domComplete\":49,\"loadEventStart\":49,\"loadEventEnd\":49.1000000089407,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":64,\"duration\":0,\"paintTime\":58.20000000298023,\"presentationTime\":64}}"
+                "stringValue": "{\"timeToFirstByte\":3.199999988079071,\"firstByteToFCP\":60.80000001192093,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -273,19 +279,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889228388-7792731886832"
+                    "stringValue": "v5-1779891712050-3268541825511"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "3262555AC105DAE77EB9844486EDFD40"
+                    "stringValue": "FAE25204A787A1226BE315272F9E3650"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "424ECD84B5E3676E831CEB1ECB494985"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "424ECD84B5E3676E831CEB1ECB494985"
                   }
                 },
                 {
@@ -341,13 +341,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
+                    "stringValue": "E62008C4CD8604F767F1DABF8E1A3FF5"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
@@ -361,8 +361,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889228516300049",
-              "observedTimeUnixNano": "1779889228516000000",
+              "timeUnixNano": "1779891712176500000",
+              "observedTimeUnixNano": "1779891712176000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -378,13 +378,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at nf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115001)\n    at Ry.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231013\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:230985)\n    at eg (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127510)"
+                    "stringValue": "Error\n    at nf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:115001)\n    at Ry.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231311\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231283)\n    at eg (http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127510)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:126\":\"befe0c236b73acf40d3eccdcd08328e6\"}"
                   }
                 },
                 {
@@ -396,13 +396,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "C1D1700FB1CB39D702C62A740A01D6FD"
+                    "stringValue": "9705950354DEB4AC4D9A0DABBA7CE154"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "424ECD84B5E3676E831CEB1ECB494985"
                   }
                 },
                 {
@@ -414,7 +414,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "424ECD84B5E3676E831CEB1ECB494985"
                   }
                 },
                 {
@@ -426,7 +426,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
+                    "stringValue": "E62008C4CD8604F767F1DABF8E1A3FF5"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-session.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "85B0BCB3FADA0B7A69248FE937A6B753"
+              "stringValue": "3B2D72CBC2A6148E4879E32F1AF4B142"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "4414096d351089d3bd58b98a1ea1d957",
-              "spanId": "916da948a004ce34",
+              "traceId": "1f864f1162b1d5034d60f0277fcf706e",
+              "spanId": "2342d77190d1bac4",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1778792195058000000",
-              "endTimeUnixNano": "1778792195224500000",
+              "startTimeUnixNano": "1779889227976000000",
+              "endTimeUnixNano": "1779889228106300049",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "199CA8C02F3291650EADCF33F469D653"
+                    "stringValue": "3E1B45D882B31DFAE7619782070721C5"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "199CA8C02F3291650EADCF33F469D653"
+                    "stringValue": "3E1B45D882B31DFAE7619782070721C5"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "doubleValue": 1778792195057.6
+                    "doubleValue": 1779889227975.7
                   }
                 },
                 {
@@ -167,7 +167,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "2CE350DFCD01FCA53D0E6EB0CE762A81"
+                    "stringValue": "F0B08A0B39B57A6FF6CD82B604A64BF9"
                   }
                 },
                 {
@@ -191,7 +191,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 11
+                    "intValue": 6
                   }
                 },
                 {
@@ -220,226 +220,7 @@
                 }
               ],
               "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "TTFB"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1778792195061-9058721366708"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "doubleValue": 6.700000002980232
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "doubleValue": 6.700000002980232
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.waitingDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.cacheDuration",
-                      "value": {
-                        "doubleValue": 5.200000002980232
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.dnsDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.connectionDuration",
-                      "value": {
-                        "doubleValue": 0.20000000298023224
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.requestDuration",
-                      "value": {
-                        "doubleValue": 1.2999999970197678
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.redirect",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.domainLookup",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tcpConnection",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tlsNegotiation",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.serverResponse",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.unattributed",
-                      "value": {
-                        "intValue": 6
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1778792195066600098",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "FCP"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1778792195061-3272700941081"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "intValue": 72
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "intValue": 72
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.timeToFirstByte",
-                      "value": {
-                        "doubleValue": 6.700000002980232
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.firstByteToFCP",
-                      "value": {
-                        "doubleValue": 65.29999999701977
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.loadState",
-                      "value": {
-                        "stringValue": "complete"
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1778792195076800049",
-                  "droppedAttributesCount": 0
-                }
-              ],
+              "events": [],
               "droppedEventsCount": 0,
               "status": {
                 "code": 0
@@ -457,13 +238,13 @@
           },
           "spans": [
             {
-              "traceId": "39642d6c377321e33f23a15d8e7dc710",
-              "spanId": "2d3f080b76c2a258",
-              "parentSpanId": "2b2fe004d2fbc27f",
+              "traceId": "9dcb3784af747acb971b548eacf30706",
+              "spanId": "e6963ef9331c5336",
+              "parentSpanId": "2ea820e5404c286f",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1778792195003800049",
-              "endTimeUnixNano": "1778792195010900049",
+              "startTimeUnixNano": "1779889227930400049",
+              "endTimeUnixNano": "1779889227935300049",
               "attributes": [
                 {
                   "key": "url.full",
@@ -495,55 +276,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1778792195003800049",
+                  "timeUnixNano": "1779889227930400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1778792195009000049",
+                  "timeUnixNano": "1779889227931500049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1778792195009000049",
+                  "timeUnixNano": "1779889227931500049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1778792195009000049",
+                  "timeUnixNano": "1779889227931500049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1778792195003800049",
+                  "timeUnixNano": "1779889227930300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1778792195009200049",
+                  "timeUnixNano": "1779889227931600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1778792195009200049",
+                  "timeUnixNano": "1779889227931700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1778792195010500049",
+                  "timeUnixNano": "1779889227934900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1778792195010900049",
+                  "timeUnixNano": "1779889227935300049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -556,13 +337,13 @@
               "flags": 257
             },
             {
-              "traceId": "39642d6c377321e33f23a15d8e7dc710",
-              "spanId": "f0ddab65ba167fb3",
-              "parentSpanId": "2b2fe004d2fbc27f",
+              "traceId": "9dcb3784af747acb971b548eacf30706",
+              "spanId": "f1a1c91d9e6b3d13",
+              "parentSpanId": "2ea820e5404c286f",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1778792195012799951",
-              "endTimeUnixNano": "1778792195022199951",
+              "startTimeUnixNano": "1779889227937199902",
+              "endTimeUnixNano": "1779889227944099902",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -573,13 +354,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 389178
+                    "intValue": 389097
                   }
                 },
                 {
@@ -603,19 +384,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 389178
+                    "intValue": 389097
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 389478
+                    "intValue": 389397
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 389178
+                    "intValue": 389097
                   }
                 },
                 {
@@ -636,49 +417,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1778792195012799951",
+                  "timeUnixNano": "1779889227937199902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1778792195012799951",
+                  "timeUnixNano": "1779889227937199902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1778792195012799951",
+                  "timeUnixNano": "1779889227937199902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1778792195012799951",
+                  "timeUnixNano": "1779889227937199902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1778792195012799951",
+                  "timeUnixNano": "1779889227937199902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1778792195017099951",
+                  "timeUnixNano": "1779889227939899902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1778792195021299951",
+                  "timeUnixNano": "1779889227943399902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1778792195022199951",
+                  "timeUnixNano": "1779889227944099902",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -691,12 +472,12 @@
               "flags": 257
             },
             {
-              "traceId": "39642d6c377321e33f23a15d8e7dc710",
-              "spanId": "2b2fe004d2fbc27f",
+              "traceId": "9dcb3784af747acb971b548eacf30706",
+              "spanId": "2ea820e5404c286f",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1778792195003899902",
-              "endTimeUnixNano": "1778792195064399902",
+              "startTimeUnixNano": "1779889227930400049",
+              "endTimeUnixNano": "1779889227979000049",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -713,7 +494,7 @@
                 {
                   "key": "user_agent.original",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
                   }
                 },
                 {
@@ -733,38 +514,44 @@
               "events": [
                 {
                   "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1779889227930400049",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1778792195016299902",
+                  "timeUnixNano": "1779889227937900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1778792195064299902",
+                  "timeUnixNano": "1779889227978900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1778792195064399902",
+                  "timeUnixNano": "1779889227978900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1778792195064399902",
+                  "timeUnixNano": "1779889227978900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1778792195064399902",
+                  "timeUnixNano": "1779889227978900049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1778792195064399902",
+                  "timeUnixNano": "1779889227979000049",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
@@ -81,7 +81,7 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "name": "WebVitalsInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "B58405BBF2C94A31F0553B56BCA18F32"
+              "stringValue": "5B397FE18F84CADBE5934C0EB25409BE"
             }
           },
           {
@@ -86,14 +86,20 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889254298000000",
-              "observedTimeUnixNano": "1779889254299000000",
+              "timeUnixNano": "1779891736345000000",
+              "observedTimeUnixNano": "1779891736345000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":12,\"dnsDuration\":0,\"connectionDuration\":1,\"requestDuration\":0,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":180,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":-2,\"domainLookupStart\":12,\"domainLookupEnd\":12,\"connectStart\":12,\"connectEnd\":13,\"secureConnectionStart\":0,\"requestStart\":13,\"responseStart\":13,\"responseEnd\":13,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":49,\"domContentLoadedEventStart\":170,\"domContentLoadedEventEnd\":171,\"domComplete\":180,\"loadEventStart\":180,\"loadEventEnd\":180,\"type\":\"navigate\",\"redirectCount\":0}}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":56,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -103,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 13
+                    "intValue": 57
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 13
+                    "intValue": 57
                   }
                 },
                 {
@@ -121,19 +127,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889254280-7667808980621"
+                    "stringValue": "v5-1779891736332-7730316270108"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -171,7 +171,7 @@
                 {
                   "key": "emb.web_vital.attribution.tcpConnection",
                   "value": {
-                    "intValue": 1
+                    "intValue": 0
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 0
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 12
+                    "intValue": 56
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "308CE41A7419C86C2D0FDEFA83C50A56"
+                    "stringValue": "8C3BC505D0F3B109D8CC43F1C4333F43"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                    "stringValue": "5A0994BC28B63E2830A5B8E66104FEF0"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                    "stringValue": "5A0994BC28B63E2830A5B8E66104FEF0"
                   }
                 },
                 {
@@ -225,27 +225,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D49A2AE24A903122065353432BC94612"
+                    "stringValue": "38384AD1ED31A050A2C4C443D6F6A5EC"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889254302000000",
-              "observedTimeUnixNano": "1779889254303000000",
+              "timeUnixNano": "1779891736348000000",
+              "observedTimeUnixNano": "1779891736348000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":13,\"firstByteToFCP\":169,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":180,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":-2,\"domainLookupStart\":12,\"domainLookupEnd\":12,\"connectStart\":12,\"connectEnd\":13,\"secureConnectionStart\":0,\"requestStart\":13,\"responseStart\":13,\"responseEnd\":13,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":49,\"domContentLoadedEventStart\":170,\"domContentLoadedEventEnd\":171,\"domComplete\":180,\"loadEventStart\":180,\"loadEventEnd\":180,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":182,\"duration\":0,\"paintTime\":182,\"presentationTime\":null}}"
+                "stringValue": "{\"timeToFirstByte\":57,\"firstByteToFCP\":80,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -255,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 182
+                    "intValue": 137
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 182
+                    "intValue": 137
                   }
                 },
                 {
@@ -273,19 +279,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889254280-3059936461508"
+                    "stringValue": "v5-1779891736332-6120618542406"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "A3929A364AD650D6617660DAA0A1321C"
+                    "stringValue": "4350F044A8696263BDD79E17277FD544"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                    "stringValue": "5A0994BC28B63E2830A5B8E66104FEF0"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                    "stringValue": "5A0994BC28B63E2830A5B8E66104FEF0"
                   }
                 },
                 {
@@ -341,27 +341,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D49A2AE24A903122065353432BC94612"
+                    "stringValue": "38384AD1ED31A050A2C4C443D6F6A5EC"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889255162000000",
-              "observedTimeUnixNano": "1779889255163000000",
+              "timeUnixNano": "1779891736526000000",
+              "observedTimeUnixNano": "1779891736527000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":13,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":169,\"target\":\"#root>h1\",\"lcpEntry\":{\"name\":\"\",\"entryType\":\"largest-contentful-paint\",\"startTime\":182,\"duration\":0,\"renderTime\":182,\"loadTime\":0,\"size\":17201,\"id\":\"\",\"url\":\"\",\"paintTime\":182,\"presentationTime\":null},\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":180,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":-2,\"domainLookupStart\":12,\"domainLookupEnd\":12,\"connectStart\":12,\"connectEnd\":13,\"secureConnectionStart\":0,\"requestStart\":13,\"responseStart\":13,\"responseEnd\":13,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":49,\"domContentLoadedEventStart\":170,\"domContentLoadedEventEnd\":171,\"domComplete\":180,\"loadEventStart\":180,\"loadEventEnd\":180,\"type\":\"navigate\",\"redirectCount\":0}}"
+                "stringValue": "{\"timeToFirstByte\":57,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":80,\"target\":\"#root>h1\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -371,13 +377,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 182
+                    "intValue": 137
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 182
+                    "intValue": 137
                   }
                 },
                 {
@@ -389,19 +395,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889254280-2881726039766"
+                    "stringValue": "v5-1779891736332-1281537775616"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -427,13 +427,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "E06F1010AE3CE2599F3833E83EF02B32"
+                    "stringValue": "75A28C64751E53D8E6595FE9A98538B4"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                    "stringValue": "5A0994BC28B63E2830A5B8E66104FEF0"
                   }
                 },
                 {
@@ -445,7 +445,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                    "stringValue": "5A0994BC28B63E2830A5B8E66104FEF0"
                   }
                 },
                 {
@@ -457,13 +457,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D49A2AE24A903122065353432BC94612"
+                    "stringValue": "38384AD1ED31A050A2C4C443D6F6A5EC"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
@@ -477,8 +477,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889256733000000",
-              "observedTimeUnixNano": "1779889256733000000",
+              "timeUnixNano": "1779891736956000000",
+              "observedTimeUnixNano": "1779891736956000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -494,13 +494,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115001\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38001\nzM</kr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37542\nzM</UM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231013\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:966\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:786\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:230987\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127511\nzM</by/ec/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28401\nEventListener.handleEvent*ng@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128307\nWo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127707\nzM</by/tc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127873\ntc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127818\nzM</by/wr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:36448\nzM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231598\nfy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:680\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231652\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:115001\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:38001\nBM</kr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:37542\nBM</xM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231311\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:966\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:786\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231285\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127511\nBM</by/ec/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:28401\nEventListener.handleEvent*ng@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:128307\nWo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127707\nBM</by/tc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127873\ntc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127818\nBM</by/wr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:36448\nBM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231896\nfy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:680\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231950\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\\n\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:126\\n\":\"befe0c236b73acf40d3eccdcd08328e6\"}"
                   }
                 },
                 {
@@ -512,13 +512,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "118D7197FB90096F85322C7C25405CC7"
+                    "stringValue": "DB1E26EC47784181E3882EFC108AD951"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                    "stringValue": "5A0994BC28B63E2830A5B8E66104FEF0"
                   }
                 },
                 {
@@ -530,7 +530,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                    "stringValue": "5A0994BC28B63E2830A5B8E66104FEF0"
                   }
                 },
                 {
@@ -542,7 +542,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D49A2AE24A903122065353432BC94612"
+                    "stringValue": "38384AD1ED31A050A2C4C443D6F6A5EC"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "7B01BFC8E406076BA6D17DF7D56BAC87"
+              "stringValue": "B58405BBF2C94A31F0553B56BCA18F32"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:148.0.2) Gecko/20100101 Firefox/148.0.2"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
             }
           },
           {
@@ -81,12 +81,404 @@
       "scopeLogs": [
         {
           "scope": {
+            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "version": "1.0.0"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1779889254298000000",
+              "observedTimeUnixNano": "1779889254299000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":12,\"dnsDuration\":0,\"connectionDuration\":1,\"requestDuration\":0,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":180,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":-2,\"domainLookupStart\":12,\"domainLookupEnd\":12,\"connectStart\":12,\"connectEnd\":13,\"secureConnectionStart\":0,\"requestStart\":13,\"responseStart\":13,\"responseEnd\":13,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":49,\"domContentLoadedEventStart\":170,\"domContentLoadedEventEnd\":171,\"domComplete\":180,\"loadEventStart\":180,\"loadEventEnd\":180,\"type\":\"navigate\",\"redirectCount\":0}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "ttfb"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 13
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 13
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889254280-7667808980621"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.redirect",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.domainLookup",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.tcpConnection",
+                  "value": {
+                    "intValue": 1
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.tlsNegotiation",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.serverResponse",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.unattributed",
+                  "value": {
+                    "intValue": 12
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "308CE41A7419C86C2D0FDEFA83C50A56"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "D49A2AE24A903122065353432BC94612"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1779889254302000000",
+              "observedTimeUnixNano": "1779889254303000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":13,\"firstByteToFCP\":169,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":180,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":-2,\"domainLookupStart\":12,\"domainLookupEnd\":12,\"connectStart\":12,\"connectEnd\":13,\"secureConnectionStart\":0,\"requestStart\":13,\"responseStart\":13,\"responseEnd\":13,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":49,\"domContentLoadedEventStart\":170,\"domContentLoadedEventEnd\":171,\"domComplete\":180,\"loadEventStart\":180,\"loadEventEnd\":180,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":182,\"duration\":0,\"paintTime\":182,\"presentationTime\":null}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "fcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 182
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 182
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889254280-3059936461508"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "A3929A364AD650D6617660DAA0A1321C"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "D49A2AE24A903122065353432BC94612"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1779889255162000000",
+              "observedTimeUnixNano": "1779889255163000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":13,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":169,\"target\":\"#root>h1\",\"lcpEntry\":{\"name\":\"\",\"entryType\":\"largest-contentful-paint\",\"startTime\":182,\"duration\":0,\"renderTime\":182,\"loadTime\":0,\"size\":17201,\"id\":\"\",\"url\":\"\",\"paintTime\":182,\"presentationTime\":null},\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":180,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":-2,\"domainLookupStart\":12,\"domainLookupEnd\":12,\"connectStart\":12,\"connectEnd\":13,\"secureConnectionStart\":0,\"requestStart\":13,\"responseStart\":13,\"responseEnd\":13,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":49,\"domContentLoadedEventStart\":170,\"domContentLoadedEventEnd\":171,\"domComplete\":180,\"loadEventStart\":180,\"loadEventEnd\":180,\"type\":\"navigate\",\"redirectCount\":0}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "lcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 182
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 182
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889254280-2881726039766"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "E06F1010AE3CE2599F3833E83EF02B32"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "D49A2AE24A903122065353432BC94612"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            }
+          ]
+        },
+        {
+          "scope": {
             "name": "embrace-web-sdk-logs"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1778792214972000000",
-              "observedTimeUnixNano": "1778792214974000000",
+              "timeUnixNano": "1779889256733000000",
+              "observedTimeUnixNano": "1779889256733000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -102,13 +494,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:97695\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:38001\nHM</kr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:37542\nHM</zM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231094\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:966\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:786\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231068\nng@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:127511\nHM</Ey/Wo/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:132565\nud@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:15162\nWo@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:128746\nhc@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:28581\nty@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:28401\nEventListener.handleEvent*ig@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:128307\n$o@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:127707\nHM</Ey/Jo/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:127873\nJo@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:127818\nHM</Ey/Lr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:36448\nHM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231679\ncy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:680\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231733\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115001\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38001\nzM</kr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37542\nzM</UM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231013\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:966\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:786\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:230987\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127511\nzM</by/ec/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28401\nEventListener.handleEvent*ng@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128307\nWo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127707\nzM</by/tc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127873\ntc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127818\nzM</by/wr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:36448\nzM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231598\nfy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:680\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231652\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:11:126\\n\":\"05d1173f5302f5d00f1464789fc7459c\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\\n\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
                   }
                 },
                 {
@@ -120,13 +512,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "7A5772558A926FD0B1BCF60D82E97F6C"
+                    "stringValue": "118D7197FB90096F85322C7C25405CC7"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "A362E6DC236C60F4ECA281DCC536BE72"
+                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
                   }
                 },
                 {
@@ -138,7 +530,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "A362E6DC236C60F4ECA281DCC536BE72"
+                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
                   }
                 },
                 {
@@ -150,7 +542,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "5A89175EF725D8D9CC8A409E7D3D2F37"
+                    "stringValue": "D49A2AE24A903122065353432BC94612"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "CB5149257B5FDE6A151885B3ADFDFB8A"
+              "stringValue": "B58405BBF2C94A31F0553B56BCA18F32"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "2db424dfadc38c57e547cb8c28eb443d",
-              "spanId": "b371b40828bf153c",
+              "traceId": "6f39143391bcaef595e6707c191162b2",
+              "spanId": "88d2cabc1daa36c3",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1779311833151000000",
-              "endTimeUnixNano": "1779311833799000000",
+              "startTimeUnixNano": "1779889254279000000",
+              "endTimeUnixNano": "1779889257191000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "14432512D79A9253B7CC3744F7B95E6D"
+                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "14432512D79A9253B7CC3744F7B95E6D"
+                    "stringValue": "76024CD0C2A5EC1294269E393CB8A0EB"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1779311833150
+                    "intValue": 1779889254278
                   }
                 },
                 {
@@ -167,7 +167,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EDACDE15893D3F4E8685206CDED75F72"
+                    "stringValue": "D49A2AE24A903122065353432BC94612"
                   }
                 },
                 {
@@ -191,7 +191,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 6
+                    "intValue": 8
                   }
                 },
                 {
@@ -226,224 +226,6 @@
                     {
                       "key": "emb.type",
                       "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "TTFB"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1779311833152-6613369703351"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "intValue": 3
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "intValue": 3
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.waitingDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.cacheDuration",
-                      "value": {
-                        "intValue": 3
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.dnsDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.connectionDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.requestDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.redirect",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.domainLookup",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tcpConnection",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tlsNegotiation",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.serverResponse",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.unattributed",
-                      "value": {
-                        "intValue": 3
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1779311833156000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "FCP"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1779311833152-9029301470951"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "intValue": 53
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "intValue": 53
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.timeToFirstByte",
-                      "value": {
-                        "intValue": 3
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.firstByteToFCP",
-                      "value": {
-                        "intValue": 50
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.loadState",
-                      "value": {
-                        "stringValue": "complete"
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1779311833166000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
                         "stringValue": "ux.tap"
                       }
                     },
@@ -461,104 +243,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1779311833302000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "LCP"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1779311833152-7107773404668"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "intValue": 53
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "intValue": 53
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.timeToFirstByte",
-                      "value": {
-                        "intValue": 3
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.resourceLoadDelay",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.resourceLoadDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.elementRenderDelay",
-                      "value": {
-                        "intValue": 50
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.target",
-                      "value": {
-                        "stringValue": "#root>h1"
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-LCP",
-                  "timeUnixNano": "1779311833304000000",
+                  "timeUnixNano": "1779889255153000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -583,7 +268,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1779311833749000000",
+                  "timeUnixNano": "1779889256731000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -604,13 +289,13 @@
           },
           "spans": [
             {
-              "traceId": "b8d5da7139ac639a29d116a09b5a6700",
-              "spanId": "ec0e0377243b7c97",
-              "parentSpanId": "e7b4d8b1417ff495",
+              "traceId": "5b19dd930d6e4879bc336db1bc359ec8",
+              "spanId": "fc5c809565a6ff0f",
+              "parentSpanId": "a8313d362ee2c05c",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1779311833110000000",
-              "endTimeUnixNano": "1779311833114000000",
+              "startTimeUnixNano": "1779889254112000000",
+              "endTimeUnixNano": "1779889254127000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -642,55 +327,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1779311833110000000",
+                  "timeUnixNano": "1779889254112000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1779311833114000000",
+                  "timeUnixNano": "1779889254126000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1779311833114000000",
+                  "timeUnixNano": "1779889254126000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1779311833114000000",
+                  "timeUnixNano": "1779889254126000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1779311833111000000",
+                  "timeUnixNano": "1779889254114000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1779311833114000000",
+                  "timeUnixNano": "1779889254127000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1779311833114000000",
+                  "timeUnixNano": "1779889254127000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1779311833114000000",
+                  "timeUnixNano": "1779889254127000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1779311833114000000",
+                  "timeUnixNano": "1779889254127000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -703,13 +388,13 @@
               "flags": 257
             },
             {
-              "traceId": "b8d5da7139ac639a29d116a09b5a6700",
-              "spanId": "32e73ba5a273d438",
-              "parentSpanId": "e7b4d8b1417ff495",
+              "traceId": "5b19dd930d6e4879bc336db1bc359ec8",
+              "spanId": "faa695fcf4ae41d1",
+              "parentSpanId": "a8313d362ee2c05c",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1779311833122000000",
-              "endTimeUnixNano": "1779311833128000000",
+              "startTimeUnixNano": "1779889254161000000",
+              "endTimeUnixNano": "1779889254212000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -720,13 +405,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-D5XYgRNU.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 389343
+                    "intValue": 389097
                   }
                 },
                 {
@@ -744,19 +429,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 389343
+                    "intValue": 389097
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 389643
+                    "intValue": 389397
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 389343
+                    "intValue": 389097
                   }
                 },
                 {
@@ -777,49 +462,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1779311833122000000",
+                  "timeUnixNano": "1779889254161000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1779311833122000000",
+                  "timeUnixNano": "1779889254161000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1779311833122000000",
+                  "timeUnixNano": "1779889254161000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1779311833122000000",
+                  "timeUnixNano": "1779889254161000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1779311833122000000",
+                  "timeUnixNano": "1779889254161000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1779311833128000000",
+                  "timeUnixNano": "1779889254202000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1779311833128000000",
+                  "timeUnixNano": "1779889254212000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1779311833128000000",
+                  "timeUnixNano": "1779889254212000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -832,12 +517,12 @@
               "flags": 257
             },
             {
-              "traceId": "b8d5da7139ac639a29d116a09b5a6700",
-              "spanId": "e7b4d8b1417ff495",
+              "traceId": "5b19dd930d6e4879bc336db1bc359ec8",
+              "spanId": "a8313d362ee2c05c",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1779311833110000000",
-              "endTimeUnixNano": "1779311833158000000",
+              "startTimeUnixNano": "1779889254112000000",
+              "endTimeUnixNano": "1779889254294000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -875,43 +560,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1779311833110000000",
+                  "timeUnixNano": "1779889254112000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1779311833123000000",
+                  "timeUnixNano": "1779889254163000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1779311833154000000",
+                  "timeUnixNano": "1779889254284000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1779311833154000000",
+                  "timeUnixNano": "1779889254285000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1779311833157000000",
+                  "timeUnixNano": "1779889254294000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1779311833157000000",
+                  "timeUnixNano": "1779889254294000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1779311833158000000",
+                  "timeUnixNano": "1779889254294000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "firstContentfulPaint",
+                  "timeUnixNano": "1779889254296000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -932,12 +623,12 @@
           },
           "spans": [
             {
-              "traceId": "0688aabe706effca57a3538aa2dd3c38",
-              "spanId": "016f827f56da96cd",
+              "traceId": "0dad82ca875fbefff2250a30f224874b",
+              "spanId": "2faafe019e793e7d",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1779311833304000000",
-              "endTimeUnixNano": "1779311833307000000",
+              "startTimeUnixNano": "1779889255159000000",
+              "endTimeUnixNano": "1779889255897000000",
               "attributes": [
                 {
                   "key": "component",
@@ -1045,49 +736,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1779311833304000000",
+                  "timeUnixNano": "1779889255159000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1779311833304000000",
+                  "timeUnixNano": "1779889255159000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1779311833304000000",
+                  "timeUnixNano": "1779889255159000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1779311833304000000",
+                  "timeUnixNano": "1779889255159000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1779311833304000000",
+                  "timeUnixNano": "1779889255159000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1779311833304000000",
+                  "timeUnixNano": "1779889255159000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1779311833304000000",
+                  "timeUnixNano": "1779889255159000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1779311833304000000",
+                  "timeUnixNano": "1779889255159000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
@@ -81,7 +81,7 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "name": "WebVitalsInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "815AFF81DEE10556443E7336F94A7F2F"
+              "stringValue": "106A92D640314916A3C15E637BC6AC0B"
             }
           },
           {
@@ -86,14 +86,20 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889247850000000",
-              "observedTimeUnixNano": "1779889247851000000",
+              "timeUnixNano": "1779891729308000000",
+              "observedTimeUnixNano": "1779891729309000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":5,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":57,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":5,\"domainLookupEnd\":5,\"connectStart\":5,\"connectEnd\":5,\"secureConnectionStart\":0,\"requestStart\":5,\"responseStart\":6,\"responseEnd\":6,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":13,\"domContentLoadedEventStart\":53,\"domContentLoadedEventEnd\":53,\"domComplete\":57,\"loadEventStart\":57,\"loadEventEnd\":57,\"type\":\"navigate\",\"redirectCount\":0}}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":34,\"dnsDuration\":0,\"connectionDuration\":1,\"requestDuration\":1}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -103,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 6
+                    "intValue": 36
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 6
+                    "intValue": 36
                   }
                 },
                 {
@@ -121,19 +127,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889247843-8940366157785"
+                    "stringValue": "v5-1779891729293-5300114366808"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -171,7 +171,7 @@
                 {
                   "key": "emb.web_vital.attribution.tcpConnection",
                   "value": {
-                    "intValue": 0
+                    "intValue": 1
                   }
                 },
                 {
@@ -189,19 +189,19 @@
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 5
+                    "intValue": 34
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "B1F71EAD0392404451F0B7C6D384DEDB"
+                    "stringValue": "7E8F01B5B7543D570529962D87964AB4"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "9A06EAF2F907878038D8529D14215BE1"
+                    "stringValue": "6DE95784F2FD505AE96BFB47EC26B18C"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "9A06EAF2F907878038D8529D14215BE1"
+                    "stringValue": "6DE95784F2FD505AE96BFB47EC26B18C"
                   }
                 },
                 {
@@ -225,27 +225,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "372AD6CD1580E363D184AF3B76826657"
+                    "stringValue": "D079E8714FB392B408F30D6DA6470460"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889247851000000",
-              "observedTimeUnixNano": "1779889247852000000",
+              "timeUnixNano": "1779891729310000000",
+              "observedTimeUnixNano": "1779891729312000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":6,\"firstByteToFCP\":51,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":57,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":5,\"domainLookupEnd\":5,\"connectStart\":5,\"connectEnd\":5,\"secureConnectionStart\":0,\"requestStart\":5,\"responseStart\":6,\"responseEnd\":6,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":13,\"domContentLoadedEventStart\":53,\"domContentLoadedEventEnd\":53,\"domComplete\":57,\"loadEventStart\":57,\"loadEventEnd\":57,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":57,\"duration\":0,\"paintTime\":57,\"presentationTime\":null}}"
+                "stringValue": "{\"timeToFirstByte\":36,\"firstByteToFCP\":88,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -255,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 57
+                    "intValue": 124
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 57
+                    "intValue": 124
                   }
                 },
                 {
@@ -273,19 +279,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889247843-8363715482300"
+                    "stringValue": "v5-1779891729293-2583988180364"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "3DF89D7641DD19F5DBE1BBC982DAF0B2"
+                    "stringValue": "B8EC96E5EFBB6E7F5478F4EF6A7A96A5"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "9A06EAF2F907878038D8529D14215BE1"
+                    "stringValue": "6DE95784F2FD505AE96BFB47EC26B18C"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "9A06EAF2F907878038D8529D14215BE1"
+                    "stringValue": "6DE95784F2FD505AE96BFB47EC26B18C"
                   }
                 },
                 {
@@ -341,13 +341,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "372AD6CD1580E363D184AF3B76826657"
+                    "stringValue": "D079E8714FB392B408F30D6DA6470460"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "57EA43C93BE035FD40FA4B1A78B46E8C"
+              "stringValue": "815AFF81DEE10556443E7336F94A7F2F"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889228391900146",
-              "observedTimeUnixNano": "1779889228392000000",
+              "timeUnixNano": "1779889247850000000",
+              "observedTimeUnixNano": "1779889247851000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":1.2000000029802322,\"dnsDuration\":0,\"connectionDuration\":0.29999999701976776,\"requestDuration\":3.2000000029802322,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":49.1000000089407,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.5,\"requestStart\":1.5,\"responseStart\":4.700000002980232,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.700000002980232,\"responseEnd\":4.799999997019768,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.700000002980232,\"domContentLoadedEventStart\":49,\"domContentLoadedEventEnd\":49,\"domComplete\":49,\"loadEventStart\":49,\"loadEventEnd\":49.1000000089407,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}}}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":5,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":57,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":5,\"domainLookupEnd\":5,\"connectStart\":5,\"connectEnd\":5,\"secureConnectionStart\":0,\"requestStart\":5,\"responseStart\":6,\"responseEnd\":6,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":13,\"domContentLoadedEventStart\":53,\"domContentLoadedEventEnd\":53,\"domComplete\":57,\"loadEventStart\":57,\"loadEventEnd\":57,\"type\":\"navigate\",\"redirectCount\":0}}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -103,13 +103,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 4.700000002980232
+                    "intValue": 6
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 4.700000002980232
+                    "intValue": 6
                   }
                 },
                 {
@@ -121,7 +121,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889228388-2417159675947"
+                    "stringValue": "v5-1779889247843-8940366157785"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 3
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 2
+                    "intValue": 5
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0CC0A105A1C4F656948BA3AEFD0DC967"
+                    "stringValue": "B1F71EAD0392404451F0B7C6D384DEDB"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "9A06EAF2F907878038D8529D14215BE1"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "9A06EAF2F907878038D8529D14215BE1"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
+                    "stringValue": "372AD6CD1580E363D184AF3B76826657"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889228405700195",
-              "observedTimeUnixNano": "1779889228405000000",
+              "timeUnixNano": "1779889247851000000",
+              "observedTimeUnixNano": "1779889247852000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":4.700000002980232,\"firstByteToFCP\":59.29999999701977,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":49.1000000089407,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.5,\"requestStart\":1.5,\"responseStart\":4.700000002980232,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.700000002980232,\"responseEnd\":4.799999997019768,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.700000002980232,\"domContentLoadedEventStart\":49,\"domContentLoadedEventEnd\":49,\"domComplete\":49,\"loadEventStart\":49,\"loadEventEnd\":49.1000000089407,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":64,\"duration\":0,\"paintTime\":58.20000000298023,\"presentationTime\":64}}"
+                "stringValue": "{\"timeToFirstByte\":6,\"firstByteToFCP\":51,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":57,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":5,\"domainLookupEnd\":5,\"connectStart\":5,\"connectEnd\":5,\"secureConnectionStart\":0,\"requestStart\":5,\"responseStart\":6,\"responseEnd\":6,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":13,\"domContentLoadedEventStart\":53,\"domContentLoadedEventEnd\":53,\"domComplete\":57,\"loadEventStart\":57,\"loadEventEnd\":57,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":57,\"duration\":0,\"paintTime\":57,\"presentationTime\":null}}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -255,13 +255,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 64
+                    "intValue": 57
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 64
+                    "intValue": 57
                   }
                 },
                 {
@@ -273,7 +273,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889228388-7792731886832"
+                    "stringValue": "v5-1779889247843-8363715482300"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "3262555AC105DAE77EB9844486EDFD40"
+                    "stringValue": "3DF89D7641DD19F5DBE1BBC982DAF0B2"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "9A06EAF2F907878038D8529D14215BE1"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "9A06EAF2F907878038D8529D14215BE1"
                   }
                 },
                 {
@@ -341,110 +341,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
+                    "stringValue": "372AD6CD1580E363D184AF3B76826657"
                   }
                 },
                 {
                   "key": "emb.type",
                   "value": {
                     "stringValue": "sys.log"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            }
-          ]
-        },
-        {
-          "scope": {
-            "name": "embrace-web-sdk-logs"
-          },
-          "logRecords": [
-            {
-              "timeUnixNano": "1779889228516300049",
-              "observedTimeUnixNano": "1779889228516000000",
-              "severityNumber": 13,
-              "severityText": "WARNING",
-              "body": {
-                "stringValue": "This is a test log message"
-              },
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "sys.log"
-                  }
-                },
-                {
-                  "key": "emb.stacktrace.js",
-                  "value": {
-                    "stringValue": "Error\n    at nf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115001)\n    at Ry.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231013\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:230985)\n    at eg (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127510)"
-                  }
-                },
-                {
-                  "key": "emb.js_file_bundle_ids",
-                  "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
-                  }
-                },
-                {
-                  "key": "emb.state",
-                  "value": {
-                    "stringValue": "foreground"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "C1D1700FB1CB39D702C62A740A01D6FD"
-                  }
-                },
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
-                  }
-                },
-                {
-                  "key": "session.previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
                   }
                 }
               ],

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
@@ -81,7 +81,7 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "name": "WebVitalsInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "D6457A450766BDA3FCB024A722FB02D0"
+              "stringValue": "D886847CA44C3C9CA561D7C2D5C59471"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:148.0.2) Gecko/20100101 Firefox/148.0.2"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
             }
           },
           {
@@ -81,12 +81,288 @@
       "scopeLogs": [
         {
           "scope": {
+            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "version": "1.0.0"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1779889248768000000",
+              "observedTimeUnixNano": "1779889248769000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":5,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":3,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":83,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":-2,\"domainLookupStart\":5,\"domainLookupEnd\":5,\"connectStart\":5,\"connectEnd\":5,\"secureConnectionStart\":0,\"requestStart\":5,\"responseStart\":8,\"responseEnd\":8,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":20,\"domContentLoadedEventStart\":75,\"domContentLoadedEventEnd\":75,\"domComplete\":82,\"loadEventStart\":82,\"loadEventEnd\":83,\"type\":\"navigate\",\"redirectCount\":0}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "ttfb"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 8
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 8
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889248750-5447533704192"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.redirect",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.domainLookup",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.tcpConnection",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.tlsNegotiation",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.serverResponse",
+                  "value": {
+                    "intValue": 3
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.unattributed",
+                  "value": {
+                    "intValue": 5
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "BB1A229397B19628FD0C1B1E79E1573C"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "7023A518BA04BDF80C107BBC79CA805B"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1779889248770000000",
+              "observedTimeUnixNano": "1779889248771000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":8,\"firstByteToFCP\":75,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":83,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":-2,\"domainLookupStart\":5,\"domainLookupEnd\":5,\"connectStart\":5,\"connectEnd\":5,\"secureConnectionStart\":0,\"requestStart\":5,\"responseStart\":8,\"responseEnd\":8,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":20,\"domContentLoadedEventStart\":75,\"domContentLoadedEventEnd\":75,\"domComplete\":82,\"loadEventStart\":82,\"loadEventEnd\":83,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":83,\"duration\":0,\"paintTime\":83,\"presentationTime\":null}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "fcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 83
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 83
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889248750-6433937788266"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "5061F510A91EA5253D1327582FFE92F2"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "7023A518BA04BDF80C107BBC79CA805B"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            }
+          ]
+        },
+        {
+          "scope": {
             "name": "embrace-web-sdk-logs"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1778792211097000000",
-              "observedTimeUnixNano": "1778792211097000000",
+              "timeUnixNano": "1779889248992000000",
+              "observedTimeUnixNano": "1779889248994000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -102,13 +378,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:97695\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:38001\nHM</kr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:37542\nHM</zM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231094\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:966\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:786\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231068\nng@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:127511\nHM</Ey/Wo/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:132565\nud@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:15162\nWo@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:128746\nhc@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:28581\nty@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:28401\nEventListener.handleEvent*ig@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:128307\n$o@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:127707\nHM</Ey/Jo/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:127873\nJo@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:127818\nHM</Ey/Lr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:36448\nHM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231679\ncy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:680\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231733\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115001\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38001\nzM</kr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37542\nzM</UM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231013\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:966\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:786\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:230987\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127511\nzM</by/ec/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28401\nEventListener.handleEvent*ng@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128307\nWo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127707\nzM</by/tc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127873\ntc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127818\nzM</by/wr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:36448\nzM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231598\nfy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:680\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231652\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:11:126\\n\":\"05d1173f5302f5d00f1464789fc7459c\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\\n\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
                   }
                 },
                 {
@@ -120,13 +396,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "EA877CAFCF8BAA2B42BE852BC9A2DAA3"
+                    "stringValue": "5A24FBFA7DAB97A077E033316BB89181"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "6FD1E17219CB7826B45965E6CCF6DB80"
+                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
                   }
                 },
                 {
@@ -138,7 +414,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "6FD1E17219CB7826B45965E6CCF6DB80"
+                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
                   }
                 },
                 {
@@ -150,7 +426,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "66818198F610F9EE55130B337CF5B899"
+                    "stringValue": "7023A518BA04BDF80C107BBC79CA805B"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "D886847CA44C3C9CA561D7C2D5C59471"
+              "stringValue": "6BFFDBE29366F1B2B7143863793D54FE"
             }
           },
           {
@@ -86,14 +86,20 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889248768000000",
-              "observedTimeUnixNano": "1779889248769000000",
+              "timeUnixNano": "1779891730237000000",
+              "observedTimeUnixNano": "1779891730238000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":5,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":3,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":83,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":-2,\"domainLookupStart\":5,\"domainLookupEnd\":5,\"connectStart\":5,\"connectEnd\":5,\"secureConnectionStart\":0,\"requestStart\":5,\"responseStart\":8,\"responseEnd\":8,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":20,\"domContentLoadedEventStart\":75,\"domContentLoadedEventEnd\":75,\"domComplete\":82,\"loadEventStart\":82,\"loadEventEnd\":83,\"type\":\"navigate\",\"redirectCount\":0}}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":32,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -103,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 8
+                    "intValue": 33
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 8
+                    "intValue": 33
                   }
                 },
                 {
@@ -121,19 +127,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889248750-5447533704192"
+                    "stringValue": "v5-1779891730229-7191451711516"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 3
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 5
+                    "intValue": 32
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "BB1A229397B19628FD0C1B1E79E1573C"
+                    "stringValue": "39DD690AD963EDE81E81BB7AEEAB2022"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
+                    "stringValue": "1877C2B4BFFF69172185565738EA95CD"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
+                    "stringValue": "1877C2B4BFFF69172185565738EA95CD"
                   }
                 },
                 {
@@ -225,27 +225,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "7023A518BA04BDF80C107BBC79CA805B"
+                    "stringValue": "B914D38768D8ED5C44A38D68A4FBED5C"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889248770000000",
-              "observedTimeUnixNano": "1779889248771000000",
+              "timeUnixNano": "1779891730250000000",
+              "observedTimeUnixNano": "1779891730251000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":8,\"firstByteToFCP\":75,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":83,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":-2,\"domainLookupStart\":5,\"domainLookupEnd\":5,\"connectStart\":5,\"connectEnd\":5,\"secureConnectionStart\":0,\"requestStart\":5,\"responseStart\":8,\"responseEnd\":8,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"contentType\":\"text/html\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":20,\"domContentLoadedEventStart\":75,\"domContentLoadedEventEnd\":75,\"domComplete\":82,\"loadEventStart\":82,\"loadEventEnd\":83,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":83,\"duration\":0,\"paintTime\":83,\"presentationTime\":null}}"
+                "stringValue": "{\"timeToFirstByte\":33,\"firstByteToFCP\":64,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -255,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 83
+                    "intValue": 97
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 83
+                    "intValue": 97
                   }
                 },
                 {
@@ -273,19 +279,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889248750-6433937788266"
+                    "stringValue": "v5-1779891730229-5710496338608"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "5061F510A91EA5253D1327582FFE92F2"
+                    "stringValue": "3FE556C207FDDEE1425CF8EC996EFDA7"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
+                    "stringValue": "1877C2B4BFFF69172185565738EA95CD"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
+                    "stringValue": "1877C2B4BFFF69172185565738EA95CD"
                   }
                 },
                 {
@@ -341,13 +341,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "7023A518BA04BDF80C107BBC79CA805B"
+                    "stringValue": "B914D38768D8ED5C44A38D68A4FBED5C"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
@@ -361,8 +361,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889248992000000",
-              "observedTimeUnixNano": "1779889248994000000",
+              "timeUnixNano": "1779891730517000000",
+              "observedTimeUnixNano": "1779891730518000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -378,13 +378,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115001\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38001\nzM</kr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37542\nzM</UM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231013\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:966\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:786\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:230987\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127511\nzM</by/ec/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28401\nEventListener.handleEvent*ng@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128307\nWo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127707\nzM</by/tc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127873\ntc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127818\nzM</by/wr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:36448\nzM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231598\nfy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:680\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231652\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:115001\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:38001\nBM</kr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:37542\nBM</xM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231311\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:966\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:786\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231285\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127511\nBM</by/ec/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:28401\nEventListener.handleEvent*ng@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:128307\nWo@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127707\nBM</by/tc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127873\ntc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127818\nBM</by/wr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:36448\nBM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231896\nfy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:680\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231950\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\\n\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:126\\n\":\"befe0c236b73acf40d3eccdcd08328e6\"}"
                   }
                 },
                 {
@@ -396,13 +396,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "5A24FBFA7DAB97A077E033316BB89181"
+                    "stringValue": "A3346029193CBD430C4C49ED99F882C1"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
+                    "stringValue": "1877C2B4BFFF69172185565738EA95CD"
                   }
                 },
                 {
@@ -414,7 +414,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "626CA246A651A1F60FBBE410C8734999"
+                    "stringValue": "1877C2B4BFFF69172185565738EA95CD"
                   }
                 },
                 {
@@ -426,7 +426,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "7023A518BA04BDF80C107BBC79CA805B"
+                    "stringValue": "B914D38768D8ED5C44A38D68A4FBED5C"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "32789F08E8840DE48AA0B9428D61E9B5"
+              "stringValue": "815AFF81DEE10556443E7336F94A7F2F"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:148.0.2) Gecko/20100101 Firefox/148.0.2"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "9943e12d505cfc89cf21b34c74f82e84",
-              "spanId": "1fd8309f29bbeb62",
+              "traceId": "754fbc5203540d406314553a375b0b4f",
+              "spanId": "ebe02379ba7f1d23",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1778792210286000000",
-              "endTimeUnixNano": "1778792210581000000",
+              "startTimeUnixNano": "1779889247842000000",
+              "endTimeUnixNano": "1779889248010000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "D7DDCDC56793CE4C0623B275AFC1EC6C"
+                    "stringValue": "9A06EAF2F907878038D8529D14215BE1"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "D7DDCDC56793CE4C0623B275AFC1EC6C"
+                    "stringValue": "9A06EAF2F907878038D8529D14215BE1"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1778792210285
+                    "intValue": 1779889247841
                   }
                 },
                 {
@@ -167,7 +167,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "3085B766A688B6DE490313244B21BBCF"
+                    "stringValue": "372AD6CD1580E363D184AF3B76826657"
                   }
                 },
                 {
@@ -191,7 +191,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 5
+                    "intValue": 7
                   }
                 },
                 {
@@ -220,226 +220,7 @@
                 }
               ],
               "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "TTFB"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1778792210287-6745376010648"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "intValue": 3
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "intValue": 3
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.waitingDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.cacheDuration",
-                      "value": {
-                        "intValue": 2
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.dnsDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.connectionDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.requestDuration",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.redirect",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.domainLookup",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tcpConnection",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tlsNegotiation",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.serverResponse",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.unattributed",
-                      "value": {
-                        "intValue": 2
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1778792210291000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "FCP"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1778792210286-6309553423094"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "intValue": 58
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "intValue": 58
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.timeToFirstByte",
-                      "value": {
-                        "intValue": 3
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.firstByteToFCP",
-                      "value": {
-                        "intValue": 55
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.loadState",
-                      "value": {
-                        "stringValue": "complete"
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1778792210295000000",
-                  "droppedAttributesCount": 0
-                }
-              ],
+              "events": [],
               "droppedEventsCount": 0,
               "status": {
                 "code": 0
@@ -457,13 +238,13 @@
           },
           "spans": [
             {
-              "traceId": "b0ee994ae3c82d7904a992a131936142",
-              "spanId": "af98425795b26b0f",
-              "parentSpanId": "b325598b2b01148a",
+              "traceId": "0f0428332e3339fe82965a2c2e761257",
+              "spanId": "201949436390bc09",
+              "parentSpanId": "de90197caf46430b",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1778792210238000000",
-              "endTimeUnixNano": "1778792210242000000",
+              "startTimeUnixNano": "1779889247792000000",
+              "endTimeUnixNano": "1779889247798000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -495,55 +276,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1778792210238000000",
+                  "timeUnixNano": "1779889247792000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1778792210241000000",
+                  "timeUnixNano": "1779889247797000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1778792210241000000",
+                  "timeUnixNano": "1779889247797000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1778792210241000000",
+                  "timeUnixNano": "1779889247797000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1778792210239000000",
+                  "timeUnixNano": "1779889247792000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1778792210241000000",
+                  "timeUnixNano": "1779889247797000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1778792210241000000",
+                  "timeUnixNano": "1779889247797000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1778792210242000000",
+                  "timeUnixNano": "1779889247798000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1778792210242000000",
+                  "timeUnixNano": "1779889247798000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -556,13 +337,13 @@
               "flags": 257
             },
             {
-              "traceId": "b0ee994ae3c82d7904a992a131936142",
-              "spanId": "6eb09c412333f2a2",
-              "parentSpanId": "b325598b2b01148a",
+              "traceId": "0f0428332e3339fe82965a2c2e761257",
+              "spanId": "8ac95b8c9de141ec",
+              "parentSpanId": "de90197caf46430b",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1778792210246000000",
-              "endTimeUnixNano": "1778792210254000000",
+              "startTimeUnixNano": "1779889247804000000",
+              "endTimeUnixNano": "1779889247819000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -573,13 +354,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 389178
+                    "intValue": 389097
                   }
                 },
                 {
@@ -597,19 +378,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 389178
+                    "intValue": 389097
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 389478
+                    "intValue": 389397
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 389178
+                    "intValue": 389097
                   }
                 },
                 {
@@ -630,49 +411,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1778792210246000000",
+                  "timeUnixNano": "1779889247804000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1778792210246000000",
+                  "timeUnixNano": "1779889247804000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1778792210246000000",
+                  "timeUnixNano": "1779889247804000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1778792210246000000",
+                  "timeUnixNano": "1779889247804000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1778792210246000000",
+                  "timeUnixNano": "1779889247804000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1778792210252000000",
+                  "timeUnixNano": "1779889247817000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1778792210253000000",
+                  "timeUnixNano": "1779889247818000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1778792210254000000",
+                  "timeUnixNano": "1779889247819000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -685,12 +466,12 @@
               "flags": 257
             },
             {
-              "traceId": "b0ee994ae3c82d7904a992a131936142",
-              "spanId": "b325598b2b01148a",
+              "traceId": "0f0428332e3339fe82965a2c2e761257",
+              "spanId": "de90197caf46430b",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1778792210237000000",
-              "endTimeUnixNano": "1778792210292000000",
+              "startTimeUnixNano": "1779889247792000000",
+              "endTimeUnixNano": "1779889247849000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -707,7 +488,7 @@
                 {
                   "key": "user_agent.original",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:148.0.2) Gecko/20100101 Firefox/148.0.2"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
                   }
                 },
                 {
@@ -727,44 +508,44 @@
               "events": [
                 {
                   "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1778792210237000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1778792210245000000",
+                  "timeUnixNano": "1779889247805000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1778792210288000000",
+                  "timeUnixNano": "1779889247845000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1778792210289000000",
+                  "timeUnixNano": "1779889247845000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1778792210292000000",
+                  "timeUnixNano": "1779889247849000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1778792210292000000",
+                  "timeUnixNano": "1779889247849000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1778792210292000000",
+                  "timeUnixNano": "1779889247849000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "firstContentfulPaint",
+                  "timeUnixNano": "1779889247849000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
@@ -81,7 +81,7 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "name": "WebVitalsInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "DC6A3853C59396A073C450E3E074D7EB"
+              "stringValue": "D18A41829D94EF282D91B069D958F282"
             }
           },
           {
@@ -86,14 +86,20 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889264864000244",
-              "observedTimeUnixNano": "1779889264865000000",
+              "timeUnixNano": "1779891749304000000",
+              "observedTimeUnixNano": "1779891749304000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":4,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":36.00000000000001,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":4,\"domainLookupStart\":4,\"domainLookupEnd\":4,\"connectStart\":4,\"connectEnd\":4,\"secureConnectionStart\":0,\"requestStart\":4,\"finalResponseHeadersStart\":5,\"firstInterimResponseStart\":0,\"responseStart\":5,\"responseEnd\":5,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":36.00000000000001,\"loadEventEnd\":36.00000000000001,\"type\":\"navigate\",\"redirectCount\":0}}"
+                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":0}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -103,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 5
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 5
+                    "intValue": 1
                   }
                 },
                 {
@@ -121,19 +127,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889264862-9330581810850"
+                    "stringValue": "v5-1779891749302-9279469787361"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 1
+                    "intValue": 0
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 4
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "F81826A8697FA3889093C2568D463080"
+                    "stringValue": "FF2525D6A25CE8BC5408D61B28E2D4E0"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                    "stringValue": "8BC49251E2CF4686D6CD9C370F3BF149"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                    "stringValue": "8BC49251E2CF4686D6CD9C370F3BF149"
                   }
                 },
                 {
@@ -225,27 +225,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EE860FEC9B16AD76490A3819A3ECE123"
+                    "stringValue": "5DEA6C3DF9E3A837AC746D6B2274537F"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889264874000244",
-              "observedTimeUnixNano": "1779889264874000000",
+              "timeUnixNano": "1779891749311000000",
+              "observedTimeUnixNano": "1779891749311000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":5,\"firstByteToFCP\":41,\"loadState\":\"dom-interactive\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":36.00000000000001,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":4,\"domainLookupStart\":4,\"domainLookupEnd\":4,\"connectStart\":4,\"connectEnd\":4,\"secureConnectionStart\":0,\"requestStart\":4,\"finalResponseHeadersStart\":5,\"firstInterimResponseStart\":0,\"responseStart\":5,\"responseEnd\":5,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":36.00000000000001,\"loadEventEnd\":36.00000000000001,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":46,\"duration\":0}}"
+                "stringValue": "{\"timeToFirstByte\":1,\"firstByteToFCP\":29,\"loadState\":\"dom-interactive\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -255,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 46
+                    "intValue": 30
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 46
+                    "intValue": 30
                   }
                 },
                 {
@@ -273,19 +279,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889264861-5539601731518"
+                    "stringValue": "v5-1779891749302-6456874041349"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "359313702088DAEB4F633371AAF1902E"
+                    "stringValue": "8302943E2B960AB97CB05D82E8764CD0"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                    "stringValue": "8BC49251E2CF4686D6CD9C370F3BF149"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                    "stringValue": "8BC49251E2CF4686D6CD9C370F3BF149"
                   }
                 },
                 {
@@ -341,27 +341,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EE860FEC9B16AD76490A3819A3ECE123"
+                    "stringValue": "5DEA6C3DF9E3A837AC746D6B2274537F"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889265001000244",
-              "observedTimeUnixNano": "1779889265002000000",
+              "timeUnixNano": "1779891749425000000",
+              "observedTimeUnixNano": "1779891749426000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":5,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":41,\"target\":\"#root>h1\",\"lcpEntry\":{\"name\":\"\",\"entryType\":\"largest-contentful-paint\",\"startTime\":46,\"duration\":0,\"loadTime\":0,\"renderTime\":46,\"size\":19216,\"id\":\"\",\"url\":\"\",\"paintTime\":46,\"presentationTime\":null},\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":36.00000000000001,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":4,\"domainLookupStart\":4,\"domainLookupEnd\":4,\"connectStart\":4,\"connectEnd\":4,\"secureConnectionStart\":0,\"requestStart\":4,\"finalResponseHeadersStart\":5,\"firstInterimResponseStart\":0,\"responseStart\":5,\"responseEnd\":5,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":36.00000000000001,\"loadEventEnd\":36.00000000000001,\"type\":\"navigate\",\"redirectCount\":0}}"
+                "stringValue": "{\"timeToFirstByte\":1,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":29,\"target\":\"#root>h1\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -371,13 +377,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 46
+                    "intValue": 30
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 46
+                    "intValue": 30
                   }
                 },
                 {
@@ -389,19 +395,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889264861-6811001789444"
+                    "stringValue": "v5-1779891749302-2810994145298"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -427,13 +427,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "423A2FF01862BD9D8C17AF6B44BACFD3"
+                    "stringValue": "F2464FB707FB2D32FF38BF28E6970E5B"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                    "stringValue": "8BC49251E2CF4686D6CD9C370F3BF149"
                   }
                 },
                 {
@@ -445,7 +445,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                    "stringValue": "8BC49251E2CF4686D6CD9C370F3BF149"
                   }
                 },
                 {
@@ -457,13 +457,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EE860FEC9B16AD76490A3819A3ECE123"
+                    "stringValue": "5DEA6C3DF9E3A837AC746D6B2274537F"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
@@ -477,8 +477,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889265419000244",
-              "observedTimeUnixNano": "1779889265420000000",
+              "timeUnixNano": "1779891749840000000",
+              "observedTimeUnixNano": "1779891749841000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -494,13 +494,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115010\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231020\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:797\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28403"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:115010\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231318\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:797\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:28403"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:126\":\"befe0c236b73acf40d3eccdcd08328e6\"}"
                   }
                 },
                 {
@@ -512,13 +512,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0F542934AC2FA37B6FD5530C5E091C94"
+                    "stringValue": "869D3DE151354F919430DDED59795E1B"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                    "stringValue": "8BC49251E2CF4686D6CD9C370F3BF149"
                   }
                 },
                 {
@@ -530,7 +530,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                    "stringValue": "8BC49251E2CF4686D6CD9C370F3BF149"
                   }
                 },
                 {
@@ -542,7 +542,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EE860FEC9B16AD76490A3819A3ECE123"
+                    "stringValue": "5DEA6C3DF9E3A837AC746D6B2274537F"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "41D6A8A930D793AB9799D8E40CCCCAAA"
+              "stringValue": "DC6A3853C59396A073C450E3E074D7EB"
             }
           },
           {
@@ -81,12 +81,404 @@
       "scopeLogs": [
         {
           "scope": {
+            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "version": "1.0.0"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1779889264864000244",
+              "observedTimeUnixNano": "1779889264865000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"waitingDuration\":4,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":36.00000000000001,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":4,\"domainLookupStart\":4,\"domainLookupEnd\":4,\"connectStart\":4,\"connectEnd\":4,\"secureConnectionStart\":0,\"requestStart\":4,\"finalResponseHeadersStart\":5,\"firstInterimResponseStart\":0,\"responseStart\":5,\"responseEnd\":5,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":36.00000000000001,\"loadEventEnd\":36.00000000000001,\"type\":\"navigate\",\"redirectCount\":0}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "ttfb"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 5
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 5
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889264862-9330581810850"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.redirect",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.domainLookup",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.tcpConnection",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.tlsNegotiation",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.serverResponse",
+                  "value": {
+                    "intValue": 1
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.unattributed",
+                  "value": {
+                    "intValue": 4
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "F81826A8697FA3889093C2568D463080"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "EE860FEC9B16AD76490A3819A3ECE123"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1779889264874000244",
+              "observedTimeUnixNano": "1779889264874000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":5,\"firstByteToFCP\":41,\"loadState\":\"dom-interactive\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":36.00000000000001,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":4,\"domainLookupStart\":4,\"domainLookupEnd\":4,\"connectStart\":4,\"connectEnd\":4,\"secureConnectionStart\":0,\"requestStart\":4,\"finalResponseHeadersStart\":5,\"firstInterimResponseStart\":0,\"responseStart\":5,\"responseEnd\":5,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":36.00000000000001,\"loadEventEnd\":36.00000000000001,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":46,\"duration\":0}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "fcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 46
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 46
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889264861-5539601731518"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "359313702088DAEB4F633371AAF1902E"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "EE860FEC9B16AD76490A3819A3ECE123"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1779889265001000244",
+              "observedTimeUnixNano": "1779889265002000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":5,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":41,\"target\":\"#root>h1\",\"lcpEntry\":{\"name\":\"\",\"entryType\":\"largest-contentful-paint\",\"startTime\":46,\"duration\":0,\"loadTime\":0,\"renderTime\":46,\"size\":19216,\"id\":\"\",\"url\":\"\",\"paintTime\":46,\"presentationTime\":null},\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":36.00000000000001,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":4,\"domainLookupStart\":4,\"domainLookupEnd\":4,\"connectStart\":4,\"connectEnd\":4,\"secureConnectionStart\":0,\"requestStart\":4,\"finalResponseHeadersStart\":5,\"firstInterimResponseStart\":0,\"responseStart\":5,\"responseEnd\":5,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":36.00000000000001,\"loadEventEnd\":36.00000000000001,\"type\":\"navigate\",\"redirectCount\":0}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "lcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 46
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 46
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889264861-6811001789444"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "423A2FF01862BD9D8C17AF6B44BACFD3"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "EE860FEC9B16AD76490A3819A3ECE123"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            }
+          ]
+        },
+        {
+          "scope": {
             "name": "embrace-web-sdk-logs"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1778792223943000000",
-              "observedTimeUnixNano": "1778792223945000000",
+              "timeUnixNano": "1779889265419000244",
+              "observedTimeUnixNano": "1779889265420000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -102,13 +494,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:97704\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231101\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:797\nng@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:132565\nud@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:15162\nWo@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:128746\nhc@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:28581\nty@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:28403"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115010\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231020\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:797\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28403"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:11:126\":\"05d1173f5302f5d00f1464789fc7459c\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
                   }
                 },
                 {
@@ -120,13 +512,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "C7F9F9114BDC3160BF2B12656C780960"
+                    "stringValue": "0F542934AC2FA37B6FD5530C5E091C94"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "E92E16C724FCD0230097C6E48FEAA678"
+                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
                   }
                 },
                 {
@@ -138,7 +530,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "E92E16C724FCD0230097C6E48FEAA678"
+                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
                   }
                 },
                 {
@@ -150,7 +542,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "BCCA95205C32501B9905F3F02A0F5D5F"
+                    "stringValue": "EE860FEC9B16AD76490A3819A3ECE123"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "41D6A8A930D793AB9799D8E40CCCCAAA"
+              "stringValue": "DC6A3853C59396A073C450E3E074D7EB"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "f4992006e9846933bbb19db134482e71",
-              "spanId": "218114310e4b8f16",
+              "traceId": "86a24f37f4b04eea53f3120b55034e21",
+              "spanId": "efd3b2ffe3a29a42",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1778792223392000000",
-              "endTimeUnixNano": "1778792223978000000",
+              "startTimeUnixNano": "1779889264859000000",
+              "endTimeUnixNano": "1779889265448000244",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "E92E16C724FCD0230097C6E48FEAA678"
+                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "E92E16C724FCD0230097C6E48FEAA678"
+                    "stringValue": "5C70E8F5C7E76E14FDFB59A4F21358AA"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1778792223390
+                    "doubleValue": 1779889264858.0002
                   }
                 },
                 {
@@ -167,7 +167,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "BCCA95205C32501B9905F3F02A0F5D5F"
+                    "stringValue": "EE860FEC9B16AD76490A3819A3ECE123"
                   }
                 },
                 {
@@ -191,7 +191,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 5
+                    "intValue": 9
                   }
                 },
                 {
@@ -226,224 +226,6 @@
                     {
                       "key": "emb.type",
                       "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "TTFB"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1778792223393-7351738689904"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "intValue": 2
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "intValue": 2
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.waitingDuration",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.cacheDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.dnsDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.connectionDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.requestDuration",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.redirect",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.domainLookup",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tcpConnection",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tlsNegotiation",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.serverResponse",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.unattributed",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1778792223394000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "FCP"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1778792223393-2600047747326"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "doubleValue": 36.00000000000001
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "doubleValue": 36.00000000000001
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.timeToFirstByte",
-                      "value": {
-                        "intValue": 2
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.firstByteToFCP",
-                      "value": {
-                        "doubleValue": 34.00000000000001
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.loadState",
-                      "value": {
-                        "stringValue": "dom-interactive"
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1778792223409000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
                         "stringValue": "ux.tap"
                       }
                     },
@@ -461,104 +243,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "2579209955636000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "LCP"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1778792223393-4053399546942"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "doubleValue": 36.00000000000001
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "doubleValue": 36.00000000000001
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.timeToFirstByte",
-                      "value": {
-                        "intValue": 2
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.resourceLoadDelay",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.resourceLoadDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.elementRenderDelay",
-                      "value": {
-                        "doubleValue": 34.00000000000001
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.target",
-                      "value": {
-                        "stringValue": "#root>h1"
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-LCP",
-                  "timeUnixNano": "1778792223530000000",
+                  "timeUnixNano": "2581375873294000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -583,7 +268,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "2579209956052000000",
+                  "timeUnixNano": "2581375873716000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -604,13 +289,13 @@
           },
           "spans": [
             {
-              "traceId": "a2f393bb7c3a8ee8bd13c436e9076c3a",
-              "spanId": "b3f6576508d3000e",
-              "parentSpanId": "f2969de800f80f75",
+              "traceId": "f42b70d66f4a2338be6fcd863c0dca9a",
+              "spanId": "cb696c9ff02f3055",
+              "parentSpanId": "0f3b0a07da7fcded",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1778792223374000000",
-              "endTimeUnixNano": "1778792223375000000",
+              "startTimeUnixNano": "1779889264832000000",
+              "endTimeUnixNano": "1779889264833000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -648,55 +333,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1778792223374000000",
+                  "timeUnixNano": "1779889264832000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1778792223374000000",
+                  "timeUnixNano": "1779889264832000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1778792223374000000",
+                  "timeUnixNano": "1779889264832000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1778792223374000000",
+                  "timeUnixNano": "1779889264832000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1778792223373000000",
+                  "timeUnixNano": "1779889264828000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1778792223374000000",
+                  "timeUnixNano": "1779889264832000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1778792223374000000",
+                  "timeUnixNano": "1779889264832000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1778792223375000000",
+                  "timeUnixNano": "1779889264833000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1778792223375000000",
+                  "timeUnixNano": "1779889264833000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -709,13 +394,13 @@
               "flags": 257
             },
             {
-              "traceId": "a2f393bb7c3a8ee8bd13c436e9076c3a",
-              "spanId": "cabdb86a1a6a5303",
-              "parentSpanId": "f2969de800f80f75",
+              "traceId": "f42b70d66f4a2338be6fcd863c0dca9a",
+              "spanId": "b9fa9f5d59baa4bb",
+              "parentSpanId": "0f3b0a07da7fcded",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1778792223378000000",
-              "endTimeUnixNano": "1778792223379000000",
+              "startTimeUnixNano": "1779889264837000000",
+              "endTimeUnixNano": "1779889264838000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -726,19 +411,19 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 389190
+                    "intValue": 389109
                   }
                 },
                 {
                   "key": "http.response_content_length_uncompressed",
                   "value": {
-                    "intValue": 389178
+                    "intValue": 389097
                   }
                 },
                 {
@@ -750,19 +435,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 389190
+                    "intValue": 389109
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 389490
+                    "intValue": 389409
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 389178
+                    "intValue": 389097
                   }
                 },
                 {
@@ -783,49 +468,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1778792223378000000",
+                  "timeUnixNano": "1779889264837000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1778792223378000000",
+                  "timeUnixNano": "1779889264837000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1778792223378000000",
+                  "timeUnixNano": "1779889264837000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1778792223378000000",
+                  "timeUnixNano": "1779889264837000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1778792223378000000",
+                  "timeUnixNano": "1779889264837000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1778792223378000000",
+                  "timeUnixNano": "1779889264837000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1778792223379000000",
+                  "timeUnixNano": "1779889264838000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1778792223379000000",
+                  "timeUnixNano": "1779889264838000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -838,12 +523,12 @@
               "flags": 257
             },
             {
-              "traceId": "a2f393bb7c3a8ee8bd13c436e9076c3a",
-              "spanId": "f2969de800f80f75",
+              "traceId": "f42b70d66f4a2338be6fcd863c0dca9a",
+              "spanId": "0f3b0a07da7fcded",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1778792223374000000",
-              "endTimeUnixNano": "1778792223395000000",
+              "startTimeUnixNano": "1779889264831000000",
+              "endTimeUnixNano": "1779889264863000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -881,19 +566,19 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1778792223374000000",
+                  "timeUnixNano": "1779889264831000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1778792223395000000",
+                  "timeUnixNano": "1779889264863000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1778792223395000000",
+                  "timeUnixNano": "1779889264863000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -914,12 +599,12 @@
           },
           "spans": [
             {
-              "traceId": "7b8f89f0421090b4ac054eff349bede1",
-              "spanId": "452dceb1c8c99676",
+              "traceId": "1f63d4c6a617b7d3e6d8326202a2b7c3",
+              "spanId": "b535c8fe6600333c",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1778792223531000000",
-              "endTimeUnixNano": "1778792223533000000",
+              "startTimeUnixNano": "1779889265001000000",
+              "endTimeUnixNano": "1779889265005000000",
               "attributes": [
                 {
                   "key": "component",
@@ -1027,43 +712,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1778792223531000000",
+                  "timeUnixNano": "1779889265001000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1778792223531000000",
+                  "timeUnixNano": "1779889265001000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1778792223531000000",
+                  "timeUnixNano": "1779889265001000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1778792223531000000",
+                  "timeUnixNano": "1779889265001000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1778792223531000000",
+                  "timeUnixNano": "1779889265001000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1778792223531000000",
+                  "timeUnixNano": "1779889265001000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1778792223533000000",
+                  "timeUnixNano": "1779889265003000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-log.json
@@ -81,7 +81,7 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "name": "WebVitalsInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-log.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "57EA43C93BE035FD40FA4B1A78B46E8C"
+              "stringValue": "184FAF04F624C23B1F8FDEE7C68C55C9"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Safari/605.1.15"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889228391900146",
-              "observedTimeUnixNano": "1779889228392000000",
+              "timeUnixNano": "1779889260643000000",
+              "observedTimeUnixNano": "1779889260644000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":1.2000000029802322,\"dnsDuration\":0,\"connectionDuration\":0.29999999701976776,\"requestDuration\":3.2000000029802322,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":49.1000000089407,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.5,\"requestStart\":1.5,\"responseStart\":4.700000002980232,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.700000002980232,\"responseEnd\":4.799999997019768,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.700000002980232,\"domContentLoadedEventStart\":49,\"domContentLoadedEventEnd\":49,\"domComplete\":49,\"loadEventStart\":49,\"loadEventEnd\":49.1000000089407,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}}}"
+                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":0,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":28,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":1,\"domainLookupStart\":1,\"domainLookupEnd\":1,\"connectStart\":1,\"connectEnd\":1,\"secureConnectionStart\":0,\"requestStart\":1,\"finalResponseHeadersStart\":1,\"firstInterimResponseStart\":0,\"responseStart\":1,\"responseEnd\":1,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":28,\"loadEventEnd\":28,\"type\":\"navigate\",\"redirectCount\":0}}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -103,13 +103,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 4.700000002980232
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 4.700000002980232
+                    "intValue": 1
                   }
                 },
                 {
@@ -121,7 +121,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889228388-2417159675947"
+                    "stringValue": "v5-1779889260641-6353181171376"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 3
+                    "intValue": 0
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 2
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0CC0A105A1C4F656948BA3AEFD0DC967"
+                    "stringValue": "741C7CC451E3217FFF8B1BE22A533160"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "E4FF41DEEDDA5E43044224E7B9AF345F"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "E4FF41DEEDDA5E43044224E7B9AF345F"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
+                    "stringValue": "0EB6F99E3DAB2E2823D4A43DC5196F0F"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889228405700195",
-              "observedTimeUnixNano": "1779889228405000000",
+              "timeUnixNano": "1779889260651000000",
+              "observedTimeUnixNano": "1779889260652000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":4.700000002980232,\"firstByteToFCP\":59.29999999701977,\"loadState\":\"complete\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":49.1000000089407,\"initiatorType\":\"navigation\",\"deliveryType\":\"\",\"nextHopProtocol\":\"http/1.1\",\"renderBlockingStatus\":\"non-blocking\",\"contentType\":\"text/html\",\"contentEncoding\":\"\",\"workerStart\":0,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedSourceType\":\"\",\"workerFinalSourceType\":\"\",\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":0,\"domainLookupStart\":1.2000000029802322,\"domainLookupEnd\":1.2000000029802322,\"connectStart\":1.2000000029802322,\"secureConnectionStart\":0,\"connectEnd\":1.5,\"requestStart\":1.5,\"responseStart\":4.700000002980232,\"firstInterimResponseStart\":0,\"finalResponseHeadersStart\":4.700000002980232,\"responseEnd\":4.799999997019768,\"transferSize\":552,\"encodedBodySize\":252,\"decodedBodySize\":252,\"responseStatus\":200,\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":7.700000002980232,\"domContentLoadedEventStart\":49,\"domContentLoadedEventEnd\":49,\"domComplete\":49,\"loadEventStart\":49,\"loadEventEnd\":49.1000000089407,\"type\":\"navigate\",\"redirectCount\":0,\"activationStart\":0,\"criticalCHRestart\":0,\"notRestoredReasons\":null,\"confidence\":{\"randomizedTriggerRate\":0.4994798,\"value\":\"low\"}},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":64,\"duration\":0,\"paintTime\":58.20000000298023,\"presentationTime\":64}}"
+                "stringValue": "{\"timeToFirstByte\":1,\"firstByteToFCP\":35.00000000000001,\"loadState\":\"dom-interactive\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":28,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":1,\"domainLookupStart\":1,\"domainLookupEnd\":1,\"connectStart\":1,\"connectEnd\":1,\"secureConnectionStart\":0,\"requestStart\":1,\"finalResponseHeadersStart\":1,\"firstInterimResponseStart\":0,\"responseStart\":1,\"responseEnd\":1,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":28,\"loadEventEnd\":28,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":36.00000000000001,\"duration\":0}}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -255,13 +255,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 64
+                    "doubleValue": 36.00000000000001
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 64
+                    "doubleValue": 36.00000000000001
                   }
                 },
                 {
@@ -273,7 +273,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889228388-7792731886832"
+                    "stringValue": "v5-1779889260641-2703138654555"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "3262555AC105DAE77EB9844486EDFD40"
+                    "stringValue": "CF016A261398C245523D5D8E7D4DD7E1"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "E4FF41DEEDDA5E43044224E7B9AF345F"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
+                    "stringValue": "E4FF41DEEDDA5E43044224E7B9AF345F"
                   }
                 },
                 {
@@ -341,110 +341,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
+                    "stringValue": "0EB6F99E3DAB2E2823D4A43DC5196F0F"
                   }
                 },
                 {
                   "key": "emb.type",
                   "value": {
                     "stringValue": "sys.log"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            }
-          ]
-        },
-        {
-          "scope": {
-            "name": "embrace-web-sdk-logs"
-          },
-          "logRecords": [
-            {
-              "timeUnixNano": "1779889228516300049",
-              "observedTimeUnixNano": "1779889228516000000",
-              "severityNumber": 13,
-              "severityText": "WARNING",
-              "body": {
-                "stringValue": "This is a test log message"
-              },
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "sys.log"
-                  }
-                },
-                {
-                  "key": "emb.stacktrace.js",
-                  "value": {
-                    "stringValue": "Error\n    at nf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115001)\n    at Ry.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231013\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:230985)\n    at eg (http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127510)"
-                  }
-                },
-                {
-                  "key": "emb.js_file_bundle_ids",
-                  "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
-                  }
-                },
-                {
-                  "key": "emb.state",
-                  "value": {
-                    "stringValue": "foreground"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "C1D1700FB1CB39D702C62A740A01D6FD"
-                  }
-                },
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
-                  }
-                },
-                {
-                  "key": "session.previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "EC470992282664A24902ACE71774C2B2"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "320D56838D3E903E5B8E109213F9FE50"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
                   }
                 }
               ],

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "184FAF04F624C23B1F8FDEE7C68C55C9"
+              "stringValue": "56C6061649BA179675D98ADC59D48812"
             }
           },
           {
@@ -86,14 +86,20 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889260643000000",
-              "observedTimeUnixNano": "1779889260644000000",
+              "timeUnixNano": "1779891745871000244",
+              "observedTimeUnixNano": "1779891745872000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":0,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":28,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":1,\"domainLookupStart\":1,\"domainLookupEnd\":1,\"connectStart\":1,\"connectEnd\":1,\"secureConnectionStart\":0,\"requestStart\":1,\"finalResponseHeadersStart\":1,\"firstInterimResponseStart\":0,\"responseStart\":1,\"responseEnd\":1,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":28,\"loadEventEnd\":28,\"type\":\"navigate\",\"redirectCount\":0}}"
+                "stringValue": "{\"waitingDuration\":2,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":6}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -103,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 1
+                    "intValue": 8
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 1
+                    "intValue": 8
                   }
                 },
                 {
@@ -121,19 +127,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889260641-6353181171376"
+                    "stringValue": "v5-1779891745868-5345865330365"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 0
+                    "intValue": 6
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 1
+                    "intValue": 2
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "741C7CC451E3217FFF8B1BE22A533160"
+                    "stringValue": "F4C58A7DEB2BBF5A378CBA6E2671AF46"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "E4FF41DEEDDA5E43044224E7B9AF345F"
+                    "stringValue": "B6E97921B8C3D961067EA42B881BC744"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "E4FF41DEEDDA5E43044224E7B9AF345F"
+                    "stringValue": "B6E97921B8C3D961067EA42B881BC744"
                   }
                 },
                 {
@@ -225,27 +225,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0EB6F99E3DAB2E2823D4A43DC5196F0F"
+                    "stringValue": "D9B6BDD1C8D54A66301CCB2B7C3EC018"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889260651000000",
-              "observedTimeUnixNano": "1779889260652000000",
+              "timeUnixNano": "1779891745879000244",
+              "observedTimeUnixNano": "1779891745880000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":1,\"firstByteToFCP\":35.00000000000001,\"loadState\":\"dom-interactive\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":28,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":1,\"domainLookupStart\":1,\"domainLookupEnd\":1,\"connectStart\":1,\"connectEnd\":1,\"secureConnectionStart\":0,\"requestStart\":1,\"finalResponseHeadersStart\":1,\"firstInterimResponseStart\":0,\"responseStart\":1,\"responseEnd\":1,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":28,\"loadEventEnd\":28,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":36.00000000000001,\"duration\":0}}"
+                "stringValue": "{\"timeToFirstByte\":8,\"firstByteToFCP\":53,\"loadState\":\"dom-interactive\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -255,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 36.00000000000001
+                    "intValue": 61
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 36.00000000000001
+                    "intValue": 61
                   }
                 },
                 {
@@ -273,19 +279,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889260641-2703138654555"
+                    "stringValue": "v5-1779891745868-2961742281938"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "CF016A261398C245523D5D8E7D4DD7E1"
+                    "stringValue": "E14FCDAD7CD367C185AA6D250445882C"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "E4FF41DEEDDA5E43044224E7B9AF345F"
+                    "stringValue": "B6E97921B8C3D961067EA42B881BC744"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "E4FF41DEEDDA5E43044224E7B9AF345F"
+                    "stringValue": "B6E97921B8C3D961067EA42B881BC744"
                   }
                 },
                 {
@@ -341,13 +341,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0EB6F99E3DAB2E2823D4A43DC5196F0F"
+                    "stringValue": "D9B6BDD1C8D54A66301CCB2B7C3EC018"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
@@ -81,7 +81,7 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "name": "WebVitalsInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "31F40DD6B7878466A734352BD699FBF2"
+              "stringValue": "D512CBCC9852DAA1073082F95265A133"
             }
           },
           {
@@ -86,14 +86,20 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889261373000000",
-              "observedTimeUnixNano": "1779889261373000000",
+              "timeUnixNano": "1779891746485000000",
+              "observedTimeUnixNano": "1779891746487000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":36.00000000000001,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":1,\"domainLookupStart\":1,\"domainLookupEnd\":1,\"connectStart\":1,\"connectEnd\":1,\"secureConnectionStart\":0,\"requestStart\":1,\"finalResponseHeadersStart\":2,\"firstInterimResponseStart\":0,\"responseStart\":2,\"responseEnd\":2,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":36.00000000000001,\"loadEventEnd\":36.00000000000001,\"type\":\"navigate\",\"redirectCount\":0}}"
+                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -121,19 +127,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889261369-9446101846468"
+                    "stringValue": "v5-1779891746481-2963521708738"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -195,13 +195,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "5F5E3CAF326AD3E5118B108F17D05DC2"
+                    "stringValue": "8D9E1121C869D4240F8C2C257529AA22"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
+                    "stringValue": "69BE4E3F43A15BCAF7A8C3A3D814DB85"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
+                    "stringValue": "69BE4E3F43A15BCAF7A8C3A3D814DB85"
                   }
                 },
                 {
@@ -225,27 +225,33 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "C4227D556363C41C5508BED0D680C14B"
+                    "stringValue": "9EE0CE3C1D50DBEBE0CB054D16264077"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1779889261387000000",
-              "observedTimeUnixNano": "1779889261387000000",
+              "timeUnixNano": "1779891746494000000",
+              "observedTimeUnixNano": "1779891746494000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":48,\"loadState\":\"dom-interactive\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":36.00000000000001,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":1,\"domainLookupStart\":1,\"domainLookupEnd\":1,\"connectStart\":1,\"connectEnd\":1,\"secureConnectionStart\":0,\"requestStart\":1,\"finalResponseHeadersStart\":2,\"firstInterimResponseStart\":0,\"responseStart\":2,\"responseEnd\":2,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":36.00000000000001,\"loadEventEnd\":36.00000000000001,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":50,\"duration\":0}}"
+                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":43,\"loadState\":\"dom-interactive\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
                 {
                   "key": "browser.web_vital.name",
                   "value": {
@@ -255,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 50
+                    "intValue": 45
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 50
+                    "intValue": 45
                   }
                 },
                 {
@@ -273,19 +279,13 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1779889261369-6190808521179"
+                    "stringValue": "v5-1779891746481-7980650977333"
                   }
                 },
                 {
                   "key": "browser.web_vital.navigation_type",
                   "value": {
                     "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "C06D680350853C2E7554EA473074B042"
+                    "stringValue": "37F3C7B9B535B6639E6605D02F1C0C66"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
+                    "stringValue": "69BE4E3F43A15BCAF7A8C3A3D814DB85"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
+                    "stringValue": "69BE4E3F43A15BCAF7A8C3A3D814DB85"
                   }
                 },
                 {
@@ -341,13 +341,13 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "C4227D556363C41C5508BED0D680C14B"
+                    "stringValue": "9EE0CE3C1D50DBEBE0CB054D16264077"
                   }
                 },
                 {
-                  "key": "emb.type",
+                  "key": "url.full",
                   "value": {
-                    "stringValue": "sys.log"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
                   }
                 }
               ],
@@ -361,8 +361,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1779889261547000000",
-              "observedTimeUnixNano": "1779889261547000000",
+              "timeUnixNano": "1779891746626000000",
+              "observedTimeUnixNano": "1779891746627000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -378,13 +378,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115010\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231020\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:797\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28403"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:115010\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:231318\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:1:797\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:9:28403"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-BUsN_Gpq.js:11:126\":\"befe0c236b73acf40d3eccdcd08328e6\"}"
                   }
                 },
                 {
@@ -396,13 +396,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "E663D97D92532049DDA737BC535D0516"
+                    "stringValue": "B476D0FDF13D94EC09E029EF56E190E1"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
+                    "stringValue": "69BE4E3F43A15BCAF7A8C3A3D814DB85"
                   }
                 },
                 {
@@ -414,7 +414,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
+                    "stringValue": "69BE4E3F43A15BCAF7A8C3A3D814DB85"
                   }
                 },
                 {
@@ -426,7 +426,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "C4227D556363C41C5508BED0D680C14B"
+                    "stringValue": "9EE0CE3C1D50DBEBE0CB054D16264077"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "1153242061B4A24F6EFB19716F7142EB"
+              "stringValue": "31F40DD6B7878466A734352BD699FBF2"
             }
           },
           {
@@ -81,12 +81,288 @@
       "scopeLogs": [
         {
           "scope": {
+            "name": "@opentelemetry/browser-instrumentation/web-vitals",
+            "version": "1.0.0"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1779889261373000000",
+              "observedTimeUnixNano": "1779889261373000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1,\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":36.00000000000001,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":1,\"domainLookupStart\":1,\"domainLookupEnd\":1,\"connectStart\":1,\"connectEnd\":1,\"secureConnectionStart\":0,\"requestStart\":1,\"finalResponseHeadersStart\":2,\"firstInterimResponseStart\":0,\"responseStart\":2,\"responseEnd\":2,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":36.00000000000001,\"loadEventEnd\":36.00000000000001,\"type\":\"navigate\",\"redirectCount\":0}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "ttfb"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 2
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 2
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889261369-9446101846468"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.redirect",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.domainLookup",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.tcpConnection",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.tlsNegotiation",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.serverResponse",
+                  "value": {
+                    "intValue": 1
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.unattributed",
+                  "value": {
+                    "intValue": 1
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "5F5E3CAF326AD3E5118B108F17D05DC2"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "C4227D556363C41C5508BED0D680C14B"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1779889261387000000",
+              "observedTimeUnixNano": "1779889261387000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":48,\"loadState\":\"dom-interactive\",\"navigationEntry\":{\"name\":\"http://localhost:3001/platforms/vite-7/es2015/index.html\",\"entryType\":\"navigation\",\"startTime\":0,\"duration\":36.00000000000001,\"initiatorType\":\"navigation\",\"nextHopProtocol\":\"http/1.1\",\"workerStart\":0,\"redirectStart\":0,\"redirectEnd\":0,\"fetchStart\":1,\"domainLookupStart\":1,\"domainLookupEnd\":1,\"connectStart\":1,\"connectEnd\":1,\"secureConnectionStart\":0,\"requestStart\":1,\"finalResponseHeadersStart\":2,\"firstInterimResponseStart\":0,\"responseStart\":2,\"responseEnd\":2,\"transferSize\":561,\"encodedBodySize\":261,\"decodedBodySize\":252,\"workerRouterEvaluationStart\":0,\"workerCacheLookupStart\":0,\"workerMatchedRouterSource\":\"\",\"workerFinalRouterSource\":\"\",\"deliveryType\":\"\",\"serverTiming\":[],\"unloadEventStart\":0,\"unloadEventEnd\":0,\"domInteractive\":0,\"domContentLoadedEventStart\":0,\"domContentLoadedEventEnd\":0,\"domComplete\":0,\"loadEventStart\":36.00000000000001,\"loadEventEnd\":36.00000000000001,\"type\":\"navigate\",\"redirectCount\":0},\"fcpEntry\":{\"name\":\"first-contentful-paint\",\"entryType\":\"paint\",\"startTime\":50,\"duration\":0}}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "fcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 50
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 50
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1779889261369-6190808521179"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "C06D680350853C2E7554EA473074B042"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "C4227D556363C41C5508BED0D680C14B"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "sys.log"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            }
+          ]
+        },
+        {
+          "scope": {
             "name": "embrace-web-sdk-logs"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1778792221615000000",
-              "observedTimeUnixNano": "1778792221616000000",
+              "timeUnixNano": "1779889261547000000",
+              "observedTimeUnixNano": "1779889261547000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -102,13 +378,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:97704\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:231101\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:1:797\nng@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:132565\nud@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:15162\nWo@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:8:128746\nhc@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:28581\nty@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:9:28403"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:115010\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:231020\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:1:797\neg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:127511\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:132565\nld@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:8:128746\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28581\ney@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:9:28403"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js:11:126\":\"05d1173f5302f5d00f1464789fc7459c\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js:11:126\":\"34f46b9da2fbc17513555e1ec2703f43\"}"
                   }
                 },
                 {
@@ -120,13 +396,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "C5E93A01D085274C088E9732006C603C"
+                    "stringValue": "E663D97D92532049DDA737BC535D0516"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "560EFFEE4C75F3EC2F77D723F7E9D54E"
+                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
                   }
                 },
                 {
@@ -138,7 +414,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "560EFFEE4C75F3EC2F77D723F7E9D54E"
+                    "stringValue": "2DCC13E1A0D7FF329EA72A600A5EFA6F"
                   }
                 },
                 {
@@ -150,7 +426,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "3BBC26ADE521B59456499807B10B2A50"
+                    "stringValue": "C4227D556363C41C5508BED0D680C14B"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "BBA981D0B074378CC9C865211C40E710"
+              "stringValue": "184FAF04F624C23B1F8FDEE7C68C55C9"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "ba466608d808d805b1b43d35eaae2860",
-              "spanId": "8b3d60676306c415",
+              "traceId": "f8b939597c3174043d861ec52be88a47",
+              "spanId": "3b472cac43fd3d1e",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1778792221199000000",
-              "endTimeUnixNano": "1778792221339000000",
+              "startTimeUnixNano": "1779889260639000000",
+              "endTimeUnixNano": "1779889260828000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "792CDED7A45C289590F2B2CA3B46AA3D"
+                    "stringValue": "E4FF41DEEDDA5E43044224E7B9AF345F"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "792CDED7A45C289590F2B2CA3B46AA3D"
+                    "stringValue": "E4FF41DEEDDA5E43044224E7B9AF345F"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1778792221198
+                    "intValue": 1779889260638
                   }
                 },
                 {
@@ -167,7 +167,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "C8E9D3EFB7784D0C2B8FC371D95F2352"
+                    "stringValue": "0EB6F99E3DAB2E2823D4A43DC5196F0F"
                   }
                 },
                 {
@@ -220,226 +220,7 @@
                 }
               ],
               "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "TTFB"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1778792221200-6762949078040"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.waitingDuration",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.cacheDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.dnsDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.connectionDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.requestDuration",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.redirect",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.domainLookup",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tcpConnection",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.tlsNegotiation",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.serverResponse",
-                      "value": {
-                        "intValue": 0
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.unattributed",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-TTFB",
-                  "timeUnixNano": "1778792221202000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [
-                    {
-                      "key": "emb.type",
-                      "value": {
-                        "stringValue": "ux.web_vital"
-                      }
-                    },
-                    {
-                      "key": "url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "browser.url.full",
-                      "value": {
-                        "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.navigation_type",
-                      "value": {
-                        "stringValue": "navigate"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.name",
-                      "value": {
-                        "stringValue": "FCP"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.rating",
-                      "value": {
-                        "stringValue": "good"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.id",
-                      "value": {
-                        "stringValue": "v5-1778792221200-4089341117426"
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.delta",
-                      "value": {
-                        "intValue": 28
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.value",
-                      "value": {
-                        "intValue": 28
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.timeToFirstByte",
-                      "value": {
-                        "intValue": 1
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.firstByteToFCP",
-                      "value": {
-                        "intValue": 27
-                      }
-                    },
-                    {
-                      "key": "emb.web_vital.attribution.loadState",
-                      "value": {
-                        "stringValue": "dom-interactive"
-                      }
-                    },
-                    {
-                      "key": "app.surface.label",
-                      "value": {
-                        "stringValue": "React + TS + Vite"
-                      }
-                    }
-                  ],
-                  "name": "emb-web-vitals-report-FCP",
-                  "timeUnixNano": "1778792221208000000",
-                  "droppedAttributesCount": 0
-                }
-              ],
+              "events": [],
               "droppedEventsCount": 0,
               "status": {
                 "code": 0
@@ -457,13 +238,13 @@
           },
           "spans": [
             {
-              "traceId": "b2d12414d19974741f932c34926311f7",
-              "spanId": "8d448a574c8f1acf",
-              "parentSpanId": "05e65a885b1a903a",
+              "traceId": "df2f9b45fb022b6bf41322a2b18419bb",
+              "spanId": "10523fb0ed119e52",
+              "parentSpanId": "edd4f69643af338d",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1778792221181000000",
-              "endTimeUnixNano": "1778792221181000000",
+              "startTimeUnixNano": "1779889260616000000",
+              "endTimeUnixNano": "1779889260616000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -501,55 +282,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1778792221181000000",
+                  "timeUnixNano": "1779889260616000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1778792221181000000",
+                  "timeUnixNano": "1779889260616000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1778792221181000000",
+                  "timeUnixNano": "1779889260616000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1778792221181000000",
+                  "timeUnixNano": "1779889260616000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1778792221180000000",
+                  "timeUnixNano": "1779889260615000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1778792221181000000",
+                  "timeUnixNano": "1779889260616000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1778792221181000000",
+                  "timeUnixNano": "1779889260616000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1778792221181000000",
+                  "timeUnixNano": "1779889260616000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1778792221181000000",
+                  "timeUnixNano": "1779889260616000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -562,13 +343,13 @@
               "flags": 257
             },
             {
-              "traceId": "b2d12414d19974741f932c34926311f7",
-              "spanId": "c98f970403fb6636",
-              "parentSpanId": "05e65a885b1a903a",
+              "traceId": "df2f9b45fb022b6bf41322a2b18419bb",
+              "spanId": "03408c8db5156eab",
+              "parentSpanId": "edd4f69643af338d",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1778792221185000000",
-              "endTimeUnixNano": "1778792221186000000",
+              "startTimeUnixNano": "1779889260623000000",
+              "endTimeUnixNano": "1779889260625000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -579,19 +360,19 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-yFKGL-qG.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BGBUaRc8.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 389190
+                    "intValue": 389109
                   }
                 },
                 {
                   "key": "http.response_content_length_uncompressed",
                   "value": {
-                    "intValue": 389178
+                    "intValue": 389097
                   }
                 },
                 {
@@ -603,19 +384,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 389190
+                    "intValue": 389109
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 389490
+                    "intValue": 389409
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 389178
+                    "intValue": 389097
                   }
                 },
                 {
@@ -636,49 +417,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1778792221185000000",
+                  "timeUnixNano": "1779889260623000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1778792221185000000",
+                  "timeUnixNano": "1779889260623000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1778792221185000000",
+                  "timeUnixNano": "1779889260623000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1778792221185000000",
+                  "timeUnixNano": "1779889260623000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1778792221185000000",
+                  "timeUnixNano": "1779889260623000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1778792221185000000",
+                  "timeUnixNano": "1779889260624000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1778792221186000000",
+                  "timeUnixNano": "1779889260624000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1778792221186000000",
+                  "timeUnixNano": "1779889260625000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -691,12 +472,12 @@
               "flags": 257
             },
             {
-              "traceId": "b2d12414d19974741f932c34926311f7",
-              "spanId": "05e65a885b1a903a",
+              "traceId": "df2f9b45fb022b6bf41322a2b18419bb",
+              "spanId": "edd4f69643af338d",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1778792221181000000",
-              "endTimeUnixNano": "1778792221202000000",
+              "startTimeUnixNano": "1779889260616000000",
+              "endTimeUnixNano": "1779889260643000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -734,19 +515,19 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1778792221181000000",
+                  "timeUnixNano": "1779889260616000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1778792221202000000",
+                  "timeUnixNano": "1779889260643000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1778792221202000000",
+                  "timeUnixNano": "1779889260643000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/utils/run-e2e-tests.ts
+++ b/tests/integration/utils/run-e2e-tests.ts
@@ -176,7 +176,7 @@ const runE2ETests = ({
       'it should end a session and send a request to the API',
       async ({
         requests,
-        waitForOTelRequest,
+        waitForOTelRequestMatching,
         navigateAndWaitUntilReady,
         page,
         browserName,
@@ -184,13 +184,38 @@ const runE2ETests = ({
         await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
         const button = page.getByRole('button', { name: 'End Session' });
         await button.click();
-        await waitForOTelRequest();
+        // Wait until the session span is present in `requests` (after gunzip).
+        // Web vitals log requests may arrive first, so waiting for any OTel
+        // request is not sufficient.
+        await waitForOTelRequestMatching(/\/v2\/spans/);
 
-        testE2E.expect(requests).toHaveLength(1);
+        // Give a short window for the concurrent log request (sent alongside the
+        // span flush) to finish being parsed from the gzip buffer.
+        if (!requests.find((req) => req.url.endsWith('/logs'))) {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+
+        const sessionRequest = requests.find((req) =>
+          req.url.endsWith('/spans'),
+        );
+        // Web vitals may have flushed a log request before session end; use the
+        // last log request which corresponds to the session end flush.
+        const logRequest = requests.find((req) => req.url.endsWith('/logs'));
 
         if (goldenFiles) {
-          extendedMockApiTestExpect(requests[0]).toMatchGoldenFile(
+          if (!sessionRequest) {
+            throw new Error('Session request was not sent to the API');
+          }
+
+          if (!logRequest) {
+            throw new Error('Log request was not sent to the API');
+          }
+
+          extendedMockApiTestExpect(sessionRequest).toMatchGoldenFile(
             `${browserName}-${codifiedName}-session.json`,
+          );
+          extendedMockApiTestExpect(logRequest).toMatchGoldenFile(
+            `${browserName}-${codifiedName}-log.json`,
           );
         }
       },

--- a/tests/integration/utils/run-e2e-tests.ts
+++ b/tests/integration/utils/run-e2e-tests.ts
@@ -278,7 +278,7 @@ const runE2ETests = ({
           () => window.EMBRACE_CURRENT_USER_SESSION_ID,
           {},
         );
-        testE2E.expect(currentUserSessionId).toBeNull();
+        testE2E.expect(currentUserSessionId).toBeFalsy();
       },
     );
 

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -68,9 +68,7 @@ const INSTRUMENTATION_WITH_SIMPLIFIED_COMPARISON = [
 ];
 // Scopes on this list have their entities sorted by a stable key before
 // comparison because the order they are emitted is non-deterministic.
-const SCOPES_WITH_SORTED_COMPARISON = new Set([
-  '@opentelemetry/browser-instrumentation/web-vitals',
-]);
+const SCOPES_WITH_SORTED_COMPARISON = new Set(['WebVitalsInstrumentation']);
 // If a log record has any of these attribute keys, its body is excluded from
 // comparison because the content (e.g. raw attribution timing values) changes every run.
 const LOGS_WITH_IGNORED_BODY = new Set(['browser.web_vital.name']);

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -55,6 +55,7 @@ type TestWithMockApi = {
   requests: EmbraceDataRequest[];
   waitForRequest: (url: RegExp) => Promise<void>;
   waitForOTelRequest: () => Promise<void>;
+  waitForOTelRequestMatching: (pattern: RegExp) => Promise<void>;
   waitForRemoteConfigRequest: () => Promise<void>;
   withRemoteConfig: (remoteConfig?: Record<string, unknown>) => Promise<void>;
   withSimulatedResponse: (response: SimulatedResponse) => Promise<void>;
@@ -65,6 +66,14 @@ type TestWithMockApi = {
 const INSTRUMENTATION_WITH_SIMPLIFIED_COMPARISON = [
   'DocumentLoadInstrumentation',
 ];
+// Scopes on this list have their entities sorted by a stable key before
+// comparison because the order they are emitted is non-deterministic.
+const SCOPES_WITH_SORTED_COMPARISON = new Set([
+  '@opentelemetry/browser-instrumentation/web-vitals',
+]);
+// If a log record has any of these attribute keys, its body is excluded from
+// comparison because the content (e.g. raw attribution timing values) changes every run.
+const LOGS_WITH_IGNORED_BODY = new Set(['browser.web_vital.name']);
 // Resource spans whose url.full matches any of these patterns are excluded from
 // comparison entirely. Favicons are fetched asynchronously by the browser and
 // may or may not complete before the SDK captures PerformanceResourceTiming
@@ -109,6 +118,9 @@ const IGNORED_ATTRIBUTES_LIST = [
   'emb.web_vital.delta',
   'emb.web_vital.id',
   'emb.web_vital.value',
+  'browser.web_vital.delta',
+  'browser.web_vital.id',
+  'browser.web_vital.value',
   'tap.coords',
 ];
 
@@ -134,6 +146,30 @@ const testWithMockApi = base.extend<TestWithMockApi>({
           .poll(() => requests.length, { timeout: testInfo.timeout })
           .toBeGreaterThan(consumed);
         consumed += 1;
+      });
+    },
+    { scope: 'test' },
+  ],
+  waitForOTelRequestMatching: [
+    async ({ requests }, use) => {
+      await use(async (pattern: RegExp) => {
+        const timeoutMs = 10_000;
+        const start = Date.now();
+        await new Promise<void>((resolve, reject) => {
+          const interval = setInterval(() => {
+            if (requests.some((r) => pattern.test(r.url))) {
+              clearInterval(interval);
+              resolve();
+            } else if (Date.now() - start > timeoutMs) {
+              clearInterval(interval);
+              reject(
+                new Error(
+                  `Expected OTel request matching ${pattern.toString()} within ${timeoutMs.toString()}ms`,
+                ),
+              );
+            }
+          }, 100);
+        });
       });
     },
     { scope: 'test' },
@@ -249,6 +285,14 @@ const isScopeSpan = (entity: IScopeSpans | IScopeLogs): entity is IScopeSpans =>
 
 const isSpan = (entity: ISpan | ILogRecord): entity is ISpan =>
   (entity as ISpan).spanId !== undefined;
+
+const getEntitySortKey = (entity: ISpan | ILogRecord): string => {
+  if (isSpan(entity)) return entity.name;
+  return (
+    entity.attributes?.find((a) => a.key === 'browser.web_vital.name')?.value
+      .stringValue ?? ''
+  );
+};
 
 const expect = testWithMockApi.expect.extend({
   toMatchAttributes: (
@@ -431,14 +475,18 @@ const expect = testWithMockApi.expect.extend({
     };
   },
   toMatchLog: (received: ILogRecord, expected: ILogRecord) => {
+    const ignoreBody =
+      received.attributes?.some((a) => LOGS_WITH_IGNORED_BODY.has(a.key)) ??
+      false;
+
     // Use this instead of objectContaining for a better error message
     expect({
-      body: received.body,
+      ...(ignoreBody ? {} : { body: received.body }),
       severityNumber: received.severityNumber,
       severityText: received.severityText,
       droppedAttributesCount: received.droppedAttributesCount,
     }).toEqual({
-      body: expected.body,
+      ...(ignoreBody ? {} : { body: expected.body }),
       severityNumber: expected.severityNumber,
       severityText: expected.severityText,
       droppedAttributesCount: expected.droppedAttributesCount,
@@ -550,11 +598,25 @@ const expect = testWithMockApi.expect.extend({
                 continue;
               }
 
+              const shouldSort = SCOPES_WITH_SORTED_COMPARISON.has(
+                receivedScope.scope.name,
+              );
+              const sortedReceived = shouldSort
+                ? [...filteredReceived].sort((a, b) =>
+                    getEntitySortKey(a).localeCompare(getEntitySortKey(b)),
+                  )
+                : filteredReceived;
+              const sortedExpected = shouldSort
+                ? [...filteredExpected].sort((a, b) =>
+                    getEntitySortKey(a).localeCompare(getEntitySortKey(b)),
+                  )
+                : filteredExpected;
+
               for (const [
                 entityIndex,
                 receivedEntity,
-              ] of filteredReceived.entries()) {
-                const expectedEntity = filteredExpected[entityIndex];
+              ] of sortedReceived.entries()) {
+                const expectedEntity = sortedExpected[entityIndex];
 
                 try {
                   if (isSpan(receivedEntity) && isSpan(expectedEntity)) {


### PR DESCRIPTION
## What problem is this solving?

Web vitals were captured as span events on the session span using `emb.web_vital.*` attribute names. The upstream OTel browser project now ships a web vitals instrumentation that emits log records using standardized `browser.web_vital.*` attribute names. We want to adopt the OTel implementation as our local fork to align with the emerging standard.

## Short description of changes

- Forked the OTel browser `WebVitalsInstrumentation` as the new base, switching from `sessionSpan.addEvent()` to `this.logger.emit()` (log records instead of span events)
- Renamed attribute keys: `emb.web_vital.*` → `browser.web_vital.*` for standard fields; `emb.web_vital.attribution.*` prefix retained for Embrace-specific computed extras (LoAF scripts, TTFB sub-parts)
- Event name unified to `browser.web_vital` (metric identified via `browser.web_vital.name` attribute) instead of per-metric names like `emb-web-vitals-report-LCP`
- Log body set to `JSON.stringify(metric.attribution)` — captures same primitive data as the old `webVitalAttributionToReport()` helper without redundancy
- Kept injectable `listeners` pattern for testability (not in OTel upstream)

## Integration test changes
  - Added `SCOPES_WITH_SORTED_COMPARISON` to handle non-deterministic web vitals arrival order in golden comparisons
  - Added `LOGS_WITH_IGNORED_BODY` to skip body comparison for web vitals logs (timing values change each run)
  - Added `browser.web_vital.delta`, `browser.web_vital.id`, `browser.web_vital.value` to ignored attributes list
  - Added bind mounts in `e2e-test.sh` so `:test` picks up local test file changes without rebuilding the container image