### PR TITLE
3/4 EMBR-11605 chore(demo): display user session and session part surface in demo

### DIFF
--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { log, session, trace } from '@embrace-io/web-sdk';
+import { log, page, session, trace, user } from '@embrace-io/web-sdk';
 import { EmbraceErrorBoundary } from '@embrace-io/web-sdk/react-instrumentation';
 
 import type { Span } from '@opentelemetry/api';
@@ -10,6 +10,26 @@ const formatValue = (value: string | null, truncate?: boolean): string => {
   if (!value) return '—';
   if (truncate) return value.substring(0, 8);
   return value;
+};
+
+const formatTimestamp = (ms: number | null): string => {
+  if (ms === null) return '—';
+  return new Date(ms).toLocaleTimeString();
+};
+
+const formatDuration = (ms: number): string => {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+};
+
+const formatSeconds = (seconds: number | null): string => {
+  if (seconds === null) return '—';
+  return formatDuration(seconds * 1000);
 };
 
 const InfoItem = ({
@@ -28,41 +48,161 @@ const InfoItem = ({
 );
 
 const POKEMON_URL = 'https://pokeapi.co/api/v2/pokemon/1/'; // some free and open source random API for testing purposes
-const sessionProvider = session.getSpanSessionManager();
-const logManager = log.getLogManager();
 
 const App = () => {
+  const userSessionManager = session.getSpanSessionManager();
+  const logManager = log.getLogManager();
   const [spans, setSpans] = useState<Span[]>([]);
-  const [currentSession, setCurrentSession] = useState<string | null>(null);
+  const [userSessionId, setUserSessionId] = useState<string | null>(null);
+  const [previousUserSessionId, setPreviousUserSessionId] = useState<
+    string | null
+  >(null);
+  const [sessionPartId, setSessionPartId] = useState<string | null>(null);
+  const [userSessionNumber, setUserSessionNumber] = useState<number | null>(
+    null,
+  );
+  const [userSessionPartNumber, setUserSessionPartNumber] = useState<
+    number | null
+  >(null);
+  const [userSessionStartTs, setUserSessionStartTs] = useState<number | null>(
+    null,
+  );
+  const [maxDurationSeconds, setMaxDurationSeconds] = useState<number | null>(
+    null,
+  );
+  const [inactivityTimeoutSeconds, setInactivityTimeoutSeconds] = useState<
+    number | null
+  >(null);
+  const [sessionDurationMs, setSessionDurationMs] = useState<number>(0);
+  const [partStartTs, setPartStartTs] = useState<number | null>(null);
+  const [partDurationMs, setPartDurationMs] = useState<number>(0);
+  const [partStartReason, setPartStartReason] = useState<string | null>(null);
+  const [isColdStart, setIsColdStart] = useState<boolean | null>(null);
+  const [partEndTs, setPartEndTs] = useState<number | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [embraceUserId, setEmbraceUserId] = useState<string | null>(null);
+  const [pageLabel, setPageLabel] = useState<string | null>(null);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: userSessionManager/logManager are stable SDK singletons resolved once after initSDK
   useEffect(() => {
-    const updateSession = () => {
-      setCurrentSession(sessionProvider.getSessionId());
+    const updateUserSession = () => {
+      setUserSessionId(session.getUserSessionId());
+      setPreviousUserSessionId(session.getPreviousUserSessionId());
+      const attrs = userSessionManager.getUserSessionAttributes();
+      setUserSessionNumber(attrs?.['emb.user_session_number'] ?? null);
+      setUserSessionStartTs(attrs?.['emb.user_session_start_ts'] ?? null);
+      setMaxDurationSeconds(
+        attrs?.['emb.user_session_max_duration_seconds'] ?? null,
+      );
+      setInactivityTimeoutSeconds(
+        attrs?.['emb.user_session_inactivity_timeout_seconds'] ?? null,
+      );
     };
 
-    // Set initial values
-    updateSession();
+    const updateSessionPart = () => {
+      setSessionPartId(userSessionManager.getSessionPartId());
+      const attrs = userSessionManager.getUserSessionAttributes();
+      setUserSessionPartNumber(attrs?.['emb.user_session_part_number'] ?? null);
+      const spanAttrs = userSessionManager.getSessionPartSpan()?.attributes;
+      const reason = spanAttrs?.['emb.session_part_start_reason'];
+      setPartStartReason(typeof reason === 'string' ? reason : null);
+      const cold = spanAttrs?.['emb.cold_start'];
+      setIsColdStart(typeof cold === 'boolean' ? cold : null);
+    };
 
-    // React to session lifecycle events
-    const unsubscribeStart =
-      sessionProvider.addSessionStartedListener(updateSession);
-    const unsubscribeEnd =
-      sessionProvider.addSessionEndedListener(updateSession);
+    const updateUser = () => {
+      setUserId(user.getUserId());
+      setEmbraceUserId(user.getEmbraceUserId());
+    };
+
+    const updatePage = () => {
+      setPageLabel(page.getPageLabel());
+    };
+
+    const updateAll = () => {
+      updateUserSession();
+      updateSessionPart();
+      updateUser();
+      updatePage();
+    };
+
+    updateAll();
+    // Cold-start part begins inside initSDK, before this effect runs, so the
+    // part-start listener has already fired. Seed an approximate start so the
+    // duration ticker has something to anchor to.
+    if (userSessionManager.getSessionPartId() !== null) {
+      setPartStartTs(Date.now());
+    }
+
+    const handlePartStart = () => {
+      setPartEndTs(null);
+      setPartStartTs(Date.now());
+      updateUserSession();
+      updateSessionPart();
+    };
+    const handlePartEnd = () => {
+      setPartEndTs(Date.now());
+      // End listeners fire before the SDK clears the part span, so defer the
+      // re-read until after the SDK finishes cleaning up its state.
+      queueMicrotask(updateSessionPart);
+    };
+
+    const unsubscribePartStart =
+      userSessionManager.addSessionPartStartedListener(handlePartStart);
+    const unsubscribePartEnd =
+      userSessionManager.addSessionPartEndedListener(handlePartEnd);
+
+    // user / page APIs have no listener hook; poll to keep the panel live.
+    // Also refresh immediately on focus / visibility gain so the display is
+    // current the moment this tab becomes engaged again.
+    //
+    // Demo-only: customer apps should not need this; they receive part
+    // lifecycle events via the internal listeners above and read user / page
+    // values lazily on render.
+    const pollInterval = setInterval(updateAll, 500);
+    window.addEventListener('focus', updateAll);
+    document.addEventListener('visibilitychange', updateAll);
 
     return () => {
-      unsubscribeStart();
-      unsubscribeEnd();
+      unsubscribePartStart();
+      unsubscribePartEnd();
+      clearInterval(pollInterval);
+      window.removeEventListener('focus', updateAll);
+      document.removeEventListener('visibilitychange', updateAll);
     };
   }, []);
 
-  const handleStartSessionSpan = () => {
-    sessionProvider.startSessionSpan();
-    setCurrentSession(sessionProvider.getSessionId());
-  };
+  useEffect(() => {
+    if (userSessionStartTs === null) {
+      setSessionDurationMs(0);
+      return;
+    }
+    const tick = () => setSessionDurationMs(Date.now() - userSessionStartTs);
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, [userSessionStartTs]);
 
-  const handleEndSessionSpan = () => {
-    sessionProvider.endSessionSpan();
-    setCurrentSession(sessionProvider.getSessionId());
+  useEffect(() => {
+    if (partStartTs === null) {
+      setPartDurationMs(0);
+      return;
+    }
+    if (partEndTs !== null) {
+      setPartDurationMs(partEndTs - partStartTs);
+      return;
+    }
+    const tick = () =>
+      setPartDurationMs(
+        performance.timeOrigin + performance.now() - partStartTs,
+      );
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, [partStartTs, partEndTs]);
+
+  const handleEndUserSession = () => {
+    session.endUserSession();
   };
 
   const handleStartSpan = () => {
@@ -83,9 +223,9 @@ const App = () => {
   };
 
   const handleRecordException = () => {
-    const sessionSpan = sessionProvider.getSessionSpan();
-    if (sessionSpan) {
-      sessionSpan.recordException({
+    const sessionPartSpan = userSessionManager.getSessionPartSpan();
+    if (sessionPartSpan) {
+      sessionPartSpan.recordException({
         name: 'Error',
         message: 'This is an error',
         stack: 'Error: This is an error',
@@ -94,8 +234,8 @@ const App = () => {
   };
 
   const handleAddPermanentSessionProperty = (key: string, value: string) => {
-    const sessionSpan = sessionProvider.getSessionSpan();
-    if (sessionSpan) {
+    const sessionPartSpan = userSessionManager.getSessionPartSpan();
+    if (sessionPartSpan) {
       session.addProperty(key, value, {
         lifespan: 'permanent',
       });
@@ -103,15 +243,15 @@ const App = () => {
   };
 
   const handleAddSessionProperty = (key: string, value: string) => {
-    const sessionSpan = sessionProvider.getSessionSpan();
-    if (sessionSpan) {
+    const sessionPartSpan = userSessionManager.getSessionPartSpan();
+    if (sessionPartSpan) {
       session.addProperty(key, value);
     }
   };
 
   const handleRemoveSessionProperty = (key: string) => {
-    const sessionSpan = sessionProvider.getSessionSpan();
-    if (sessionSpan) {
+    const sessionPartSpan = userSessionManager.getSessionPartSpan();
+    if (sessionPartSpan) {
       session.removeProperty(key);
     }
   };
@@ -284,9 +424,84 @@ const App = () => {
   return (
     <>
       <fieldset style={{ gridColumn: '1 / -1' }}>
-        <legend>Experience</legend>
+        <legend>User Session</legend>
         <dl className="info-list info-list-grid">
-          <InfoItem label="Session ID" value={currentSession} truncate />
+          <InfoItem
+            label="User Session #"
+            value={userSessionNumber?.toString() ?? null}
+          />
+          <InfoItem label="ID" value={userSessionId} truncate />
+          <InfoItem
+            label="Previous ID"
+            value={previousUserSessionId}
+            truncate
+          />
+          <InfoItem
+            label="Started"
+            value={formatTimestamp(userSessionStartTs)}
+          />
+          <InfoItem
+            label="Duration"
+            value={
+              userSessionStartTs === null
+                ? null
+                : formatDuration(sessionDurationMs)
+            }
+          />
+        </dl>
+      </fieldset>
+
+      <fieldset style={{ gridColumn: '1 / -1' }}>
+        <legend>Session Part</legend>
+        <dl className="info-list info-list-grid">
+          <InfoItem
+            label="Part #"
+            value={userSessionPartNumber?.toString() ?? null}
+          />
+          <InfoItem label="ID" value={sessionPartId} truncate />
+          <InfoItem label="Started" value={formatTimestamp(partStartTs)} />
+          <InfoItem
+            label="Duration"
+            value={partStartTs === null ? null : formatDuration(partDurationMs)}
+          />
+          <InfoItem label="Start Reason" value={partStartReason} />
+          <InfoItem
+            label="Cold Start"
+            value={isColdStart === null ? null : isColdStart ? 'yes' : 'no'}
+          />
+        </dl>
+      </fieldset>
+
+      <fieldset style={{ gridColumn: '1 / -1' }}>
+        <legend>Session Config (locked at creation)</legend>
+        <dl className="info-list info-list-horizontal">
+          <InfoItem
+            label="Max Duration"
+            value={formatSeconds(maxDurationSeconds)}
+          />
+          <InfoItem
+            label="Inactivity Timeout"
+            value={formatSeconds(inactivityTimeoutSeconds)}
+          />
+        </dl>
+      </fieldset>
+
+      <fieldset style={{ gridColumn: '1 / -1' }}>
+        <legend>Context</legend>
+        <dl className="info-list info-list-horizontal">
+          <InfoItem
+            label="Part Status"
+            value={
+              sessionPartId !== null
+                ? `active (foreground; started ${partStartReason ?? '—'})`
+                : partEndTs !== null
+                  ? `inactive (ended ${formatTimestamp(partEndTs)})`
+                  : 'inactive'
+            }
+          />
+          <InfoItem label="Page Label" value={pageLabel} />
+          <InfoItem label="User ID" value={userId} />
+          <InfoItem label="Embrace User ID" value={embraceUserId} truncate />
         </dl>
       </fieldset>
 
@@ -295,25 +510,11 @@ const App = () => {
         <div className="actions">
           <button
             type="button"
-            onClick={handleStartSessionSpan}
-            disabled={sessionProvider.getSessionSpan() !== null}
+            onClick={handleEndUserSession}
+            disabled={userSessionManager.getSessionPartSpan() === null}
+            title="End the current user session; a new one starts on the next foreground part"
           >
-            Start Session span
-          </button>
-          <button
-            type="button"
-            onClick={handleStartSessionSpan}
-            disabled={sessionProvider.getSessionSpan() === null}
-            title="Force a new Session Span to start"
-          >
-            Override Session span
-          </button>
-          <button
-            type="button"
-            onClick={handleEndSessionSpan}
-            disabled={sessionProvider.getSessionSpan() === null}
-          >
-            End Session Span
+            End User Session
           </button>
         </div>
       </fieldset>
@@ -323,7 +524,7 @@ const App = () => {
         <button
           type="button"
           onClick={handleStartSpan}
-          disabled={sessionProvider.getSessionSpan() === null}
+          disabled={userSessionManager.getSessionPartSpan() === null}
         >
           Start Span
         </button>
@@ -351,21 +552,21 @@ const App = () => {
           <button
             type="button"
             onClick={handleSendEmbraceInfoLog}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Send Embrace Info Log
           </button>
           <button
             type="button"
             onClick={handleSendEmbraceWarnLog}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Send Embrace Warning Log
           </button>
           <button
             type="button"
             onClick={handleSendEmbraceErrorLog}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Send Embrace Error Log
           </button>
@@ -383,7 +584,7 @@ const App = () => {
                 'permanent-value',
               )
             }
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Add Permanent Session Property
           </button>
@@ -391,7 +592,7 @@ const App = () => {
           <button
             type="button"
             onClick={() => handleRemoveSessionProperty('permanent-key')}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Remove Permanent Session Property
           </button>
@@ -402,14 +603,14 @@ const App = () => {
             onClick={() =>
               handleAddSessionProperty('session-key', 'session-value')
             }
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Add Session Property
           </button>
           <button
             type="button"
             onClick={() => handleRemoveSessionProperty('session-key')}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Remove Session Property
           </button>
@@ -422,21 +623,21 @@ const App = () => {
           <button
             type="button"
             onClick={handleRecordException}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Record Exception
           </button>
           <button
             type="button"
             onClick={handleThrowError}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Throw Error
           </button>
           <button
             type="button"
             onClick={handleRejectPromise}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Reject Promise
           </button>
@@ -446,28 +647,28 @@ const App = () => {
           <button
             type="button"
             onClick={handleThrowDOMException}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Throw DOM Exception
           </button>
           <button
             type="button"
             onClick={handleThrowString}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Throw String
           </button>
           <button
             type="button"
             onClick={handleThrowUndefined}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Throw Undefined
           </button>
           <button
             type="button"
             onClick={handleFailedResourceLoad}
-            disabled={sessionProvider.getSessionSpan() === null}
+            disabled={userSessionManager.getSessionPartSpan() === null}
           >
             Trigger Failed Resource Load
           </button>
@@ -513,8 +714,8 @@ const App = () => {
           <button type="button" onClick={handleLoadLoafScripts}>
             Load LoAF Scripts (x4)
           </button>
-          <button type="button" onClick={handleEndSessionSpan}>
-            End Session (flush LoAF report)
+          <button type="button" onClick={handleEndUserSession}>
+            End User Session (flush LoAF report)
           </button>
         </div>
       </fieldset>

--- a/demo/frontend/src/NavPage.tsx
+++ b/demo/frontend/src/NavPage.tsx
@@ -2,7 +2,6 @@ import { session } from '@embrace-io/web-sdk';
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 
-const sessionProvider = session.getSpanSessionManager();
 const navEntry = window.performance.getEntriesByType('navigation')[0] as
   | PerformanceNavigationTiming
   | undefined;
@@ -16,23 +15,32 @@ const NavPage = ({
   nav?: ReactNode;
   children?: ReactNode;
 }) => {
-  const [sessionId, setSessionId] = useState<string | null>(null);
+  // Resolve at render time, not module load: the proxy's getSpanSessionManager()
+  // returns the underlying manager directly, and at module load that's still
+  // the no-op stand-in (setupSDK runs after this module's imports resolve).
+  const userSessionManager = session.getSpanSessionManager();
+  const [sessionPartId, setSessionPartId] = useState<string | null>(null);
+  const [userSessionPartNumber, setUserSessionPartNumber] = useState<
+    number | null
+  >(null);
 
-  const updateSession = useCallback(() => {
-    setSessionId(sessionProvider.getSessionId());
-  }, []);
+  const updateSessionPart = useCallback(() => {
+    setSessionPartId(userSessionManager.getSessionPartId());
+    const attrs = userSessionManager.getUserSessionAttributes();
+    setUserSessionPartNumber(attrs?.['emb.user_session_part_number'] ?? null);
+  }, [userSessionManager]);
 
   useEffect(() => {
-    updateSession();
+    updateSessionPart();
     const unsubscribeStart =
-      sessionProvider.addSessionStartedListener(updateSession);
+      userSessionManager.addSessionPartStartedListener(updateSessionPart);
     const unsubscribeEnd =
-      sessionProvider.addSessionEndedListener(updateSession);
+      userSessionManager.addSessionPartEndedListener(updateSessionPart);
     return () => {
       unsubscribeStart();
       unsubscribeEnd();
     };
-  }, [updateSession]);
+  }, [userSessionManager, updateSessionPart]);
 
   return (
     <>
@@ -51,10 +59,12 @@ const NavPage = ({
         </dl>
       </fieldset>
       <fieldset>
-        <legend>Session</legend>
+        <legend>Session Part</legend>
         <dl className="info-list">
-          <dt>Session ID</dt>
-          <dd>{sessionId ?? '—'}</dd>
+          <dt>Part #</dt>
+          <dd>{userSessionPartNumber?.toString() ?? '—'}</dd>
+          <dt>Session Part ID</dt>
+          <dd>{sessionPartId ?? '—'}</dd>
         </dl>
       </fieldset>
     </>

--- a/demo/frontend/src/otel-base.ts
+++ b/demo/frontend/src/otel-base.ts
@@ -3,6 +3,9 @@ import { DiagLogLevel, initSDK, user } from '@embrace-io/web-sdk';
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-web';
+import { version } from '../../../packages/web-sdk/package.json' with {
+  type: 'json',
+};
 
 const APP_ID = import.meta.env.VITE_APP_ID;
 const DATA_URL = import.meta.env.VITE_DATA_URL;
@@ -12,7 +15,7 @@ const setupSDK = (instrumentations?: Instrumentation[]) => {
   const result = initSDK({
     logLevel: DiagLogLevel.ALL,
     appID: APP_ID || undefined,
-    appVersion: '1.0.0',
+    appVersion: version,
     spanExporters: [new ConsoleSpanExporter()],
     logExporters: [new ConsoleLogRecordExporter()],
     defaultInstrumentationConfig: {
@@ -32,7 +35,7 @@ const setupSDK = (instrumentations?: Instrumentation[]) => {
   });
 
   if (result) {
-    console.log('Successfully initialized the Embrace SDK', APP_ID);
+    console.log('Successfully initialized the Embrace SDK', APP_ID, version);
   } else {
     console.error('Failed to initialize the Embrace SDK', APP_ID);
   }


### PR DESCRIPTION
## What problem is this solving?

The in-repo demo predates the user-session and session-part redefinition: it calls deprecated no-op listener stubs and never touches the part-level surface, so QA cannot exercise the spec end to end. This PR refreshes `demo/frontend/` against the public API on the 2/4 branch.

## Short description of changes

- `demo/frontend/src/App.tsx`: panel rewrite with `User Session`, `Session Part`, `Session Config (locked at creation)`, and `Context` blocks; single `End User Session` button replacing the old start/override/end trio; live duration tickers on both layers. Reads through `session.getSpanSessionManager()` (returns `SpanSessionManagerInternal` on 2/4) for `getSessionPartId`, `getSessionPartSpan`, `getUserSessionAttributes`, and the part-level listeners. The SDK does not expose a part start timestamp, so the demo seeds `partStartTs` from `Date.now()` inside `addSessionPartStartedListener` and a one-time mount seed covers the cold-start part that begins inside `initSDK` before the React effect runs. Drops the `storage` event listener: cross-tab storage events were removed earlier in the stack.
- `demo/frontend/src/NavPage.tsx`: switch to `getSessionPartId` and `addSessionPartStartedListener` / `addSessionPartEndedListener`. The previous `addSessionStartedListener` / `addSessionEndedListener` calls are now no-op stubs and never fired, so the panel was stuck on its initial render. Show `Part #` next to `Session Part ID`. Resolve the manager inside the component body, not at module load: `ProxySpanSessionManager.getSpanSessionManager()` returns the underlying field directly, and at import time that is still the no-op stand-in (`setupSDK` runs after the imports resolve), so caching at module load left the subscription attached to the wrong instance.
- `demo/frontend/src/otel-base.ts`: source `appVersion` from the SDK `package.json` so the value matches the binary under test.

## Stack

Based on 2/4 (#1308). Follow-up will land the mechanical rename to `UserSession` / `SessionPart` and the API documentation.

## Testing

- [x] `npm run check`
- [ ] Manual: load `/`, watch `User Session #` / `Part #` advance, click `End User Session` and confirm a fresh user session begins on the next foreground part. Verify `Part #` and `Session Part ID` appear and increment on `/soft/`, `/react-router-v5/`, `/react-router-v6-data/`, and `/react-router-v6-declarative/` after each soft nav.