### PR TITLE
refactor(managers): require storage / perf / visibilityDoc deps

### DIFF
--- a/packages/web-sdk/src/api-logs/logAPI.test.ts
+++ b/packages/web-sdk/src/api-logs/logAPI.test.ts
@@ -1,10 +1,12 @@
 import { expect } from 'chai';
+import { InMemoryStorage } from '../../tests/utils/index.ts';
 import {
   DEFAULT_LIMITS,
   EmbraceLimitManager,
   EmbraceLogManager,
   EmbraceSpanSessionManager,
 } from '../managers/index.ts';
+import { OTelPerformanceManager } from '../utils/index.ts';
 import { log } from './logAPI.ts';
 
 describe('logAPI', () => {
@@ -32,9 +34,19 @@ describe('logAPI', () => {
 
     beforeEach(() => {
       const limitManager = new EmbraceLimitManager({ ...DEFAULT_LIMITS });
+      const storage = new InMemoryStorage();
+      const perf = new OTelPerformanceManager();
       manager = new EmbraceLogManager({
-        spanSessionManager: new EmbraceSpanSessionManager({ limitManager }),
+        spanSessionManager: new EmbraceSpanSessionManager({
+          limitManager,
+          perf,
+          storage,
+          visibilityDoc: window.document,
+        }),
         limitManager,
+        perf,
+        storage,
+        visibilityDoc: window.document,
       });
       log.setGlobalLogManager(manager);
     });

--- a/packages/web-sdk/src/api-sessions/sessionAPI.test.ts
+++ b/packages/web-sdk/src/api-sessions/sessionAPI.test.ts
@@ -1,9 +1,11 @@
 import { expect } from 'chai';
+import { InMemoryStorage } from '../../tests/utils/index.ts';
 import {
   DEFAULT_LIMITS,
   EmbraceLimitManager,
   EmbraceSpanSessionManager,
 } from '../managers/index.ts';
+import { OTelPerformanceManager } from '../utils/index.ts';
 import { session } from './sessionAPI.ts';
 
 describe('sessionAPI', () => {
@@ -57,6 +59,9 @@ describe('sessionAPI', () => {
     beforeEach(() => {
       manager = new EmbraceSpanSessionManager({
         limitManager: new EmbraceLimitManager({ ...DEFAULT_LIMITS }),
+        perf: new OTelPerformanceManager(),
+        storage: new InMemoryStorage(),
+        visibilityDoc: window.document,
       });
       manager.startSessionSpan();
       session.setGlobalSessionManager(manager);

--- a/packages/web-sdk/src/api-users/userAPI.test.ts
+++ b/packages/web-sdk/src/api-users/userAPI.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { InMemoryStorage } from '../../tests/utils/index.ts';
 import { EmbraceUserManager } from '../managers/index.ts';
 import { UserAPI } from './api/index.ts';
 import { user } from './userAPI.ts';
@@ -33,7 +34,7 @@ describe('userAPI', () => {
     ];
 
     beforeEach(() => {
-      manager = new EmbraceUserManager();
+      manager = new EmbraceUserManager({ storage: new InMemoryStorage() });
       user.setGlobalUserManager(manager);
     });
 

--- a/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
@@ -3,6 +3,7 @@ import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
 import * as chai from 'chai';
 import {
   InMemoryDiagLogger,
+  InMemoryStorage,
   setupTestTraceExporter,
 } from '../../../../tests/utils/index.ts';
 import type { SpanSessionManager } from '../../../api-sessions/index.ts';
@@ -12,6 +13,7 @@ import {
   EmbraceLimitManager,
   EmbraceSpanSessionManager,
 } from '../../../managers/index.ts';
+import { OTelPerformanceManager } from '../../../utils/index.ts';
 import { ClicksInstrumentation } from './ClicksInstrumentation.ts';
 
 const { expect } = chai;
@@ -32,6 +34,9 @@ describe('ClicksInstrumentation', () => {
     diag = new InMemoryDiagLogger();
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
     });
     session.setGlobalSessionManager(spanSessionManager);
     spanSessionManager.startSessionSpan();

--- a/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
@@ -2,6 +2,7 @@ import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
 import * as chai from 'chai';
 import {
   InMemoryDiagLogger,
+  InMemoryStorage,
   setupTestTraceExporter,
 } from '../../../../tests/utils/index.ts';
 import type { SpanSessionManager } from '../../../api-sessions/index.ts';
@@ -11,6 +12,7 @@ import {
   EmbraceLimitManager,
   EmbraceSpanSessionManager,
 } from '../../../managers/index.ts';
+import { OTelPerformanceManager } from '../../../utils/index.ts';
 import { EmptyRootInstrumentation } from './EmptyRootInstrumentation.ts';
 
 const { expect } = chai;
@@ -30,6 +32,9 @@ describe('EmptyInstrumentation', () => {
     diag = new InMemoryDiagLogger();
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
     });
     session.setGlobalSessionManager(spanSessionManager);
     spanSessionManager.startSessionSpan();

--- a/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.test.ts
@@ -4,6 +4,7 @@ import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {
+  InMemoryStorage,
   MockPerformanceManager,
   setupTestLogExporter,
 } from '../../../../tests/utils/index.ts';
@@ -44,13 +45,22 @@ describe('GlobalExceptionInstrumentation', () => {
   beforeEach(() => {
     memoryExporter.reset();
     const limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
-    logManager = new EmbraceLogManager({
-      spanSessionManager: new EmbraceSpanSessionManager({ limitManager }),
-      limitManager,
-    });
-    log.setGlobalLogManager(logManager);
+    const storage = new InMemoryStorage();
     clock = sinon.useFakeTimers();
     perf = new MockPerformanceManager(clock);
+    logManager = new EmbraceLogManager({
+      spanSessionManager: new EmbraceSpanSessionManager({
+        limitManager,
+        perf,
+        storage,
+        visibilityDoc: window.document,
+      }),
+      limitManager,
+      perf,
+      storage,
+      visibilityDoc: window.document,
+    });
+    log.setGlobalLogManager(logManager);
     instrumentation = new GlobalExceptionInstrumentation({
       perf,
     });
@@ -73,7 +83,6 @@ describe('GlobalExceptionInstrumentation', () => {
         existingErrorHandler?.call(window, event, source, lineno, colno, error);
       }
     };
-    localStorage.clear();
   });
 
   afterEach(() => {

--- a/packages/web-sdk/src/instrumentations/exceptions/react/EmbraceErrorBoundary/EmbraceErrorBoundary.test.ts
+++ b/packages/web-sdk/src/instrumentations/exceptions/react/EmbraceErrorBoundary/EmbraceErrorBoundary.test.ts
@@ -2,7 +2,10 @@ import { SeverityNumber } from '@opentelemetry/api-logs';
 import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
 import * as chai from 'chai';
 import type React from 'react';
-import { setupTestLogExporter } from '../../../../../tests/utils/index.ts';
+import {
+  InMemoryStorage,
+  setupTestLogExporter,
+} from '../../../../../tests/utils/index.ts';
 import type { LogManager } from '../../../../api-logs/index.ts';
 import { log } from '../../../../api-logs/index.ts';
 import {
@@ -16,6 +19,7 @@ import {
   EmbraceLogManager,
   EmbraceSpanSessionManager,
 } from '../../../../managers/index.ts';
+import { OTelPerformanceManager } from '../../../../utils/index.ts';
 import { EmbraceErrorBoundary } from './EmbraceErrorBoundary.ts';
 
 const { expect } = chai;
@@ -37,9 +41,19 @@ describe('EmbraceErrorBoundary', () => {
   beforeEach(() => {
     memoryExporter.reset();
     const limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
+    const storage = new InMemoryStorage();
+    const perf = new OTelPerformanceManager();
     logManager = new EmbraceLogManager({
-      spanSessionManager: new EmbraceSpanSessionManager({ limitManager }),
+      spanSessionManager: new EmbraceSpanSessionManager({
+        limitManager,
+        perf,
+        storage,
+        visibilityDoc: window.document,
+      }),
       limitManager,
+      perf,
+      storage,
+      visibilityDoc: window.document,
     });
     log.setGlobalLogManager(logManager);
 
@@ -47,8 +61,6 @@ describe('EmbraceErrorBoundary', () => {
       fallback: () => 'fallback',
       children: 'children',
     });
-
-    localStorage.clear();
   });
 
   it('should catch an error and log an exception', () => {

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
@@ -4,6 +4,7 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {
   InMemoryDiagLogger,
+  InMemoryStorage,
   MockPerformanceManager,
   setupTestLogExporter,
   setupTestTraceExporter,
@@ -99,11 +100,20 @@ describe('LoafInstrumentation', () => {
     clock = sinon.useFakeTimers();
     perf = new MockPerformanceManager(clock);
     const limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
-    spanSessionManager = new EmbraceSpanSessionManager({ limitManager });
+    const storage = new InMemoryStorage();
+    spanSessionManager = new EmbraceSpanSessionManager({
+      limitManager,
+      perf,
+      storage,
+      visibilityDoc: window.document,
+    });
     spanSessionManager.startSessionSpan();
     const logManager = new EmbraceLogManager({
       spanSessionManager,
       limitManager,
+      perf,
+      storage,
+      visibilityDoc: window.document,
     });
     log.setGlobalLogManager(logManager);
 
@@ -481,13 +491,20 @@ describe('LoafInstrumentation', () => {
 
     // Create a second session manager and switch to it
     const limitManager2 = new EmbraceLimitManager(DEFAULT_LIMITS);
+    const storage2 = new InMemoryStorage();
     const spanSessionManager2 = new EmbraceSpanSessionManager({
       limitManager: limitManager2,
+      perf,
+      storage: storage2,
+      visibilityDoc: window.document,
     });
     spanSessionManager2.startSessionSpan();
     const logManager2 = new EmbraceLogManager({
       spanSessionManager: spanSessionManager2,
       limitManager: limitManager2,
+      perf,
+      storage: storage2,
+      visibilityDoc: window.document,
     });
     log.setGlobalLogManager(logManager2);
     instrumentation.setSessionManager(spanSessionManager2);

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
@@ -2,6 +2,7 @@ import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
 import * as chai from 'chai';
 import {
   InMemoryDiagLogger,
+  InMemoryStorage,
   setupTestTraceExporter,
 } from '../../../../tests/utils/index.ts';
 import { page } from '../../../api-page/index.ts';
@@ -13,6 +14,7 @@ import {
   EmbracePageManager,
   EmbraceSpanSessionManager,
 } from '../../../managers/index.ts';
+import { OTelPerformanceManager } from '../../../utils/index.ts';
 import { NavigationInstrumentation } from './NavigationInstrumentation.ts';
 
 const { expect } = chai;
@@ -34,6 +36,9 @@ describe('NavigationInstrumentation', () => {
 
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
     });
     session.setGlobalSessionManager(spanSessionManager);
 

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV5/ReactRouterV5.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV5/ReactRouterV5.test.tsx
@@ -2,7 +2,10 @@ import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
 import * as chai from 'chai';
 import { createBrowserHistory } from 'history';
 import { Route, Router, Switch, useHistory } from 'react-router-domv4v5';
-import { setupTestTraceExporter } from '../../../../../../tests/utils/index.ts';
+import {
+  InMemoryStorage,
+  setupTestTraceExporter,
+} from '../../../../../../tests/utils/index.ts';
 import { render } from '../../../../../../tests/utils/react/reactTestUtils.ts';
 import { runReactRouterTest } from '../../../../../../tests/utils/react/sharedTests.ts';
 import {
@@ -21,6 +24,7 @@ import {
   EmbraceSpanSessionManager,
 } from '../../../../../managers/index.ts';
 import { PageSpanProcessor } from '../../../../../processors/index.ts';
+import { OTelPerformanceManager } from '../../../../../utils/index.ts';
 import { withEmbraceRoutingLegacy } from './withEmbraceRoutingLegacy.ts';
 
 const { expect } = chai;
@@ -71,6 +75,9 @@ describe('ReactRouterV5Legacy', () => {
   before(() => {
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
     });
 
     session.setGlobalSessionManager(spanSessionManager);

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Data/ReactRouterV6Data.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Data/ReactRouterV6Data.test.tsx
@@ -8,7 +8,10 @@ import {
   RouterProvider,
   useNavigate,
 } from 'react-router-domv6plus';
-import { setupTestTraceExporter } from '../../../../../../tests/utils/index.ts';
+import {
+  InMemoryStorage,
+  setupTestTraceExporter,
+} from '../../../../../../tests/utils/index.ts';
 import { render } from '../../../../../../tests/utils/react/reactTestUtils.ts';
 import { runReactRouterTest } from '../../../../../../tests/utils/react/sharedTests.ts';
 import {
@@ -27,6 +30,7 @@ import {
   EmbraceSpanSessionManager,
 } from '../../../../../managers/index.ts';
 import { PageSpanProcessor } from '../../../../../processors/index.ts';
+import { OTelPerformanceManager } from '../../../../../utils/index.ts';
 import { listenToRouterChanges } from './listenToRouterChanges.ts';
 
 const { expect } = chai;
@@ -108,6 +112,9 @@ describe('ReactRouterV6Data', () => {
   before(() => {
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
     });
 
     session.setGlobalSessionManager(spanSessionManager);

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Declarative/ReactRouterV6Declarative.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Declarative/ReactRouterV6Declarative.test.tsx
@@ -7,7 +7,10 @@ import {
   Routes,
   useNavigate,
 } from 'react-router-domv6plus';
-import { setupTestTraceExporter } from '../../../../../../tests/utils/index.ts';
+import {
+  InMemoryStorage,
+  setupTestTraceExporter,
+} from '../../../../../../tests/utils/index.ts';
 import { render } from '../../../../../../tests/utils/react/reactTestUtils.ts';
 import { runReactRouterTest } from '../../../../../../tests/utils/react/sharedTests.ts';
 import {
@@ -26,6 +29,7 @@ import {
   EmbraceSpanSessionManager,
 } from '../../../../../managers/index.ts';
 import { PageSpanProcessor } from '../../../../../processors/index.ts';
+import { OTelPerformanceManager } from '../../../../../utils/index.ts';
 import { withEmbraceRouting } from './withEmbraceRouting.ts';
 
 const { expect } = chai;
@@ -83,6 +87,9 @@ describe('ReactRouterV6Declarative', () => {
   before(() => {
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
     });
 
     session.setGlobalSessionManager(spanSessionManager);

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
@@ -3,6 +3,7 @@ import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {
+  InMemoryStorage,
   MockPerformanceManager,
   setupTestLogExporter,
 } from '../../../../tests/utils/index.ts';
@@ -50,11 +51,20 @@ describe('ServerTimingInstrumentation', () => {
     perf = new MockPerformanceManager(clock);
 
     limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
-    const spanSessionManager = new EmbraceSpanSessionManager({ limitManager });
+    const storage = new InMemoryStorage();
+    const spanSessionManager = new EmbraceSpanSessionManager({
+      limitManager,
+      perf,
+      storage,
+      visibilityDoc: window.document,
+    });
     spanSessionManager.startSessionSpan();
     const logManager = new EmbraceLogManager({
       spanSessionManager,
       limitManager,
+      perf,
+      storage,
+      visibilityDoc: window.document,
     });
     log.setGlobalLogManager(logManager);
 

--- a/packages/web-sdk/src/instrumentations/session/SpanSessionBrowserActivityInstrumentation/SpanSessionBrowserActivityInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/SpanSessionBrowserActivityInstrumentation/SpanSessionBrowserActivityInstrumentation.test.ts
@@ -4,6 +4,7 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {
   InMemoryDiagLogger,
+  InMemoryStorage,
   setupTestTraceExporter,
 } from '../../../../tests/utils/index.ts';
 import type { SpanSessionManager } from '../../../api-sessions/index.ts';
@@ -17,6 +18,7 @@ import {
   EmbraceLimitManager,
   EmbraceSpanSessionManager,
 } from '../../../managers/index.ts';
+import { OTelPerformanceManager } from '../../../utils/index.ts';
 import { TIMEOUT_TIME, WINDOW_USER_EVENTS } from './constants.ts';
 import { SpanSessionBrowserActivityInstrumentation } from './SpanSessionBrowserActivityInstrumentation.ts';
 
@@ -39,6 +41,9 @@ describe('SpanSessionBrowserActivityInstrumentation', () => {
     diag = new InMemoryDiagLogger();
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
     });
     session.setGlobalSessionManager(spanSessionManager);
   });

--- a/packages/web-sdk/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.test.ts
@@ -1,7 +1,10 @@
 import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
 import * as chai from 'chai';
 import sinon from 'sinon';
-import { setupTestTraceExporter } from '../../../../tests/utils/index.ts';
+import {
+  InMemoryStorage,
+  setupTestTraceExporter,
+} from '../../../../tests/utils/index.ts';
 import type { SpanSessionManager } from '../../../api-sessions/index.ts';
 import { session } from '../../../api-sessions/index.ts';
 import type { VisibilityStateDocument } from '../../../common/index.ts';
@@ -36,6 +39,8 @@ describe('SpanSessionVisibilityInstrumentation', () => {
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
       perf,
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
     });
     session.setGlobalSessionManager(spanSessionManager);
   });

--- a/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
@@ -6,6 +6,7 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {
   InMemoryDiagLogger,
+  InMemoryStorage,
   MockPerformanceManager,
   setupTestLogExporter,
   setupTestTraceExporter,
@@ -115,11 +116,20 @@ describe('UserTimingInstrumentation', () => {
     perf = new MockPerformanceManager(clock);
 
     limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
-    const spanSessionManager = new EmbraceSpanSessionManager({ limitManager });
+    const storage = new InMemoryStorage();
+    const spanSessionManager = new EmbraceSpanSessionManager({
+      limitManager,
+      perf,
+      storage,
+      visibilityDoc: window.document,
+    });
     spanSessionManager.startSessionSpan();
     const logManager = new EmbraceLogManager({
       spanSessionManager,
       limitManager,
+      perf,
+      storage,
+      visibilityDoc: window.document,
     });
     log.setGlobalLogManager(logManager);
 

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -10,6 +10,7 @@ import type {
 } from 'web-vitals/attribution';
 import {
   InMemoryDiagLogger,
+  InMemoryStorage,
   MockPerformanceManager,
   setupTestTraceExporter,
   setupTestWebVitalListeners,
@@ -62,6 +63,9 @@ describe('WebVitalsInstrumentation', () => {
     diag = new InMemoryDiagLogger();
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      perf,
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
     });
     session.setGlobalSessionManager(spanSessionManager);
     spanSessionManager.startSessionSpan();

--- a/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.test.ts
@@ -31,6 +31,7 @@ describe('EmbraceDynamicConfigManager', () => {
 
   it('should set the config using setConfig method', () => {
     const configManager = new EmbraceDynamicConfigManager({
+      storage,
       defaultConfig: {
         samplingPct: 50,
       },
@@ -47,7 +48,7 @@ describe('EmbraceDynamicConfigManager', () => {
   });
 
   it('should get the default config for an app not connected to Embrace', () => {
-    const configManager = new EmbraceDynamicConfigManager();
+    const configManager = new EmbraceDynamicConfigManager({ storage });
 
     const config = configManager.getConfig();
 
@@ -59,6 +60,7 @@ describe('EmbraceDynamicConfigManager', () => {
 
   it('should get the user-provided config for an app not connected to Embrace', () => {
     const configManager = new EmbraceDynamicConfigManager({
+      storage,
       defaultConfig: {
         samplingPct: 50,
       },
@@ -117,7 +119,7 @@ describe('EmbraceDynamicConfigManager', () => {
   });
 
   it('should not fetch the remote config if is not connected to Embrace', async () => {
-    const configManager = new EmbraceDynamicConfigManager();
+    const configManager = new EmbraceDynamicConfigManager({ storage });
 
     await configManager.refreshRemoteConfig();
 

--- a/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.ts
@@ -45,11 +45,11 @@ export class EmbraceDynamicConfigManager implements DynamicConfigManager {
     diag: diagParam = diag.createComponentLogger({
       namespace: 'embrace-config-manager',
     }),
-    storage = window.localStorage,
+    storage,
     // Allow users to provide a default config
     defaultConfig = {},
     embraceConfigURL,
-  }: EmbraceDynamicConfigManagerArgs = {}) {
+  }: EmbraceDynamicConfigManagerArgs) {
     if (appID && appVersion && deviceId) {
       this._remoteConfigURL = getConfigURL(
         appID,

--- a/packages/web-sdk/src/managers/EmbraceConfigManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceConfigManager/types.ts
@@ -27,7 +27,7 @@ export interface EmbraceDynamicConfigManagerArgs {
   appVersion?: string;
   deviceId?: string;
   diag?: DiagLogger;
-  storage?: Storage;
+  storage: Storage;
   defaultConfig?: Partial<DynamicSDKConfig>;
   embraceConfigURL?: string;
 }

--- a/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
@@ -16,6 +16,7 @@ import sinonChai from 'sinon-chai';
 import {
   FailingStorage,
   InMemoryDiagLogger,
+  InMemoryStorage,
   setupTestLogExporter,
   setupTestTraceExporter,
 } from '../../../tests/utils/index.ts';
@@ -57,6 +58,7 @@ describe('EmbraceLogManager', () => {
   let spanSessionManager: EmbraceSpanSessionManager;
   let limitManager: EmbraceLimitManager;
   let diag: InMemoryDiagLogger;
+  let storage: InMemoryStorage;
 
   before(() => {
     memoryExporter = setupTestLogExporter();
@@ -92,15 +94,20 @@ describe('EmbraceLogManager', () => {
       },
     });
 
+    storage = new InMemoryStorage();
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager,
+      perf,
+      storage,
+      visibilityDoc: window.document,
     });
     manager = new EmbraceLogManager({
       perf,
       spanSessionManager,
       limitManager,
+      storage,
+      visibilityDoc: window.document,
     });
-    localStorage.clear();
   });
 
   afterEach(() => {
@@ -119,6 +126,8 @@ describe('EmbraceLogManager', () => {
       perf,
       spanSessionManager,
       limitManager,
+      storage,
+      visibilityDoc: window.document,
     });
 
     testManager.message('   ', 'info');
@@ -139,6 +148,8 @@ describe('EmbraceLogManager', () => {
       perf,
       spanSessionManager,
       limitManager,
+      storage,
+      visibilityDoc: window.document,
     });
 
     // @ts-expect-error testing invalid severity
@@ -161,6 +172,8 @@ describe('EmbraceLogManager', () => {
       perf,
       spanSessionManager,
       limitManager,
+      storage,
+      visibilityDoc: window.document,
     });
 
     testManager.message('test message', 'info', {
@@ -187,6 +200,8 @@ describe('EmbraceLogManager', () => {
       perf,
       spanSessionManager,
       limitManager,
+      storage,
+      visibilityDoc: window.document,
     });
 
     testManager.logException(new Error('test'), {
@@ -917,6 +932,7 @@ describe('EmbraceLogManager', () => {
       perf,
       spanSessionManager,
       limitManager,
+      storage,
       visibilityDoc,
     });
 
@@ -1243,6 +1259,8 @@ describe('EmbraceLogManager', () => {
         spanSessionManager,
         limitManager,
         loggerProvider,
+        storage,
+        visibilityDoc: window.document,
       });
 
       manager.message('Test message', 'info');
@@ -1279,6 +1297,32 @@ describe('EmbraceLogManager', () => {
         spanSessionManager,
         limitManager,
         storage: new FailingStorage(),
+        visibilityDoc: window.document,
+      });
+      manager.logException(new Error('exception 1'));
+      manager.logException(new Error('exception 2'));
+
+      const finishedLogs = memoryExporter.getFinishedLogRecords();
+      expect(finishedLogs).to.have.lengthOf(2);
+
+      expect(finishedLogs[0].attributes).to.have.property(
+        'emb.exception_number',
+        1,
+      );
+      expect(finishedLogs[1].attributes).to.have.property(
+        'emb.exception_number',
+        1,
+      );
+    });
+
+    it('should handle being setup with a non-functional storage', () => {
+      manager = new EmbraceLogManager({
+        perf,
+        spanSessionManager,
+        limitManager,
+        // @ts-expect-error dealing with potential restricted browser environments where storage APIs are unavailable
+        storage: null,
+        visibilityDoc: window.document,
       });
       manager.logException(new Error('exception 1'));
       manager.logException(new Error('exception 2'));

--- a/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.ts
@@ -33,7 +33,6 @@ import {
   GLOBAL_CONFIG,
   getIncrementedCount,
   getVisibilityState,
-  OTelPerformanceManager,
 } from '../../utils/index.ts';
 import type { LimitManagerInternal } from '../EmbraceLimitManager/index.ts';
 import type { SpanSessionManagerInternal } from '../EmbraceSpanSessionManager/index.ts';
@@ -62,8 +61,8 @@ export class EmbraceLogManager implements LogManager {
     spanSessionManager,
     limitManager,
     loggerProvider: globalLoggerProviderOverride,
-    visibilityDoc = window.document,
-    storage = window.localStorage,
+    visibilityDoc,
+    storage,
   }: EmbraceLogManagerArgs) {
     const loggerProvider = globalLoggerProviderOverride ?? logs;
 
@@ -72,7 +71,7 @@ export class EmbraceLogManager implements LogManager {
       diag.createComponentLogger({
         namespace: 'EmbraceLogManager',
       });
-    this._perf = perf ?? new OTelPerformanceManager();
+    this._perf = perf;
     this._logger = loggerProvider.getLogger('embrace-web-sdk-logs');
     this._spanSessionManager = spanSessionManager;
     this._limitManager = limitManager;

--- a/packages/web-sdk/src/managers/EmbraceLogManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/types.ts
@@ -7,10 +7,10 @@ import type { SpanSessionManagerInternal } from '../EmbraceSpanSessionManager/in
 
 export interface EmbraceLogManagerArgs {
   diag?: DiagLogger;
-  perf?: PerformanceManager;
+  perf: PerformanceManager;
   spanSessionManager: SpanSessionManagerInternal;
   limitManager: LimitManagerInternal;
   loggerProvider?: LoggerProvider;
-  visibilityDoc?: VisibilityStateDocument;
-  storage?: Storage;
+  visibilityDoc: VisibilityStateDocument;
+  storage: Storage;
 }

--- a/packages/web-sdk/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.test.ts
@@ -19,6 +19,7 @@ import {
   KEY_EMB_SESSION_REASON_STARTED,
   KEY_PREFIX_EMB_PROPERTIES,
 } from '../../constants/attributes.ts';
+import { OTelPerformanceManager } from '../../utils/index.ts';
 import {
   DEFAULT_LIMITS,
   EmbraceLimitManager,
@@ -59,7 +60,13 @@ describe('EmbraceSpanSessionManager', () => {
       },
     });
 
-    manager = new EmbraceSpanSessionManager({ diag, storage, limitManager });
+    manager = new EmbraceSpanSessionManager({
+      diag,
+      storage,
+      limitManager,
+      perf: new OTelPerformanceManager(),
+      visibilityDoc: window.document,
+    });
     storage.clear();
   });
 
@@ -214,6 +221,8 @@ describe('EmbraceSpanSessionManager', () => {
     const manager = new EmbraceSpanSessionManager({
       visibilityDoc,
       limitManager,
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
     });
     manager.startSessionSpan();
     manager.endSessionSpan();
@@ -232,6 +241,8 @@ describe('EmbraceSpanSessionManager', () => {
     const manager = new EmbraceSpanSessionManager({
       visibilityDoc,
       limitManager,
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
     });
     manager.startSessionSpan();
     manager.endSessionSpan();
@@ -244,7 +255,12 @@ describe('EmbraceSpanSessionManager', () => {
 
   it('should call the session start listener when starting a session', () => {
     const listener = sinon.stub();
-    const manager = new EmbraceSpanSessionManager({ limitManager });
+    const manager = new EmbraceSpanSessionManager({
+      limitManager,
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
+    });
     const removeListener = manager.addSessionStartedListener(listener);
 
     void expect(listener.calledOnce).to.be.false;
@@ -265,7 +281,12 @@ describe('EmbraceSpanSessionManager', () => {
     const listener = () => {
       listenerSessionId = manager.getSessionId();
     };
-    const manager = new EmbraceSpanSessionManager({ limitManager });
+    const manager = new EmbraceSpanSessionManager({
+      limitManager,
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
+    });
     const removeListener = manager.addSessionEndedListener(listener);
 
     void expect(listenerSessionId).to.be.null;
@@ -653,7 +674,13 @@ describe('EmbraceSpanSessionManager', () => {
     memoryExporter.reset();
 
     // instantiate a new manager w/ the same storage instance, should get a cold start again but a session number of 4
-    manager = new EmbraceSpanSessionManager({ diag, limitManager, storage });
+    manager = new EmbraceSpanSessionManager({
+      diag,
+      limitManager,
+      storage,
+      perf: new OTelPerformanceManager(),
+      visibilityDoc: window.document,
+    });
 
     manager.startSessionSpan();
     manager.endSessionSpan();
@@ -708,6 +735,32 @@ describe('EmbraceSpanSessionManager', () => {
       diag,
       limitManager,
       storage: new FailingStorage(),
+      perf: new OTelPerformanceManager(),
+      visibilityDoc: window.document,
+    });
+
+    manager.startSessionSpan();
+    manager.endSessionSpan();
+
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    expect(finishedSpans).to.have.lengthOf(1);
+    const sessionSpan = finishedSpans[0];
+    expect(sessionSpan.attributes).to.have.property('emb.session_number', 1);
+
+    const warningLogs = diag.getWarnLogs();
+    expect(warningLogs).to.include(
+      'Error loading permanent session properties',
+    );
+  });
+
+  it('should handle being setup with a non-functional storage', () => {
+    manager = new EmbraceSpanSessionManager({
+      diag,
+      limitManager,
+      // @ts-expect-error dealing with potential restricted browser environments where storage APIs are unavailable
+      storage: null,
+      perf: new OTelPerformanceManager(),
+      visibilityDoc: window.document,
     });
 
     manager.startSessionSpan();

--- a/packages/web-sdk/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceSpanSessionManager/EmbraceSpanSessionManager.ts
@@ -31,7 +31,6 @@ import {
   generateUUID,
   getIncrementedCount,
   getVisibilityState,
-  OTelPerformanceManager,
 } from '../../utils/index.ts';
 import type { LimitManagerInternal } from '../EmbraceLimitManager/index.ts';
 import { EmbraceExtendedSpan } from '../EmbraceTraceManager/EmbraceExtendedSpan.ts';
@@ -64,8 +63,8 @@ export class EmbraceSpanSessionManager implements SpanSessionManagerInternal {
   public constructor({
     diag: diagParam,
     perf,
-    visibilityDoc = window.document,
-    storage = window.localStorage,
+    visibilityDoc,
+    storage,
     limitManager,
   }: EmbraceSpanSessionManagerArgs) {
     this._diag =
@@ -73,7 +72,7 @@ export class EmbraceSpanSessionManager implements SpanSessionManagerInternal {
       diag.createComponentLogger({
         namespace: 'EmbraceSpanSessionManager',
       });
-    this._perf = perf ?? new OTelPerformanceManager();
+    this._perf = perf;
     this._visibilityDoc = visibilityDoc;
     this._storage = storage;
     this._limitManager = limitManager;

--- a/packages/web-sdk/src/managers/EmbraceSpanSessionManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceSpanSessionManager/types.ts
@@ -6,9 +6,9 @@ import type { LimitManagerInternal } from '../EmbraceLimitManager/index.ts';
 
 export interface EmbraceSpanSessionManagerArgs {
   diag?: DiagLogger;
-  perf?: PerformanceManager;
-  visibilityDoc?: VisibilityStateDocument;
-  storage?: Storage;
+  perf: PerformanceManager;
+  visibilityDoc: VisibilityStateDocument;
+  storage: Storage;
   limitManager: LimitManagerInternal;
 }
 

--- a/packages/web-sdk/src/managers/EmbraceUserManager/EmbraceUserManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserManager/EmbraceUserManager.ts
@@ -14,10 +14,7 @@ export class EmbraceUserManager implements UserManagerInternal {
   private readonly _storage: Storage;
   private _embraceUserId: string | null = null;
 
-  public constructor({
-    diag: diagParam,
-    storage = window.localStorage,
-  }: EmbraceUserManagerArgs = {}) {
+  public constructor({ diag: diagParam, storage }: EmbraceUserManagerArgs) {
     this._diag =
       diagParam ??
       diag.createComponentLogger({

--- a/packages/web-sdk/src/managers/EmbraceUserManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserManager/types.ts
@@ -2,7 +2,7 @@ import type { DiagLogger } from '@opentelemetry/api';
 
 export interface EmbraceUserManagerArgs {
   diag?: DiagLogger;
-  storage?: Storage;
+  storage: Storage;
 }
 
 export const isUserId = (userId: unknown): userId is string =>

--- a/packages/web-sdk/src/processors/EmbraceSessionBatchedSpanProcessor/EmbraceSessionBatchedSpanProcessor.test.ts
+++ b/packages/web-sdk/src/processors/EmbraceSessionBatchedSpanProcessor/EmbraceSessionBatchedSpanProcessor.test.ts
@@ -7,6 +7,7 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import {
   InMemoryDiagLogger,
+  InMemoryStorage,
   setupTestTraceExporter,
 } from '../../../tests/utils/index.ts';
 import {
@@ -19,6 +20,7 @@ import {
   EmbraceLimitManager,
   EmbraceSpanSessionManager,
 } from '../../managers/index.ts';
+import { OTelPerformanceManager } from '../../utils/index.ts';
 import { EmbraceSessionBatchedSpanProcessor } from './EmbraceSessionBatchedSpanProcessor.ts';
 
 const { expect } = chai;
@@ -67,6 +69,9 @@ describe('EmbraceSessionBatchedSpanProcessor', () => {
 
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager,
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
     });
 
     processor = new EmbraceSessionBatchedSpanProcessor({

--- a/packages/web-sdk/src/processors/IdentifiableSessionLogRecordProcessor/IdentifiableSessionLogRecordProcessor.test.ts
+++ b/packages/web-sdk/src/processors/IdentifiableSessionLogRecordProcessor/IdentifiableSessionLogRecordProcessor.test.ts
@@ -2,13 +2,17 @@ import type { Logger } from '@opentelemetry/api-logs';
 import { logs } from '@opentelemetry/api-logs';
 import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
 import * as chai from 'chai';
-import { setupTestLogExporter } from '../../../tests/utils/index.ts';
+import {
+  InMemoryStorage,
+  setupTestLogExporter,
+} from '../../../tests/utils/index.ts';
 import type { SpanSessionManager } from '../../api-sessions/index.ts';
 import {
   DEFAULT_LIMITS,
   EmbraceLimitManager,
   EmbraceSpanSessionManager,
 } from '../../managers/index.ts';
+import { OTelPerformanceManager } from '../../utils/index.ts';
 import { IdentifiableSessionLogRecordProcessor } from './IdentifiableSessionLogRecordProcessor.ts';
 
 const { expect } = chai;
@@ -21,6 +25,9 @@ describe('IdentifiableSessionLogRecordProcessor', () => {
   beforeEach(() => {
     spanSessionManager = new EmbraceSpanSessionManager({
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      perf: new OTelPerformanceManager(),
+      storage: new InMemoryStorage(),
+      visibilityDoc: window.document,
     });
     memoryExporter = setupTestLogExporter([
       new IdentifiableSessionLogRecordProcessor({

--- a/packages/web-sdk/src/sdk/initSDK.ts
+++ b/packages/web-sdk/src/sdk/initSDK.ts
@@ -218,8 +218,10 @@ export const initSDK = (
 
     const spanSessionManager = setupSession({
       limitManager,
+      perf,
       registerGlobally,
       sdkLocalStorage,
+      visibilityDoc: window.document,
     });
 
     let embraceSpanProcessor: EmbraceSessionBatchedSpanProcessor | undefined;
@@ -275,10 +277,12 @@ export const initSDK = (
       spanSessionManager,
       limitManager,
       attributeScrubbers: finalAttributeScrubbers,
+      perf,
       registerGlobally,
       embraceLogProcessor,
       sdkLocalStorage,
       pageManager,
+      visibilityDoc: window.document,
     });
 
     spanSessionManager.startSessionSpan({ reason: 'init' });
@@ -359,12 +363,16 @@ const setupUser = ({ registerGlobally, sdkLocalStorage }: SetupUserArgs) => {
 
 const setupSession = ({
   limitManager,
+  perf,
   registerGlobally,
   sdkLocalStorage,
+  visibilityDoc,
 }: SetupSessionArgs) => {
   const embraceSpanSessionManager = new EmbraceSpanSessionManager({
     limitManager,
+    perf,
     storage: sdkLocalStorage,
+    visibilityDoc,
   });
 
   if (registerGlobally) {
@@ -445,10 +453,12 @@ const setupLogs = ({
   spanSessionManager,
   limitManager,
   attributeScrubbers,
+  perf,
   registerGlobally,
   embraceLogProcessor,
   sdkLocalStorage,
   pageManager,
+  visibilityDoc,
 }: SetupLogsArgs) => {
   const finalLogProcessors: LogRecordProcessor[] = [
     ...logProcessors,
@@ -479,7 +489,9 @@ const setupLogs = ({
     spanSessionManager,
     limitManager,
     loggerProvider: registerGlobally ? undefined : loggerProvider,
+    perf,
     storage: sdkLocalStorage,
+    visibilityDoc,
   });
 
   if (registerGlobally) {

--- a/packages/web-sdk/src/sdk/types.ts
+++ b/packages/web-sdk/src/sdk/types.ts
@@ -19,7 +19,10 @@ import type { PageManager } from '../api-page/index.ts';
 import type { SpanSessionManager } from '../api-sessions/index.ts';
 import type { TraceManager } from '../api-traces/index.ts';
 import type { UserManager } from '../api-users/index.ts';
-import type { AttributeScrubber } from '../common/index.ts';
+import type {
+  AttributeScrubber,
+  VisibilityStateDocument,
+} from '../common/index.ts';
 import type {
   ClicksInstrumentationArgs,
   DocumentLoadInstrumentationConfig,
@@ -37,6 +40,7 @@ import type {
   LimitManagerInternal,
   SpanSessionManagerInternal,
 } from '../managers/index.ts';
+import type { PerformanceManager } from '../utils/index.ts';
 
 export interface DynamicSDKConfig {
   /**
@@ -298,8 +302,10 @@ export interface SetupUserArgs {
 
 export interface SetupSessionArgs {
   limitManager: LimitManagerInternal;
+  perf: PerformanceManager;
   registerGlobally?: boolean;
   sdkLocalStorage: Storage;
+  visibilityDoc: VisibilityStateDocument;
 }
 
 export interface SetupTracesArgs {
@@ -325,10 +331,12 @@ export interface SetupLogsArgs {
   spanSessionManager: SpanSessionManagerInternal;
   limitManager: LimitManagerInternal;
   attributeScrubbers: AttributeScrubber[];
+  perf: PerformanceManager;
   registerGlobally?: boolean;
   embraceLogProcessor?: BatchLogRecordProcessor;
   sdkLocalStorage: Storage;
   pageManager: PageManager;
+  visibilityDoc: VisibilityStateDocument;
 }
 
 export interface SetupPageArgs {


### PR DESCRIPTION
## What problem is this solving?

`EmbraceUserManager`, `EmbraceDynamicConfigManager`, `EmbraceLogManager`, and `EmbraceSpanSessionManager` all advertised optional `storage` / `perf` / `visibilityDoc` constructor args that silently fell back to `window.localStorage`, `new OTelPerformanceManager()`, and `window.document`. Production already supplied all three through `initSDK`, so the optional-with-default contract was a fiction that hid load-bearing dependencies and let tests accidentally exercise the real browser globals (cross-test pollution risk).

## Short description of changes

- `EmbraceUserManager`, `EmbraceDynamicConfigManager`, `EmbraceLogManager`, `EmbraceSpanSessionManager`: `storage` is now required. The `window.localStorage` fallback is gone.
- `EmbraceLogManager`, `EmbraceSpanSessionManager`: `perf` and `visibilityDoc` are now required. The `OTelPerformanceManager` and `window.document` fallbacks are gone.
- `initSDK.ts` and `sdk/types.ts`: thread `perf` and `window.document` through `setupSession` and `setupLogs`.
- Every test that constructs one of these managers now passes the now-required deps explicitly (`InMemoryStorage`, `OTelPerformanceManager` or existing `MockPerformanceManager(clock)`, `window.document`).
- `diag` stays optional with the OTel ambient default. Logging is observational; storage / perf / visibilityDoc are load-bearing.