### PR TITLE
refactor(storage): make NamespacedStorage handle errors and disable writes safely

### DIFF
--- a/packages/web-sdk/src/sdk/initSDK.ts
+++ b/packages/web-sdk/src/sdk/initSDK.ts
@@ -149,13 +149,15 @@ export const initSDK = (
       );
     }
 
-    const useNamespace = !registerGlobally && appID;
-    const sdkLocalStorage = useNamespace
-      ? new NamespacedStorage(appID, window.localStorage)
-      : window.localStorage;
-    const sdkSessionStorage = useNamespace
-      ? new NamespacedStorage(appID, window.sessionStorage)
-      : window.sessionStorage;
+    const namespace = !registerGlobally && appID ? appID : '';
+    const sdkLocalStorage = new NamespacedStorage({
+      namespace,
+      storage: window.localStorage,
+    });
+    const sdkSessionStorage = new NamespacedStorage({
+      namespace,
+      storage: window.sessionStorage,
+    });
 
     const resourceWithWebSDKAttributes = getWebSDKOverridableResource()
       .merge(resource)

--- a/packages/web-sdk/src/utils/NamespacedStorage/NamespacedStorage.test.ts
+++ b/packages/web-sdk/src/utils/NamespacedStorage/NamespacedStorage.test.ts
@@ -1,5 +1,10 @@
+import type { DiagLogger } from '@opentelemetry/api';
 import * as chai from 'chai';
-import { InMemoryStorage } from '../../../tests/utils/index.ts';
+import {
+  FailingStorage,
+  InMemoryDiagLogger,
+  InMemoryStorage,
+} from '../../../tests/utils/index.ts';
 import { NamespacedStorage } from './NamespacedStorage.ts';
 
 const { expect } = chai;
@@ -12,7 +17,10 @@ describe('NamespacedStorage', () => {
   });
 
   it('should set and get values using a prefix on the key', () => {
-    const storage = new NamespacedStorage('prefix', inMemoryStorage);
+    const storage = new NamespacedStorage({
+      namespace: 'prefix',
+      storage: inMemoryStorage,
+    });
 
     storage.setItem('key1', 'foo');
     storage.setItem('key2', 'bar');
@@ -32,7 +40,10 @@ describe('NamespacedStorage', () => {
   });
 
   it('should remove items using a prefix on the key', () => {
-    const storage = new NamespacedStorage('prefix', inMemoryStorage);
+    const storage = new NamespacedStorage({
+      namespace: 'prefix',
+      storage: inMemoryStorage,
+    });
 
     storage.setItem('key1', 'foo');
     inMemoryStorage.setItem('key1', 'baz');
@@ -50,7 +61,10 @@ describe('NamespacedStorage', () => {
   });
 
   it('should return keys that match the prefix', () => {
-    const storage = new NamespacedStorage('prefix', inMemoryStorage);
+    const storage = new NamespacedStorage({
+      namespace: 'prefix',
+      storage: inMemoryStorage,
+    });
 
     storage.setItem('key1', 'foo');
     inMemoryStorage.setItem('key3', 'baz');
@@ -69,7 +83,10 @@ describe('NamespacedStorage', () => {
   });
 
   it('should clear keys that match the prefix', () => {
-    const storage = new NamespacedStorage('prefix', inMemoryStorage);
+    const storage = new NamespacedStorage({
+      namespace: 'prefix',
+      storage: inMemoryStorage,
+    });
 
     storage.setItem('key1', 'foo');
     inMemoryStorage.setItem('key3', 'baz');
@@ -89,10 +106,277 @@ describe('NamespacedStorage', () => {
     expect(inMemoryStorage.key(1)).to.equal('key4');
   });
 
-  it('should expose the underlying storage event key for namespaced keys', () => {
-    const storage = new NamespacedStorage('app123', inMemoryStorage);
-    expect(storage.getStorageEventKey('embrace_user_session_state')).to.equal(
-      'app123_embrace_user_session_state',
-    );
+  describe('without a namespace prefix', () => {
+    it('stores keys without a prefix when the namespace is omitted', () => {
+      const storage = new NamespacedStorage({
+        storage: inMemoryStorage,
+      });
+
+      storage.setItem('key1', 'foo');
+      inMemoryStorage.setItem('key2', 'bar');
+
+      expect(storage.getItem('key1')).to.equal('foo');
+      expect(storage.getItem('key2')).to.equal('bar');
+      expect(inMemoryStorage.getItem('key1')).to.equal('foo');
+      expect(inMemoryStorage.getItem('_key1')).to.equal(null);
+
+      expect(storage.length).to.equal(2);
+      expect([storage.key(0), storage.key(1)].sort()).to.deep.equal([
+        'key1',
+        'key2',
+      ]);
+    });
+
+    it('stores keys without a prefix when the namespace is an empty string', () => {
+      const storage = new NamespacedStorage({
+        namespace: '',
+        storage: inMemoryStorage,
+      });
+
+      storage.setItem('key1', 'foo');
+      inMemoryStorage.setItem('key2', 'bar');
+
+      expect(storage.getItem('key1')).to.equal('foo');
+      expect(storage.getItem('key2')).to.equal('bar');
+      expect(inMemoryStorage.getItem('key1')).to.equal('foo');
+      expect(inMemoryStorage.getItem('_key1')).to.equal(null);
+
+      expect(storage.length).to.equal(2);
+      expect([storage.key(0), storage.key(1)].sort()).to.deep.equal([
+        'key1',
+        'key2',
+      ]);
+    });
+  });
+
+  describe('error handling', () => {
+    let diagLogger: InMemoryDiagLogger;
+
+    beforeEach(() => {
+      diagLogger = new InMemoryDiagLogger();
+    });
+
+    it('returns null and warns when getItem throws', () => {
+      const storage = new NamespacedStorage({
+        namespace: 'prefix',
+        storage: new FailingStorage(),
+        diag: diagLogger,
+      });
+
+      expect(storage.getItem('foo')).to.equal(null);
+      expect(diagLogger.getWarnLogs()).to.have.lengthOf(1);
+      expect(diagLogger.getWarnLogs()[0]).to.contain('foo');
+    });
+
+    it('returns 0 length and warns when storage.length throws', () => {
+      const storage = new NamespacedStorage({
+        namespace: 'prefix',
+        storage: new FailingStorage(),
+        diag: diagLogger,
+      });
+
+      expect(storage.length).to.equal(0);
+      expect(storage.key(0)).to.equal(null);
+      expect(diagLogger.getWarnLogs().some((m) => m.includes('length'))).to.be
+        .true;
+    });
+
+    it('swallows removeItem failure and warns', () => {
+      const storage = new NamespacedStorage({
+        namespace: 'prefix',
+        storage: new FailingStorage(),
+        diag: diagLogger,
+      });
+
+      expect(() => {
+        storage.removeItem('foo');
+      }).to.not.throw();
+      expect(diagLogger.getWarnLogs().some((m) => m.includes('prefix_foo'))).to
+        .be.true;
+    });
+
+    it('swallows setItem failure and disables further writes after the first', () => {
+      let setCalls = 0;
+      const failingWrites: Storage = {
+        get length() {
+          return 0;
+        },
+        clear: () => undefined,
+        getItem: () => null,
+        key: () => null,
+        removeItem: () => undefined,
+        setItem: () => {
+          setCalls++;
+          throw new Error('QuotaExceeded');
+        },
+      };
+      const storage = new NamespacedStorage({
+        namespace: 'prefix',
+        storage: failingWrites,
+        diag: diagLogger,
+      });
+
+      expect(() => {
+        storage.setItem('a', '1');
+      }).to.not.throw();
+      expect(() => {
+        storage.setItem('b', '2');
+      }).to.not.throw();
+      expect(() => {
+        storage.setItem('c', '3');
+      }).to.not.throw();
+
+      expect(setCalls).to.equal(1);
+      expect(diagLogger.getErrorLogs()).to.have.lengthOf(1);
+    });
+
+    it('keeps reads, removes, and clears working after writes are disabled', () => {
+      inMemoryStorage.setItem('prefix_kept', 'value');
+      inMemoryStorage.setItem('prefix_removed', 'gone');
+
+      let allowWrites = true;
+      const flakyStorage: Storage = {
+        get length() {
+          return inMemoryStorage.length;
+        },
+        clear: () => {
+          inMemoryStorage.clear();
+        },
+        getItem: (k) => inMemoryStorage.getItem(k),
+        key: (i) => inMemoryStorage.key(i),
+        removeItem: (k) => {
+          inMemoryStorage.removeItem(k);
+        },
+        setItem: (k, v) => {
+          if (!allowWrites) {
+            throw new Error('QuotaExceeded');
+          }
+          inMemoryStorage.setItem(k, v);
+        },
+      };
+      const storage = new NamespacedStorage({
+        namespace: 'prefix',
+        storage: flakyStorage,
+        diag: diagLogger,
+      });
+
+      allowWrites = false;
+      storage.setItem('attempt', 'value');
+      storage.setItem('also-attempt', 'value');
+
+      expect(storage.getItem('kept')).to.equal('value');
+
+      storage.removeItem('removed');
+      expect(storage.getItem('removed')).to.equal(null);
+
+      inMemoryStorage.setItem('prefix_for_clear', 'value');
+      storage.clear();
+      expect(storage.length).to.equal(0);
+
+      expect(diagLogger.getErrorLogs()).to.have.lengthOf(1);
+      expect(diagLogger.getWarnLogs()).to.have.lengthOf(0);
+    });
+
+    it('continues iterating when storage.key(i) throws for some indices', () => {
+      const partialKeyFail: Storage = {
+        get length() {
+          return 3;
+        },
+        clear: () => undefined,
+        getItem: () => null,
+        key: (i) => {
+          if (i === 0) return 'prefix_a';
+          if (i === 2) return 'prefix_b';
+          throw new Error('reading-prevented');
+        },
+        removeItem: () => undefined,
+        setItem: () => undefined,
+      };
+      const storage = new NamespacedStorage({
+        namespace: 'prefix',
+        storage: partialKeyFail,
+        diag: diagLogger,
+      });
+
+      expect(storage.length).to.equal(2);
+      expect([storage.key(0), storage.key(1)].sort()).to.deep.equal(['a', 'b']);
+      expect(diagLogger.getWarnLogs()).to.not.be.empty;
+      expect(diagLogger.getWarnLogs().every((m) => m.includes('index 1'))).to.be
+        .true;
+    });
+
+    it('logs only the error name on setItem failure, not the value', () => {
+      const value = 'sensitive-payload';
+      const errorCalls: unknown[][] = [];
+      const captureLogger: DiagLogger = {
+        debug: () => undefined,
+        error: (...callArgs) => {
+          errorCalls.push(callArgs);
+        },
+        info: () => undefined,
+        verbose: () => undefined,
+        warn: () => undefined,
+      };
+      const failingWrites: Storage = {
+        get length() {
+          return 0;
+        },
+        clear: () => undefined,
+        getItem: () => null,
+        key: () => null,
+        removeItem: () => undefined,
+        setItem: () => {
+          const e = new Error(`quota exceeded while writing ${value}`);
+          e.name = 'QuotaExceededError';
+          throw e;
+        },
+      };
+      const storage = new NamespacedStorage({
+        namespace: 'prefix',
+        storage: failingWrites,
+        diag: captureLogger,
+      });
+
+      storage.setItem('k', value);
+
+      expect(errorCalls).to.have.lengthOf(1);
+      const flat = errorCalls[0].map(String).join(' ');
+      expect(flat).to.contain('QuotaExceededError');
+      expect(flat).to.not.contain(value);
+    });
+
+    it('swallows clear() failure when underlying removeItem throws', () => {
+      inMemoryStorage.setItem('prefix_a', '1');
+      inMemoryStorage.setItem('prefix_b', '2');
+
+      const removeFails: Storage = {
+        get length() {
+          return inMemoryStorage.length;
+        },
+        clear: () => {
+          inMemoryStorage.clear();
+        },
+        getItem: (k) => inMemoryStorage.getItem(k),
+        key: (i) => inMemoryStorage.key(i),
+        removeItem: () => {
+          throw new Error('locked');
+        },
+        setItem: (k, v) => {
+          inMemoryStorage.setItem(k, v);
+        },
+      };
+      const storage = new NamespacedStorage({
+        namespace: 'prefix',
+        storage: removeFails,
+        diag: diagLogger,
+      });
+
+      expect(() => {
+        storage.clear();
+      }).to.not.throw();
+      expect(diagLogger.getWarnLogs()).to.have.lengthOf(2);
+      expect(diagLogger.getWarnLogs().every((m) => m.includes('prefix_'))).to.be
+        .true;
+    });
   });
 });

--- a/packages/web-sdk/src/utils/NamespacedStorage/NamespacedStorage.ts
+++ b/packages/web-sdk/src/utils/NamespacedStorage/NamespacedStorage.ts
@@ -1,21 +1,67 @@
+import type { DiagLogger } from '@opentelemetry/api';
+import { diag } from '@opentelemetry/api';
+
+export interface NamespacedStorageArgs {
+  storage: Storage;
+  namespace?: string;
+  diag?: DiagLogger;
+}
+
+/**
+ * `Storage` wrapper that isolates the SDK from storage errors and
+ * optionally namespaces keys with a prefix.
+ *
+ * Read failures (`getItem`, `key`, `length`) log at warn level.
+ *
+ * The first `setItem` failure puts the wrapper into a sticky
+ * write-disabled state and logs once at error level. Subsequent
+ * `setItem` calls become no-ops so a one-time quota error or revoked
+ * permission does not keep throwing on every attempt. Reads, removes,
+ * and clears continue to work.
+ *
+ * An empty namespace skips the key prefix; the wrapper then exposes the
+ * underlying storage's full keyspace with only the safety layer applied.
+ */
 export class NamespacedStorage implements Storage {
+  private readonly _diag: DiagLogger;
   private readonly _keyPrefix: string;
   private readonly _storage: Storage;
+  private _writeDisabled = false;
 
-  public constructor(namespace: string, storage: Storage) {
-    this._keyPrefix = `${namespace}_`;
+  public constructor({
+    namespace,
+    storage,
+    diag: diagParam,
+  }: NamespacedStorageArgs) {
+    this._diag =
+      diagParam ??
+      diag.createComponentLogger({ namespace: 'NamespacedStorage' });
+    this._keyPrefix = namespace ? `${namespace}_` : '';
     this._storage = storage;
   }
 
   protected getNamespacedKeys(): string[] {
-    const keys = [];
-    for (let i = 0; i < this._storage.length; i++) {
-      const key = this._storage.key(i);
-      if (key?.startsWith(this._keyPrefix)) {
-        keys.push(key.substring(this._keyPrefix.length));
+    const keys: string[] = [];
+    let length: number;
+    try {
+      length = this._storage.length;
+    } catch (e) {
+      this._diag.warn('failed to read storage length', String(e));
+      return keys;
+    }
+    for (let i = 0; i < length; i++) {
+      try {
+        const key = this._storage.key(i);
+        if (key?.startsWith(this._keyPrefix)) {
+          keys.push(key.substring(this._keyPrefix.length));
+        }
+      } catch (e) {
+        this._diag.warn(
+          `failed to read storage key at index ${i.toString()}`,
+          String(e),
+        );
       }
     }
-
     return keys;
   }
 
@@ -24,13 +70,18 @@ export class NamespacedStorage implements Storage {
   }
 
   public clear(): void {
-    this.getNamespacedKeys().forEach((key) => {
-      this._storage.removeItem(`${this._keyPrefix}${key}`);
-    });
+    for (const key of this.getNamespacedKeys()) {
+      this._safeRemove(`${this._keyPrefix}${key}`);
+    }
   }
 
   public getItem(key: string): string | null {
-    return this._storage.getItem(`${this._keyPrefix}${key}`);
+    try {
+      return this._storage.getItem(`${this._keyPrefix}${key}`);
+    } catch (e) {
+      this._diag.warn(`failed to read ${key}`, String(e));
+      return null;
+    }
   }
 
   public key(index: number): string | null {
@@ -38,21 +89,38 @@ export class NamespacedStorage implements Storage {
   }
 
   public removeItem(key: string): void {
-    this._storage.removeItem(`${this._keyPrefix}${key}`);
+    this._safeRemove(`${this._keyPrefix}${key}`);
   }
 
   public setItem(key: string, value: string): void {
-    this._storage.setItem(`${this._keyPrefix}${key}`, value);
+    if (this._writeDisabled) {
+      return;
+    }
+    try {
+      this._storage.setItem(`${this._keyPrefix}${key}`, value);
+    } catch (e) {
+      this._disableWrites(e);
+    }
   }
 
-  /**
-   * Returns the namespaced underlying-storage key for a logical key. Browser
-   * `storage` events fire with the underlying key, so callers that filter
-   * those events need to compare against this value rather than the logical
-   * key. Plain `Storage` instances do not expose this method; callers should
-   * fall back to the logical key in that case.
-   */
-  public getStorageEventKey(logicalKey: string): string {
-    return `${this._keyPrefix}${logicalKey}`;
+  private _safeRemove(namespacedKey: string): void {
+    try {
+      this._storage.removeItem(namespacedKey);
+    } catch (e) {
+      this._diag.warn(`failed to remove ${namespacedKey}`, String(e));
+    }
+  }
+
+  // Log only error.name: error.message can leak the value on some browsers.
+  private _disableWrites(error: unknown): void {
+    if (this._writeDisabled) {
+      return;
+    }
+    this._writeDisabled = true;
+    const errorName = error instanceof Error ? error.name : 'UnknownError';
+    this._diag.error(
+      'writes disabled after failure; continuing in-memory only',
+      errorName,
+    );
   }
 }


### PR DESCRIPTION
## What problem is this solving?

`NamespacedStorage` was a thin key-prefix wrapper that let underlying storage exceptions propagate. Quota errors, revoked permissions, and similar environmental failures surfaced to every caller and kept throwing on every subsequent write attempt.

## Short description of changes

- All underlying storage calls are now guarded internally; reads that fail return `null` and writes that fail are swallowed.
- First write failure flips a sticky disabled flag and emits one error log. Subsequent `setItem` calls become no-ops so a single failure does not keep throwing.
- Public API and constructor signature unchanged. `implements Storage` preserved, so no consumers need to update.

## Testing

- `npm run validate` clean.
- `npm run test` for `NamespacedStorage`: 10 passed, including new coverage for swallowed read/remove failures and the sticky disable-after-first-write-failure behavior.