### PR TITLE
chore(clicks): suppress useDomNodeTextContent lint warning

### DIFF
--- a/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/nursery/useDomNodeTextContent: we want to capture what the user sees */
 import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
 import * as chai from 'chai';
 import {

--- a/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
@@ -58,7 +58,8 @@ export class ClicksInstrumentation extends EmbraceInstrumentationBase {
                 element,
                 innerTextForElement
                   ? innerTextForElement(element)
-                  : element.innerText,
+                  : // biome-ignore lint/nursery/useDomNodeTextContent: we want to capture what the user sees
+                    element.innerText,
               ),
               'tap.coords': `${event.x.toString()},${event.y.toString()}`,
             },


### PR DESCRIPTION
## What problem is this solving?
Biome's `useDomNodeTextContent` lint rule flags `element.innerText` usage in the clicks instrumentation, but `innerText` is intentional here: we want to capture text as the user sees it (respecting CSS visibility/styling), not the raw `textContent`.

## Short description of changes
- Add targeted `biome-ignore` on the `element.innerText` call in `ClicksInstrumentation.ts` with rationale
- Add file-level `biome-ignore-all` in `ClicksInstrumentation.test.ts` for the same rule

## Testing
- [x] `npm run lint` passes without the warning
- [x] `npm run test` still passes