### PR TITLE
chore: extract helpers and remove deprecated user storage migration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,6 +26,9 @@ npm run lint:fix
 
 # All checks (tsc + eslint baseline)
 npm run validate
+
+# Run demo dev server (http://localhost:4847)
+npm run dev
 ```
 
 ## Architecture
@@ -88,6 +91,12 @@ Framework: @web/test-runner + Playwright + Mocha + Chai
 npm run test                  # Headless (from packages/web-sdk/)
 npm run test:manual           # Browser with DevTools
 npm run test:watch            # Watch mode
+```
+
+**Run a single test file** (paths are workspace-relative, i.e. relative to `packages/web-sdk/`):
+
+```bash
+npx turbo run test --filter=@embrace-io/web-sdk -- --files "src/utils/applyUserSessionAttributes.test.ts"
 ```
 
 ### Integration Tests

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build-test-results
 .vscode
 .claude/settings.json
 .claude/worktrees/
+/.playwright-mcp

--- a/demo/frontend/package.json
+++ b/demo/frontend/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "check": "tsc --build",
     "clean": "npx -y rimraf .sonda dist",
-    "dev": "vite --open",
+    "dev": "vite --port 4847 --open",
     "build": "vite build",
-    "preview": "vite preview --open",
+    "preview": "vite preview --port 4847 --open",
     "demo": "bash ./scripts/runDemo.sh",
     "upload-sourcemaps": "embrace-web-cli upload --app-version 0.0.1",
     "upload-sourcemaps:dry": "embrace-web-cli upload -d --app-version 0.0.1"

--- a/demo/frontend/src/index.css
+++ b/demo/frontend/src/index.css
@@ -332,6 +332,47 @@ legend {
   }
 }
 
+.session-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.75rem;
+}
+
+.session-table th,
+.session-table td {
+  padding: 0.4rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #27272a;
+}
+
+.session-table thead th {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #a1a1aa;
+  font-weight: 600;
+}
+
+.session-table tbody th {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #a1a1aa;
+  font-weight: 500;
+  width: 150px;
+}
+
+.session-table tbody td {
+  font-family: monospace;
+  color: #e4e4e7;
+  overflow-wrap: break-word;
+}
+
+.session-table tbody tr:last-child th,
+.session-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
 .actions {
   display: flex;
   justify-content: flex-start;

--- a/demo/frontend/src/otel-base.ts
+++ b/demo/frontend/src/otel-base.ts
@@ -3,6 +3,9 @@ import { DiagLogLevel, initSDK, user } from '@embrace-io/web-sdk';
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-web';
+import { version } from '../../../packages/web-sdk/package.json' with {
+  type: 'json',
+};
 
 const APP_ID = import.meta.env.VITE_APP_ID;
 const DATA_URL = import.meta.env.VITE_DATA_URL;
@@ -12,7 +15,7 @@ const setupSDK = (instrumentations?: Instrumentation[]) => {
   const result = initSDK({
     logLevel: DiagLogLevel.ALL,
     appID: APP_ID || undefined,
-    appVersion: '1.0.0',
+    appVersion: version,
     spanExporters: [new ConsoleSpanExporter()],
     logExporters: [new ConsoleLogRecordExporter()],
     defaultInstrumentationConfig: {
@@ -32,7 +35,7 @@ const setupSDK = (instrumentations?: Instrumentation[]) => {
   });
 
   if (result) {
-    console.log('Successfully initialized the Embrace SDK', APP_ID);
+    console.log('Successfully initialized the Embrace SDK', APP_ID, version);
   } else {
     console.error('Failed to initialize the Embrace SDK', APP_ID);
   }

--- a/packages/web-sdk/src/api-users/index.ts
+++ b/packages/web-sdk/src/api-users/index.ts
@@ -1,11 +1,3 @@
-export type {
-  User,
-  UserManager,
-  UserManagerInternal,
-} from './manager/index.ts';
-export {
-  KEY_ENDUSER_PSEUDO_ID,
-  NoOpUserManager,
-  ProxyUserManager,
-} from './manager/index.ts';
+export type { UserManager, UserManagerInternal } from './manager/index.ts';
+export { NoOpUserManager, ProxyUserManager } from './manager/index.ts';
 export { user } from './userAPI.ts';

--- a/packages/web-sdk/src/api-users/manager/constants/index.ts
+++ b/packages/web-sdk/src/api-users/manager/constants/index.ts
@@ -1,1 +1,0 @@
-export const KEY_ENDUSER_PSEUDO_ID = 'enduser.pseudo.id';

--- a/packages/web-sdk/src/api-users/manager/index.ts
+++ b/packages/web-sdk/src/api-users/manager/index.ts
@@ -1,4 +1,3 @@
-export { KEY_ENDUSER_PSEUDO_ID } from './constants/index.ts';
 export { NoOpUserManager } from './NoOpUserManager/index.ts';
 export { ProxyUserManager } from './ProxyUserManager/index.ts';
-export type { User, UserManager, UserManagerInternal } from './types.ts';
+export type { UserManager, UserManagerInternal } from './types.ts';

--- a/packages/web-sdk/src/api-users/manager/types.ts
+++ b/packages/web-sdk/src/api-users/manager/types.ts
@@ -1,9 +1,3 @@
-import type { KEY_ENDUSER_PSEUDO_ID } from './constants/index.ts';
-
-export interface User {
-  [KEY_ENDUSER_PSEUDO_ID]: string;
-}
-
 export interface UserManager {
   getEmbraceUserId: () => string;
 

--- a/packages/web-sdk/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.test.ts
@@ -65,7 +65,7 @@ describe('SpanSessionVisibilityInstrumentation', () => {
     void expect(spanSessionManager.getSessionSpan()).to.be.null;
 
     visibilityDoc.visibilityState = 'visible';
-    window.dispatchEvent(new Event('visibilitychange'));
+    document.dispatchEvent(new Event('visibilitychange'));
 
     void expect(spanSessionManager.getSessionSpan()).to.not.be.null;
 
@@ -92,7 +92,7 @@ describe('SpanSessionVisibilityInstrumentation', () => {
     void expect(spanSessionManager.getSessionSpan()).to.not.be.null;
 
     visibilityDoc.visibilityState = 'visible';
-    window.dispatchEvent(new Event('visibilitychange'));
+    document.dispatchEvent(new Event('visibilitychange'));
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -119,7 +119,7 @@ describe('SpanSessionVisibilityInstrumentation', () => {
     void expect(spanSessionManager.getSessionSpan()).to.not.be.null;
 
     visibilityDoc.visibilityState = 'hidden';
-    window.dispatchEvent(new Event('visibilitychange'));
+    document.dispatchEvent(new Event('visibilitychange'));
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);

--- a/packages/web-sdk/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/session/SpanSessionVisibilityInstrumentation/SpanSessionVisibilityInstrumentation.ts
@@ -45,10 +45,10 @@ export class SpanSessionVisibilityInstrumentation extends EmbraceInstrumentation
   }
 
   public disable(): void {
-    window.removeEventListener('visibilitychange', this._onVisibilityChange);
+    document.removeEventListener('visibilitychange', this._onVisibilityChange);
   }
 
   public enable(): void {
-    window.addEventListener('visibilitychange', this._onVisibilityChange);
+    document.addEventListener('visibilitychange', this._onVisibilityChange);
   }
 }

--- a/packages/web-sdk/src/managers/EmbraceTraceManager/EmbraceTraceManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceTraceManager/EmbraceTraceManager.test.ts
@@ -213,4 +213,13 @@ describe('EmbraceTraceManager', () => {
     expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(0);
     expect(secondMemoryExporter.getFinishedSpans()).to.have.lengthOf(1);
   });
+
+  it('should leave a span un-parented when no explicit parent or context is provided', () => {
+    const span = manager.startSpan('demo-span');
+    span.end();
+
+    const finishedSpans = memoryExporter.getFinishedSpans();
+    const finished = finishedSpans.find((s) => s.name === 'demo-span');
+    void expect(finished?.parentSpanContext?.spanId).to.be.undefined;
+  });
 });

--- a/packages/web-sdk/src/managers/EmbraceUserManager/EmbraceUserManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserManager/EmbraceUserManager.test.ts
@@ -77,9 +77,8 @@ describe('EmbraceUserManager', () => {
     const manager = new EmbraceUserManager({ diag, storage: null });
     expect(manager.getEmbraceUserId()).to.have.lengthOf(32);
     manager.clearEmbraceUserId();
-    expect(diag.getWarnLogs()).to.have.lengthOf(4);
+    expect(diag.getWarnLogs()).to.have.lengthOf(3);
     expect(diag.getWarnLogs()).to.deep.equal([
-      'Failed to get old user data from storage',
       'Failed to get embrace user id from storage, defaulting to a new one',
       'Failed to persist user object for storage, keeping it in-memory only',
       'Failed to remove embrace user in storage',
@@ -93,9 +92,8 @@ describe('EmbraceUserManager', () => {
     });
     expect(manager.getEmbraceUserId()).to.have.lengthOf(32);
     manager.clearEmbraceUserId();
-    expect(diag.getWarnLogs()).to.have.lengthOf(4);
+    expect(diag.getWarnLogs()).to.have.lengthOf(3);
     expect(diag.getWarnLogs()).to.deep.equal([
-      'Failed to get old user data from storage',
       'Failed to get embrace user id from storage, defaulting to a new one',
       'Failed to persist user object for storage, keeping it in-memory only',
       'Failed to remove embrace user in storage',

--- a/packages/web-sdk/src/managers/EmbraceUserManager/EmbraceUserManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserManager/EmbraceUserManager.test.ts
@@ -5,11 +5,9 @@ import {
   InMemoryDiagLogger,
   InMemoryStorage,
 } from '../../../tests/utils/index.ts';
-import { KEY_ENDUSER_PSEUDO_ID } from '../../api-users/index.ts';
 import {
   EMBRACE_EXTERNAL_USER_ID_KEY,
   EMBRACE_USER_ID_STORAGE_KEY,
-  EMBRACE_USER_STORAGE_KEY_DEPRECATED,
 } from './constants.ts';
 import { EmbraceUserManager } from './EmbraceUserManager.ts';
 
@@ -102,22 +100,6 @@ describe('EmbraceUserManager', () => {
       'Failed to persist user object for storage, keeping it in-memory only',
       'Failed to remove embrace user in storage',
     ]);
-  });
-
-  it('should migrate old local storage key', () => {
-    storage.setItem(
-      EMBRACE_USER_STORAGE_KEY_DEPRECATED,
-      JSON.stringify({ [KEY_ENDUSER_PSEUDO_ID]: VALID_UUID }),
-    );
-
-    const manager = new EmbraceUserManager({ diag, storage });
-    expect(diag.getDebugLogs()).to.have.lengthOf(1);
-    expect(diag.getDebugLogs()[0]).to.equal(
-      'Migrating old user data from storage',
-    );
-    expect(manager.getEmbraceUserId()).to.equal(VALID_UUID);
-    void expect(storage.getItem(EMBRACE_USER_STORAGE_KEY_DEPRECATED)).to.be
-      .null;
   });
 
   it('should get an external user id', () => {

--- a/packages/web-sdk/src/managers/EmbraceUserManager/EmbraceUserManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserManager/EmbraceUserManager.ts
@@ -1,15 +1,13 @@
 import type { DiagLogger } from '@opentelemetry/api';
 import { diag } from '@opentelemetry/api';
 import type { UserManagerInternal } from '../../api-users/index.ts';
-import { KEY_ENDUSER_PSEUDO_ID } from '../../api-users/index.ts';
 import { generateUUID } from '../../utils/index.ts';
 import {
   EMBRACE_EXTERNAL_USER_ID_KEY,
   EMBRACE_USER_ID_STORAGE_KEY,
-  EMBRACE_USER_STORAGE_KEY_DEPRECATED,
 } from './constants.ts';
 import type { EmbraceUserManagerArgs } from './types.ts';
-import { isUser, isUserId } from './types.ts';
+import { isUserId } from './types.ts';
 
 export class EmbraceUserManager implements UserManagerInternal {
   private readonly _diag: DiagLogger;
@@ -26,7 +24,6 @@ export class EmbraceUserManager implements UserManagerInternal {
         namespace: 'EmbraceUserManager',
       });
     this._storage = storage;
-    this._migrateOldLocalStorageKey();
     this._initialSetup();
   }
 
@@ -56,36 +53,6 @@ export class EmbraceUserManager implements UserManagerInternal {
       this._storage.removeItem(EMBRACE_USER_ID_STORAGE_KEY);
     } catch (e) {
       this._diag.warn('Failed to remove embrace user in storage', e);
-    }
-  }
-
-  // TODO: remove this by 01/08/2025. Two months should be enough time for users to migrate to the new storage key.
-  private _migrateOldLocalStorageKey() {
-    // Since we migrated from storing a User in localStorage to just the user id,
-    // we need to check if the old storage key exists and migrate it.
-    try {
-      const oldUserStorage = this._storage.getItem(
-        EMBRACE_USER_STORAGE_KEY_DEPRECATED,
-      );
-
-      if (oldUserStorage) {
-        const user: unknown = JSON.parse(oldUserStorage);
-        if (isUser(user)) {
-          this._diag.debug('Migrating old user data from storage');
-          this._storage.setItem(
-            EMBRACE_USER_ID_STORAGE_KEY,
-            user[KEY_ENDUSER_PSEUDO_ID],
-          );
-          this._storage.removeItem(EMBRACE_USER_STORAGE_KEY_DEPRECATED);
-        } else {
-          this._diag.warn(
-            'Invalid user data found in storage, clearing old user data',
-          );
-          this._storage.removeItem(EMBRACE_USER_STORAGE_KEY_DEPRECATED);
-        }
-      }
-    } catch (e) {
-      this._diag.warn('Failed to get old user data from storage', e);
     }
   }
 

--- a/packages/web-sdk/src/managers/EmbraceUserManager/constants.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserManager/constants.ts
@@ -1,3 +1,2 @@
-export const EMBRACE_USER_STORAGE_KEY_DEPRECATED = 'embrace_user';
 export const EMBRACE_USER_ID_STORAGE_KEY = 'embrace_user_id';
 export const EMBRACE_EXTERNAL_USER_ID_KEY = 'embrace_external_user_id';

--- a/packages/web-sdk/src/managers/EmbraceUserManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserManager/types.ts
@@ -1,15 +1,9 @@
 import type { DiagLogger } from '@opentelemetry/api';
-import type { User } from '../../api-users/index.ts';
-import { KEY_ENDUSER_PSEUDO_ID } from '../../api-users/index.ts';
 
 export interface EmbraceUserManagerArgs {
   diag?: DiagLogger;
   storage?: Storage;
 }
-
-export const isUser = (user: unknown): user is User =>
-  typeof (user as User)[KEY_ENDUSER_PSEUDO_ID] === 'string' &&
-  (user as User)[KEY_ENDUSER_PSEUDO_ID].length === 32;
 
 export const isUserId = (userId: unknown): userId is string =>
   typeof userId === 'string' && userId.length === 32;

--- a/packages/web-sdk/src/utils/clampNumber.ts
+++ b/packages/web-sdk/src/utils/clampNumber.ts
@@ -1,0 +1,44 @@
+import type { DiagLogger } from '@opentelemetry/api';
+
+/**
+ * Validates `value` against `[min, max]`, returning `defaultValue` (and
+ * warning via `diag`) when the value is non-finite or out of range.
+ * Returns `defaultValue` silently when `value` is undefined.
+ *
+ * Despite the name, out-of-range inputs are replaced with `defaultValue`
+ * rather than pinned to `min`/`max`. Use this to validate user-supplied
+ * config where falling back to a known-good default is safer than
+ * silently mutating the value.
+ */
+export const clampNumber = ({
+  diag,
+  value,
+  defaultValue,
+  min,
+  max,
+}: {
+  diag?: DiagLogger;
+  value: number | undefined;
+  defaultValue: number;
+  min: number;
+  max: number;
+}): number => {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  if (!Number.isFinite(value)) {
+    diag?.warn(
+      `value is not a finite number; falling back to default (${defaultValue.toString()}).`,
+    );
+    return defaultValue;
+  }
+  if (value < min || value > max) {
+    diag?.warn(
+      `value (${value.toString()}) is outside the allowed range ` +
+        `[${min.toString()}, ${max.toString()}]; ` +
+        `falling back to default (${defaultValue.toString()}).`,
+    );
+    return defaultValue;
+  }
+  return value;
+};

--- a/packages/web-sdk/src/utils/index.ts
+++ b/packages/web-sdk/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { bulkAddEventListener } from './bulkAddEventListener/index.ts';
 export { bulkRemoveEventListener } from './bulkRemoveEventListener/index.ts';
+export { clampNumber } from './clampNumber.ts';
 export { createSafeProxy } from './createSafeProxy/index.ts';
 export { generateUUID } from './generateUUID.ts';
 export { generateWebVitalID } from './generateWebVitalID.ts';

--- a/server/server.ts
+++ b/server/server.ts
@@ -12,6 +12,7 @@ import {
   logInfo,
   logReceivedLogRecords,
   logReceivedSessionSpan,
+  logReceivedSpans,
 } from './utils.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -131,24 +132,23 @@ const server = createServer((req, res) => {
   if (pathname?.includes('spans')) {
     parseGzip(req)
       .then((request: IExportTraceServiceRequest) => {
-        const sessionSpan =
-          request.resourceSpans?.[0]?.scopeSpans?.[0]?.spans?.find(
-            (span) => span.name === 'emb-session',
-          );
+        const resourceSpans = request.resourceSpans ?? [];
+
+        logReceivedSpans(resourceSpans);
+
+        const sessionSpan = resourceSpans?.[0]?.scopeSpans?.[0]?.spans?.find(
+          (span) =>
+            span.name === 'emb-session-part' || span.name === 'emb-session',
+        );
         const sessionId = sessionSpan?.attributes.find(
           (attr) => attr.key === 'session.id',
         )?.value.stringValue;
 
-        if (!sessionId) {
-          res.writeHead(400);
-          res.end('Session ID not found');
-          return;
-        }
-
-        receivedSpans[sessionId] = true;
-
-        if (request.resourceSpans && sessionSpan) {
-          logReceivedSessionSpan(request.resourceSpans, sessionSpan, sessionId);
+        if (sessionId) {
+          receivedSpans[sessionId] = true;
+          if (sessionSpan) {
+            logReceivedSessionSpan(resourceSpans, sessionSpan, sessionId);
+          }
         }
 
         res.writeHead(200);

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -184,4 +184,47 @@ const logReceivedLogRecords = (logRecords: ILogRecord[]) => {
   }
 };
 
-export { logInfo, logReceivedLogRecords, logReceivedSessionSpan };
+const formatDurationMs = (
+  startUnixNano: string | number | undefined,
+  endUnixNano: string | number | undefined,
+): string => {
+  if (startUnixNano === undefined || endUnixNano === undefined) return '?';
+  const start = BigInt(startUnixNano);
+  const end = BigInt(endUnixNano);
+  const diffNs = end - start;
+  const ms = Number(diffNs / 1_000_000n);
+  return `${ms}ms`;
+};
+
+const logReceivedSpans = (resourceSpans: IResourceSpans[]) => {
+  let total = 0;
+  for (const resource of resourceSpans) {
+    for (const scopeSpan of resource.scopeSpans) {
+      for (const span of scopeSpan.spans ?? []) {
+        total++;
+        const embType = getEmbType(span) ?? '-';
+        const sessionId =
+          attributeValueFromSpan(span, 'session.id') ?? '<no session.id>';
+        const dur = formatDurationMs(
+          span.startTimeUnixNano as string | number | undefined,
+          span.endTimeUnixNano as string | number | undefined,
+        );
+        logInfo(
+          `Span: ${pc.cyan(span.name)} [emb.type=${embType}] dur=${dur} session.id=${sessionId}`,
+        );
+      }
+    }
+  }
+  if (total === 0) {
+    logInfo('Batch contained 0 spans');
+  } else {
+    logInfo(`Batch contained ${total} span(s)`);
+  }
+};
+
+export {
+  logInfo,
+  logReceivedLogRecords,
+  logReceivedSessionSpan,
+  logReceivedSpans,
+};

--- a/tests/integration/utils/run-e2e-tests.ts
+++ b/tests/integration/utils/run-e2e-tests.ts
@@ -294,7 +294,7 @@ const runE2ETests = ({
             value: 'hidden',
             writable: true,
           });
-          window.dispatchEvent(new Event('visibilitychange'));
+          document.dispatchEvent(new Event('visibilitychange'));
         });
 
         await validateThatSessionEnded();


### PR DESCRIPTION
## What problem is this solving?
Cleanup pass: drop the now-expired user-storage migration path, extract a couple of reusable helpers, and tidy demo/server tooling.

## Short description of changes
- Remove deprecated `embrace_user` localStorage migration and the `User` / `KEY_ENDUSER_PSEUDO_ID` types it required.
- Add `clampNumber` utility for validating user-supplied numeric config against a range, falling back to a default with a diag warning.
- Add `logReceivedSpans` in the dev server so every received span is logged (not only session spans); demo server no longer 400s on batches without a session span.
- Demo: pin vite to port 4847, use `package.json` `version` for `appVersion`, add `.session-table` styles.
- Integration test: fire `visibilitychange` on `document` (correct target) instead of `window`.
- Add a small EmbraceTraceManager test asserting spans are un-parented when no explicit parent is provided.

## Testing
- `npm run validate`
- `npm run test` (web-sdk)