### PR TITLE
chore(test): ignore scripts when installing E2E platform dependencies

### DIFF
--- a/tests/integration/scripts/installE2EPlatformDependencies.sh
+++ b/tests/integration/scripts/installE2EPlatformDependencies.sh
@@ -1,5 +1,5 @@
 find ./platforms -mindepth 2 -maxdepth 2 -type f -name package.json | while read pkg; do
   dir=$(dirname "$pkg")
   echo "Installing dependencies in $dir"
-  npm install --prefix "$dir"
+  npm install --ignore-scripts --prefix "$dir"
 done


### PR DESCRIPTION
## What problem is this solving?
Speed up and harden E2E platform dependency installs by skipping postinstall scripts from third-party packages.

## Short description of changes
- Add `--ignore-scripts` to `npm install` in `installE2EPlatformDependencies.sh`

## Testing
- [x] CI integration tests pass