### PR TITLE
fix(deps): pin fflate via @arethetypeswrong/core override

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,11 @@
     "typescript-eslint": "8.59.3",
     "vite": "8.0.13"
   },
+  "overrides": {
+    "@arethetypeswrong/core": {
+      "fflate": "0.8.2"
+    }
+  },
   "packageManager": "npm@11.9.0",
   "devEngines": {
     "packageManager": {


### PR DESCRIPTION
## What problem is this solving?
`@arethetypeswrong/core` pulls in an incompatible transitive `fflate` version. Pinning it via npm `overrides` resolves the audit warning without waiting on an upstream release.

## Short description of changes
- Add `overrides.@arethetypeswrong/core.fflate` = `0.8.2` in root `package.json`

## Testing
- `npm install` resolves cleanly
- `npm run check` passes (pre-commit hook)