### PR TITLE
EMBR-12323 chore: increase minimum release age for npm dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,10 @@
   "separateMajorMinor": false,
   "packageRules": [
     {
+      "matchDatasource": ["npm"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
       "description": "GitHub Actions",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions"


### PR DESCRIPTION
The preset we get from "config:best-practices" is 3 days:
https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm

Bumping this to 7 to reduce the likelihood we'll pull in a compromised packaged even further. Defining this under a new `packageRules` entry to avoid it being overridden by the preset, see https://github.com/renovatebot/renovate/discussions/39963