### PR TITLE
fix(sessions): flush spans on page exit and add web_hard_navigation reason

### DIFF
--- a/packages/web-sdk/src/api-sessions/manager/types.ts
+++ b/packages/web-sdk/src/api-sessions/manager/types.ts
@@ -112,8 +112,8 @@ export type StartSessionOptions = {
 // `manual`, `inactivity`, `max_duration_reached`, `user_session_rollover`,
 // `user_session_ended`) are emitted unprefixed so the backend can correlate
 // them across platforms. Reasons that describe behaviour specific to the web
-// environment (`web_foreground`, `web_background`, `web_activity`) are
-// stamped with a `web_` prefix.
+// environment (`web_foreground`, `web_background`, `web_activity`,
+// `web_hard_navigation`) are stamped with a `web_` prefix.
 
 export type SessionPartStartReason =
   | 'init' // first part on SDK init (page load); covers the hard-nav load side
@@ -122,7 +122,8 @@ export type SessionPartStartReason =
   | 'user_session_rollover'; // synchronous user-session rollover forced a new part (endUserSession API / max-duration timer)
 
 export type SessionPartEndReason =
-  | 'web_background' // tab became disengaged via visibilitychange (hidden), blur, or pagehide; covers the hard-nav unload side
+  | 'web_background' // tab became disengaged via visibilitychange (hidden), blur, or pagehide (persisted=true / BFCache freeze)
+  | 'web_hard_navigation' // hard-nav unload (pagehide with persisted=false): user navigated away, closed the tab, or reloaded
   | 'inactivity' // no keyboard/mouse/scroll input during the active part for the configured inactivity window; also ends the enclosing user session, with the part span end timestamp anchored to the last activity
   | 'user_session_ended'; // closed because the enclosing user session ended (manual endUserSession, max-duration); stamped on the span by the manager
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -309,9 +309,10 @@ describe('EmbraceUserSessionManager browser activity', () => {
   it('starts a new part with reason foreground on pageshow (BFCache restore)', () => {
     manager.startSessionPartInternal('init');
 
-    // BFCache restore path: pagehide ended the prior part, then pageshow
-    // signals the canonical restore. No part is active when pageshow fires.
-    firePageHide();
+    // BFCache restore path: pagehide with persisted=true freezes the tab and
+    // ends the prior part as web_background, then pageshow signals the
+    // canonical restore. No part is active when pageshow fires.
+    firePageHide(true);
     void expect(manager.getSessionPartId()).to.be.null;
 
     // Document is restored visible on BFCache restore.
@@ -325,16 +326,29 @@ describe('EmbraceUserSessionManager browser activity', () => {
   it('does not start a part on pageshow (BFCache restore) when the tab is disengaged at restore', () => {
     manager.startSessionPartInternal('init');
 
-    // Tab freezes while disengaged: pagehide ends the prior part, then by
-    // the time pageshow fires, the document has restored hidden (the user
-    // restored a backgrounded tab without bringing it to focus).
-    firePageHide();
+    // Tab freezes while disengaged: pagehide with persisted=true ends the
+    // prior part, then by the time pageshow fires, the document has restored
+    // hidden (the user restored a backgrounded tab without bringing it to
+    // focus).
+    firePageHide(true);
     visibilityDoc.visibilityState = 'hidden';
     firePageShow();
 
     // No new part. Only 'init' is in the start log.
     expect(startReasons()).to.deep.equal(['init']);
     void expect(manager.getSessionPartId()).to.be.null;
+  });
+
+  it('swallows errors thrown by endSessionPartInternal during pagehide', () => {
+    manager.startSessionPartInternal('init');
+
+    // The pagehide handler wraps endSessionPartInternal in try/catch because
+    // a throw at unload would skip the keepalive flush. Stub the dependency
+    // to throw and assert the handler does not propagate.
+    endSpy.restore();
+    sinon.stub(manager, 'endSessionPartInternal').throws(new Error('boom'));
+
+    expect(() => firePageHide()).to.not.throw();
   });
 
   it('re-arms the part-inactivity timer when an engagement event fires while already engaged and active', () => {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -106,10 +106,11 @@ describe('EmbraceUserSessionManager browser activity', () => {
 
   // Per the Page Lifecycle spec, visibilityState is already 'hidden' by the
   // time pagehide fires (visibilitychange to 'hidden' fires first), so the
-  // helper mirrors that ordering.
-  const firePageHide = () => {
+  // helper mirrors that ordering. persisted=true is the BFCache-freeze
+  // variant; persisted=false (the default here) is hard-nav unload.
+  const firePageHide = (persisted = false) => {
     visibilityDoc.visibilityState = 'hidden';
-    target.dispatchEvent(new Event('pagehide'));
+    target.dispatchEvent(new PageTransitionEvent('pagehide', { persisted }));
   };
 
   const firePageShow = () => {
@@ -230,12 +231,38 @@ describe('EmbraceUserSessionManager browser activity', () => {
     void expect(manager.getSessionPartId()).to.not.be.null;
   });
 
-  it('ends the active part with reason background on pagehide', () => {
+  it('ends the active part with reason web_hard_navigation on pagehide unload', () => {
     manager.startSessionPartInternal('init');
 
     firePageHide();
 
+    expect(endReasons()).to.deep.equal(['web_hard_navigation']);
+    void expect(manager.getSessionPartId()).to.be.null;
+  });
+
+  it('ends the active part with reason web_background on BFCache pagehide', () => {
+    manager.startSessionPartInternal('init');
+
+    firePageHide(true);
+
     expect(endReasons()).to.deep.equal(['web_background']);
+    void expect(manager.getSessionPartId()).to.be.null;
+  });
+
+  it('ends the active part on pagehide even when the document is still visible and focused', () => {
+    // Chrome hard-nav: pagehide fires before any visibilitychange to
+    // 'hidden' and while the window still reports focus. Without an explicit
+    // end here, the Embrace processor's pending spans would never get
+    // pushed to the exporter before the page is gone.
+    manager.startSessionPartInternal('init');
+
+    visibilityDoc.visibilityState = 'visible';
+    visibilityDoc.hasFocus = () => true;
+    target.dispatchEvent(
+      new PageTransitionEvent('pagehide', { persisted: false }),
+    );
+
+    expect(endReasons()).to.deep.equal(['web_hard_navigation']);
     void expect(manager.getSessionPartId()).to.be.null;
   });
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -801,12 +801,11 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   };
 
   // Navigation away (hard nav, tab close) OR BFCache freeze. Both signal the
-  // page is about to stop running, so we always end the active part to push
-  // its span (and any pending non-part spans buffered in the Embrace
-  // processor) into the export pipeline while the page can still issue a
-  // keepalive fetch. On BFCache restore, pageshow will start a fresh part.
-  // event.persisted distinguishes the two: false is a confirmed hard nav,
-  // true is a BFCache freeze that may come back via pageshow.
+  // page is about to stop running, so we always end the active part. Ending
+  // the part flushes its span (and the spans batched against it in
+  // EmbraceSessionPartBatchedSpanProcessor) through the export pipeline while
+  // the page can still issue a keepalive fetch. On BFCache restore, pageshow
+  // will start a fresh part.
   private readonly _onPageHide = (event: PageTransitionEvent): void => {
     try {
       if (this._activeSessionPartId === null) {
@@ -820,7 +819,10 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
       );
       this.endSessionPartInternal(reason);
     } catch (e) {
-      this._diag.warn('Error handling pagehide event', e);
+      this._diag.error(
+        `Error ending session part on pagehide (persisted=${event.persisted})`,
+        e,
+      );
     }
   };
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -800,13 +800,28 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     );
   };
 
-  // Navigation away (hard nav, tab close) OR BFCache freeze. event.persisted
-  // only affects the debug source string; both disengage the tab, so the
-  // disengage branch of _handleEngagementTransition ends the active part.
+  // Navigation away (hard nav, tab close) OR BFCache freeze. Both signal the
+  // page is about to stop running, so we always end the active part to push
+  // its span (and any pending non-part spans buffered in the Embrace
+  // processor) into the export pipeline while the page can still issue a
+  // keepalive fetch. On BFCache restore, pageshow will start a fresh part.
+  // event.persisted distinguishes the two: false is a confirmed hard nav,
+  // true is a BFCache freeze that may come back via pageshow.
   private readonly _onPageHide = (event: PageTransitionEvent): void => {
-    this._handleEngagementTransition(
-      event.persisted ? 'pagehide-bfcache' : 'pagehide-unload',
-    );
+    try {
+      if (this._activeSessionPartId === null) {
+        return;
+      }
+      const reason: SessionPartEndReason = event.persisted
+        ? 'web_background'
+        : 'web_hard_navigation';
+      this._diag.debug(
+        `page hiding (persisted=${event.persisted}); ending current part as ${reason}`,
+      );
+      this.endSessionPartInternal(reason);
+    } catch (e) {
+      this._diag.warn('Error handling pagehide event', e);
+    }
   };
 
   private _handleEngagementTransition(source: string): void {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -101,7 +101,8 @@ engagement condition holds, the call is a debug-level no-op.
 
 | Value | Trigger |
 | --- | --- |
-| `web_background` | `visibilitychange` to hidden, `blur`, or `pagehide` while a session part is active. |
+| `web_background` | `visibilitychange` to hidden, `blur`, or `pagehide` with `persisted=true` (BFCache freeze). |
+| `web_hard_navigation` | `pagehide` with `persisted=false` (hard navigation away, tab close, or reload). |
 | `inactivity` | The 30 minute part-inactivity timer fires without any user input event resetting it. |
 | `user_session_ended` | `_terminateUserSession` ending the active part, fired on manual `endUserSession()` or max-duration expiry. |
 
@@ -295,9 +296,10 @@ Several specific edge cases are handled:
 There is no BFCache-specific code in the manager. Behavior is absorbed by the
 existing engagement events:
 
-- **Freeze** (entering BFCache). `pagehide` fires.
-  `EmbraceUserSessionManager._onEngagementChange` ends the active part with
-  reason `web_background`.
+- **Freeze** (entering BFCache). `pagehide` fires with `persisted=true`.
+  `EmbraceUserSessionManager._onPageHide` ends the active part with reason
+  `web_background`. A `pagehide` with `persisted=false` is a hard navigation,
+  not a BFCache freeze, and ends the part with `web_hard_navigation` instead.
 - **Restore** (leaving BFCache). `pageshow` fires. If the document is visible
   and focused and no part is active, a new part starts with reason
   `web_foreground`. If the document restores hidden, no part starts.


### PR DESCRIPTION
## What problem is this solving?
On hard navigations (pagehide with persisted=false) Chrome fires pagehide before any visibilitychange to hidden and while the window still reports focus. The previous engagement-transition path could leave the active session part open, so pending spans buffered in the Embrace processor were never pushed to the exporter before the page went away.

## Short description of changes
- Handle pagehide directly: always end the active part so the span (and any pending spans) reach the export pipeline while the page can still issue a keepalive fetch.
- Add new `web_hard_navigation` SessionPartEndReason for pagehide with `persisted=false`; keep `web_background` for BFCache freeze (`persisted=true`).
- Update types/comments to document the prefix and the two pagehide variants.

## Testing
- Unit tests cover hard-nav pagehide, BFCache pagehide, and the visible+focused hard-nav edge case.
- `npm run test` from packages/web-sdk/.