### PR TITLE
EMBR-12374 chore: address race condition in integration test

### DIFF
--- a/tests/integration/utils/run-e2e-tests.ts
+++ b/tests/integration/utils/run-e2e-tests.ts
@@ -185,12 +185,6 @@ const runE2ETests = ({
         await button.click();
         await waitForOTelRequest();
 
-        if (requests.length === 0) {
-          // Small hack to avoid some flakiness where sometimes the response has returned but `requests` was not
-          // yet populated
-          await new Promise((resolve) => setTimeout(resolve, 500));
-        }
-
         testE2E.expect(requests).toHaveLength(1);
 
         if (goldenFiles) {
@@ -406,12 +400,6 @@ const runE2ETests = ({
 
         await page.getByRole('button', { name: 'End Session' }).click();
         await waitForOTelRequest();
-
-        if (requests.length === 1) {
-          // Small hack to avoid some flakiness where sometimes the response has returned but `requests` was not
-          // yet populated
-          await new Promise((resolve) => setTimeout(resolve, 500));
-        }
 
         testE2E.expect(requests).toHaveLength(2);
         // Should contain a span capturing the fetch request

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -158,24 +158,19 @@ const testWithMockApi = base.extend<TestWithMockApi>({
           return;
         }
 
-        // Decompress the gzipped data
-        zlib.gunzip(buffer, (err, result) => {
-          if (err) {
-            console.error('Failed to decompress request from SDK:', err);
-          } else {
-            try {
-              const json = result.toString('utf-8');
-
-              requests.push({
-                url: request.url(),
-                headers: request.headers(),
-                data: JSON.parse(json) as Record<string, unknown>,
-              });
-            } catch (e) {
-              console.error('Failed to parse request to JSON:', e);
-            }
-          }
-        });
+        // Decompress and record synchronously before route.continue() so the
+        // entry is visible in `requests` by the time waitForOTelRequest resolves
+        // on the response.
+        try {
+          const json = zlib.gunzipSync(buffer).toString('utf-8');
+          requests.push({
+            url: request.url(),
+            headers: request.headers(),
+            data: JSON.parse(json) as Record<string, unknown>,
+          });
+        } catch (e) {
+          console.error('Failed to parse request from SDK:', e);
+        }
 
         await route.continue();
       };


### PR DESCRIPTION
In the integration test mock api a callback was used to decompress the payload which meant that there was a small chance that the test expectation was ran before the data in `requests` was populated, switching to a synchronous call for decompression to see if that makes things more stable