### PR TITLE
refactor(tests): modernize integration-test platforms to user-session API

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -216,7 +216,7 @@ runE2ETests({
 4. **Expose session ID on window:**
 
 ```javascript
-window.EMBRACE_CURRENT_SESSION_ID = getCurrentSessionId();
+window.EMBRACE_CURRENT_USER_SESSION_ID = getCurrentUserSessionId();
 ```
 
 ## Troubleshooting
@@ -235,7 +235,7 @@ Check that:
 1. Build tests passed (required for e2e setup)
 2. The correct number of spans is set in `numberOfExpectedSpans`
 3. Required buttons are present and use correct labels
-4. Session ID is exposed on `window.EMBRACE_CURRENT_SESSION_ID`
+4. Session ID is exposed on `window.EMBRACE_CURRENT_USER_SESSION_ID`
 
 ### Golden file mismatches
 

--- a/tests/integration/platforms/next-15-turbopack-app/src/components/EmbraceWebSdk.tsx
+++ b/tests/integration/platforms/next-15-turbopack-app/src/components/EmbraceWebSdk.tsx
@@ -22,12 +22,12 @@ export const embraceWebSdk = initSDK({
 
 declare global {
   interface Window {
-    EMBRACE_CURRENT_SESSION_ID: string | null;
+    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
   }
 }
 
 if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_SESSION_ID = session.getSessionId();
+  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
 }
 
 export default function EmbraceWebSdk() {

--- a/tests/integration/platforms/next-15-turbopack-app/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-15-turbopack-app/src/components/SDKTest.tsx
@@ -5,7 +5,7 @@ import { embraceWebSdk } from './EmbraceWebSdk.tsx';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
-    session.endSessionSpan();
+    session.endUserSession();
     if (embraceWebSdk) {
       await embraceWebSdk.flush();
     }

--- a/tests/integration/platforms/next-15-turbopack-pages/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-15-turbopack-pages/src/components/SDKTest.tsx
@@ -3,7 +3,7 @@ import { embraceWebSdk } from '../lib/embrace.ts';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
-    session.endSessionSpan();
+    session.endUserSession();
     if (embraceWebSdk) {
       await embraceWebSdk.flush();
     }

--- a/tests/integration/platforms/next-15-turbopack-pages/src/lib/embrace.ts
+++ b/tests/integration/platforms/next-15-turbopack-pages/src/lib/embrace.ts
@@ -18,10 +18,10 @@ export const embraceWebSdk = initSDK({
 
 declare global {
   interface Window {
-    EMBRACE_CURRENT_SESSION_ID: string | null;
+    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
   }
 }
 
 if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_SESSION_ID = session.getSessionId();
+  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
 }

--- a/tests/integration/platforms/next-15-webpack-app/src/components/EmbraceWebSdk.tsx
+++ b/tests/integration/platforms/next-15-webpack-app/src/components/EmbraceWebSdk.tsx
@@ -22,12 +22,12 @@ export const embraceWebSdk = initSDK({
 
 declare global {
   interface Window {
-    EMBRACE_CURRENT_SESSION_ID: string | null;
+    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
   }
 }
 
 if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_SESSION_ID = session.getSessionId();
+  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
 }
 
 export default function EmbraceWebSdk() {

--- a/tests/integration/platforms/next-15-webpack-app/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-15-webpack-app/src/components/SDKTest.tsx
@@ -5,7 +5,7 @@ import { embraceWebSdk } from './EmbraceWebSdk.tsx';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
-    session.endSessionSpan();
+    session.endUserSession();
     if (embraceWebSdk) {
       await embraceWebSdk.flush();
     }

--- a/tests/integration/platforms/next-15-webpack-pages/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-15-webpack-pages/src/components/SDKTest.tsx
@@ -3,7 +3,7 @@ import { embraceWebSdk } from '../lib/embrace.ts';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
-    session.endSessionSpan();
+    session.endUserSession();
     if (embraceWebSdk) {
       await embraceWebSdk.flush();
     }

--- a/tests/integration/platforms/next-15-webpack-pages/src/lib/embrace.ts
+++ b/tests/integration/platforms/next-15-webpack-pages/src/lib/embrace.ts
@@ -18,10 +18,10 @@ export const embraceWebSdk = initSDK({
 
 declare global {
   interface Window {
-    EMBRACE_CURRENT_SESSION_ID: string | null;
+    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
   }
 }
 
 if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_SESSION_ID = session.getSessionId();
+  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
 }

--- a/tests/integration/platforms/next-16-app/src/components/EmbraceWebSdk.tsx
+++ b/tests/integration/platforms/next-16-app/src/components/EmbraceWebSdk.tsx
@@ -22,12 +22,12 @@ export const embraceWebSdk = initSDK({
 
 declare global {
   interface Window {
-    EMBRACE_CURRENT_SESSION_ID: string | null;
+    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
   }
 }
 
 if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_SESSION_ID = session.getSessionId();
+  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
 }
 
 export default function EmbraceWebSdk() {

--- a/tests/integration/platforms/next-16-app/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-16-app/src/components/SDKTest.tsx
@@ -5,7 +5,7 @@ import { embraceWebSdk } from './EmbraceWebSdk.tsx';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
-    session.endSessionSpan();
+    session.endUserSession();
     if (embraceWebSdk) {
       await embraceWebSdk.flush();
     }

--- a/tests/integration/platforms/next-16-pages/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-16-pages/src/components/SDKTest.tsx
@@ -3,7 +3,7 @@ import { embraceWebSdk } from '../lib/embrace.ts';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
-    session.endSessionSpan();
+    session.endUserSession();
     if (embraceWebSdk) {
       await embraceWebSdk.flush();
     }

--- a/tests/integration/platforms/next-16-pages/src/lib/embrace.ts
+++ b/tests/integration/platforms/next-16-pages/src/lib/embrace.ts
@@ -18,10 +18,10 @@ export const embraceWebSdk = initSDK({
 
 declare global {
   interface Window {
-    EMBRACE_CURRENT_SESSION_ID: string | null;
+    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
   }
 }
 
 if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_SESSION_ID = session.getSessionId();
+  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
 }

--- a/tests/integration/platforms/vite-6/src/SDKTest.tsx
+++ b/tests/integration/platforms/vite-6/src/SDKTest.tsx
@@ -3,7 +3,7 @@ import { sdkControl } from './otel.ts';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
-    session.endSessionSpan();
+    session.endUserSession();
 
     if (sdkControl) {
       await sdkControl.flush();

--- a/tests/integration/platforms/vite-6/src/otel.ts
+++ b/tests/integration/platforms/vite-6/src/otel.ts
@@ -20,10 +20,10 @@ const sdkControl = initSDK({
 
 declare global {
   interface Window {
-    EMBRACE_CURRENT_SESSION_ID: string | null;
+    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
   }
 }
 
-window.EMBRACE_CURRENT_SESSION_ID = session.getSessionId();
+window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
 
 export { sdkControl };

--- a/tests/integration/platforms/vite-7/src/SDKTest.tsx
+++ b/tests/integration/platforms/vite-7/src/SDKTest.tsx
@@ -3,7 +3,7 @@ import { sdkControl } from './otel.ts';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
-    session.endSessionSpan();
+    session.endUserSession();
 
     if (sdkControl) {
       await sdkControl.flush();

--- a/tests/integration/platforms/vite-7/src/otel.ts
+++ b/tests/integration/platforms/vite-7/src/otel.ts
@@ -19,10 +19,10 @@ const sdkControl = initSDK({
 
 declare global {
   interface Window {
-    EMBRACE_CURRENT_SESSION_ID: string | null;
+    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
   }
 }
 
-window.EMBRACE_CURRENT_SESSION_ID = session.getSessionId();
+window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
 
 export { sdkControl };

--- a/tests/integration/platforms/webpack-5/src/SDKTest.tsx
+++ b/tests/integration/platforms/webpack-5/src/SDKTest.tsx
@@ -3,7 +3,7 @@ import { sdkControl } from './otel.ts';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
-    session.endSessionSpan();
+    session.endUserSession();
 
     if (sdkControl) {
       await sdkControl.flush();

--- a/tests/integration/platforms/webpack-5/src/otel.ts
+++ b/tests/integration/platforms/webpack-5/src/otel.ts
@@ -20,10 +20,10 @@ const sdkControl = initSDK({
 
 declare global {
   interface Window {
-    EMBRACE_CURRENT_SESSION_ID: string | null;
+    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
   }
 }
 
-window.EMBRACE_CURRENT_SESSION_ID = session.getSessionId();
+window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
 
 export { sdkControl };

--- a/tests/integration/types.ts
+++ b/tests/integration/types.ts
@@ -1,6 +1,6 @@
 declare global {
   interface Window {
-    EMBRACE_CURRENT_SESSION_ID: string | null;
+    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
   }
 }
 

--- a/tests/integration/utils/run-e2e-tests.ts
+++ b/tests/integration/utils/run-e2e-tests.ts
@@ -7,28 +7,28 @@ const EXPECTED_SPAN_ENDED_TEXT =
   'EmbraceSessionPartBatchedSpanProcessor non-session-part span ended';
 
 type E2ETestFixture = {
-  getCurrentSessionId: () => Promise<string>;
+  getCurrentUserSessionId: () => Promise<string>;
   waitUntilSpanLogged: () => Promise<void>;
   navigateAndWaitUntilReady: (
     url: string,
     numberOfExpectedSpans: number,
   ) => Promise<void>;
-  validateThatSessionEnded: (sessionId?: string) => Promise<void>;
+  validateThatUserSessionEnded: (userSessionId?: string) => Promise<void>;
 };
 
 const testE2E = testWithMockApi.extend<E2ETestFixture>({
-  getCurrentSessionId: async ({ page }, use) => {
+  getCurrentUserSessionId: async ({ page }, use) => {
     await use(async () => {
-      const sessionId = await page.evaluate(
-        () => window.EMBRACE_CURRENT_SESSION_ID,
+      const userSessionId = await page.evaluate(
+        () => window.EMBRACE_CURRENT_USER_SESSION_ID,
         {},
       );
 
-      if (!sessionId) {
+      if (!userSessionId) {
         throw new Error('Session ID is not available on the page');
       }
 
-      return sessionId;
+      return userSessionId;
     });
   },
 
@@ -90,9 +90,10 @@ const testE2E = testWithMockApi.extend<E2ETestFixture>({
       });
     });
   },
-  validateThatSessionEnded: async ({ getCurrentSessionId }, use) => {
-    await use(async (sessionId?: string) => {
-      const currentSessionId = sessionId || (await getCurrentSessionId());
+  validateThatUserSessionEnded: async ({ getCurrentUserSessionId }, use) => {
+    await use(async (userSessionId?: string) => {
+      const currentUserSessionId =
+        userSessionId || (await getCurrentUserSessionId());
 
       // Easy way of making sure the server registered the session end
       // If this gets flaky, we can increase the timeout or read the server logs
@@ -108,7 +109,7 @@ const testE2E = testWithMockApi.extend<E2ETestFixture>({
             );
             const receivedSpans = (await response.json()) as ReceivedSpans;
 
-            if (receivedSpans[currentSessionId]) {
+            if (receivedSpans[currentUserSessionId]) {
               clearInterval(interval);
               clearTimeout(timeout);
               resolve(null);
@@ -239,25 +240,26 @@ const runE2ETests = ({
         page,
         navigateAndWaitUntilReady,
         withRemoteConfig,
-        getCurrentSessionId,
+        getCurrentUserSessionId,
       }) => {
         await withRemoteConfig({
           threshold: 0,
         });
         await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
-        let currentSessionId: string | null = await getCurrentSessionId();
+        let currentUserSessionId: string | null =
+          await getCurrentUserSessionId();
 
         // First load works as expected as we don't wait for the remote config to be applied
-        testE2E.expect(currentSessionId).toHaveLength(32);
+        testE2E.expect(currentUserSessionId).toHaveLength(32);
 
         await page.reload();
 
         // After reload, the session id should not be set as it is sampled out
-        currentSessionId = await page.evaluate(
-          () => window.EMBRACE_CURRENT_SESSION_ID,
+        currentUserSessionId = await page.evaluate(
+          () => window.EMBRACE_CURRENT_USER_SESSION_ID,
           {},
         );
-        testE2E.expect(currentSessionId).toBeNull();
+        testE2E.expect(currentUserSessionId).toBeNull();
       },
     );
 
@@ -266,25 +268,29 @@ const runE2ETests = ({
       async ({
         navigateAndWaitUntilReady,
         page,
-        validateThatSessionEnded,
-        getCurrentSessionId,
+        validateThatUserSessionEnded,
+        getCurrentUserSessionId,
         browserName,
       }) => {
         testE2E.skip(browserName === 'webkit', 'Skipping on WebKit');
         testE2E.skip(browserName === 'firefox', 'Skipping on Firefox');
 
         await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
-        const currentSessionId = await getCurrentSessionId();
+        const currentUserSessionId = await getCurrentUserSessionId();
 
         await page.close();
 
-        await validateThatSessionEnded(currentSessionId);
+        await validateThatUserSessionEnded(currentUserSessionId);
       },
     );
 
     testE2E(
       'it should end the session and send it to the API if the page loses focus',
-      async ({ navigateAndWaitUntilReady, page, validateThatSessionEnded }) => {
+      async ({
+        navigateAndWaitUntilReady,
+        page,
+        validateThatUserSessionEnded,
+      }) => {
         await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
 
         // Simulate losing focus by minimizing the page or changing the tab
@@ -297,7 +303,7 @@ const runE2ETests = ({
           document.dispatchEvent(new Event('visibilitychange'));
         });
 
-        await validateThatSessionEnded();
+        await validateThatUserSessionEnded();
       },
     );
 
@@ -306,18 +312,18 @@ const runE2ETests = ({
       async ({
         navigateAndWaitUntilReady,
         page,
-        validateThatSessionEnded,
-        getCurrentSessionId,
+        validateThatUserSessionEnded,
+        getCurrentUserSessionId,
         browserName,
       }) => {
         testE2E.skip(browserName === 'firefox', 'Skipping on Firefox');
 
         await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
-        const currentSessionId = await getCurrentSessionId();
+        const currentUserSessionId = await getCurrentUserSessionId();
 
         await page.reload();
 
-        await validateThatSessionEnded(currentSessionId);
+        await validateThatUserSessionEnded(currentUserSessionId);
       },
     );
 
@@ -326,21 +332,21 @@ const runE2ETests = ({
       async ({
         navigateAndWaitUntilReady,
         page,
-        validateThatSessionEnded,
-        getCurrentSessionId,
+        validateThatUserSessionEnded,
+        getCurrentUserSessionId,
         browserName,
       }) => {
         testE2E.skip(browserName === 'webkit', 'Skipping on WebKit');
 
         await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
-        const currentSessionId = await getCurrentSessionId();
+        const currentUserSessionId = await getCurrentUserSessionId();
 
         const button = page.getByRole('button', {
           name: 'Navigate to Another Page',
         });
         await button.click();
 
-        await validateThatSessionEnded(currentSessionId);
+        await validateThatUserSessionEnded(currentUserSessionId);
       },
     );
 
@@ -349,21 +355,21 @@ const runE2ETests = ({
       async ({
         navigateAndWaitUntilReady,
         page,
-        validateThatSessionEnded,
-        getCurrentSessionId,
+        validateThatUserSessionEnded,
+        getCurrentUserSessionId,
         browserName,
       }) => {
         testE2E.skip(browserName === 'webkit', 'Skipping on WebKit');
 
         await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
-        const currentSessionId = await getCurrentSessionId();
+        const currentUserSessionId = await getCurrentUserSessionId();
 
         // Simulate navigation by changing the URL directly
         // This is a workaround since Playwright does not support changing the URL bar directly
         // Not exactly the same as a user typing in the URL bar, but is the best we can do
         await page.goto('about:blank');
 
-        await validateThatSessionEnded(currentSessionId);
+        await validateThatUserSessionEnded(currentUserSessionId);
       },
     );
 


### PR DESCRIPTION
## What problem is this solving?
The integration-test platforms still call the deprecated session-span API (`session.getSessionId()`, `session.endSessionSpan()`) and use the bare-"session" `window.EMBRACE_CURRENT_SESSION_ID` global. The deprecated forwarders exist only for backwards compat; per the user-session terminology rule, these call sites should use the canonical user-session API.

## Short description of changes
- `session.getSessionId()` → `session.getUserSessionId()` across all 9 platforms.
- `session.endSessionSpan()` → `session.endUserSession()` in every platform's SDKTest.
- `window.EMBRACE_CURRENT_SESSION_ID` → `EMBRACE_CURRENT_USER_SESSION_ID` (declarations + assignments + README references + shared `types.ts`).
- `tests/integration/utils/run-e2e-tests.ts`: rename fixtures and locals (`getCurrentSessionId` → `getCurrentUserSessionId`, `validateThatSessionEnded` → `validateThatUserSessionEnded`, `currentSessionId` → `currentUserSessionId`, `sessionId` → `userSessionId`).

## Testing
- npm run check passes.