### PR TITLE
EMBR-12323 chore: fix renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,7 @@
   "separateMajorMinor": false,
   "packageRules": [
     {
-      "matchDatasource": ["npm"],
+      "matchDatasourc": ["npm"],
       "minimumReleaseAge": "7 days"
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,7 @@
   "separateMajorMinor": false,
   "packageRules": [
     {
-      "matchDatasourc": ["npm"],
+      "matchDatasources": ["npm"],
       "minimumReleaseAge": "7 days"
     },
     {

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -1,0 +1,29 @@
+name: Renovate Config Validator
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/renovate.json
+  pull_request:
+    paths:
+      - .github/renovate.json
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Validate .github/renovate.json
+        run: npx --yes --package=renovate -- renovate-config-validator .github/renovate.json

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -26,4 +26,9 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Validate .github/renovate.json
+        # LOG_FORMAT=json bypasses Renovate's async pretty-printer; the validator
+        # calls process.exit() without draining streams, so in non-TTY CI any
+        # in-flight pretty-printed errors are dropped before they reach the log.
+        env:
+          LOG_FORMAT: json
         run: npx --yes --package=renovate -- renovate-config-validator .github/renovate.json


### PR DESCRIPTION
There's a typo in the renovate config, first adding a new GHA that invokes `renovate-config-validator` and should fail on the current config, then actually addressing the typo which should then get the check passing

Validation failure prior to fix: https://github.com/embrace-io/embrace-web-sdk/actions/runs/26404082927/job/77723129385?pr=1346