### PR TITLE
EMBR-12416 refactor(sessions): remove pagehide/pageshow listeners and web_hard_navigation reason

### DIFF
--- a/packages/web-sdk/src/api-sessions/manager/types.ts
+++ b/packages/web-sdk/src/api-sessions/manager/types.ts
@@ -122,7 +122,7 @@ export type SessionPartStartReason =
   | 'user_session_rollover'; // synchronous user-session rollover forced a new part (endUserSession API / max-duration timer)
 
 export type SessionPartEndReason =
-  | 'web_background' // tab became disengaged via visibilitychange (hidden) or blur; also covers hard-nav unload and BFCache freeze, since blur or an earlier visibilitychange-to-hidden ends the part before pagehide fires
+  | 'web_background' // tab disengaged via visibilitychange (hidden) or blur. Also covers hard-nav unload and BFCache freeze (pagehide is not listened to)
   | 'inactivity' // no keyboard/mouse/scroll input during the active part for the configured inactivity window; also ends the enclosing user session, with the part span end timestamp anchored to the last activity
   | 'user_session_ended'; // closed because the enclosing user session ended (manual endUserSession, max-duration); stamped on the span by the manager
 

--- a/packages/web-sdk/src/api-sessions/manager/types.ts
+++ b/packages/web-sdk/src/api-sessions/manager/types.ts
@@ -112,18 +112,17 @@ export type StartSessionOptions = {
 // `manual`, `inactivity`, `max_duration_reached`, `user_session_rollover`,
 // `user_session_ended`) are emitted unprefixed so the backend can correlate
 // them across platforms. Reasons that describe behaviour specific to the web
-// environment (`web_foreground`, `web_background`, `web_activity`,
-// `web_hard_navigation`) are stamped with a `web_` prefix.
+// environment (`web_foreground`, `web_background`, `web_activity`) are stamped
+// with a `web_` prefix.
 
 export type SessionPartStartReason =
   | 'init' // first part on SDK init (page load); covers the hard-nav load side
-  | 'web_foreground' // tab became engaged via visibilitychange (visible), focus, or pageshow while no part was active
+  | 'web_foreground' // tab became engaged via visibilitychange (visible) or focus while no part was active
   | 'web_activity' // user input resumed after an inactivity-killed part
   | 'user_session_rollover'; // synchronous user-session rollover forced a new part (endUserSession API / max-duration timer)
 
 export type SessionPartEndReason =
-  | 'web_background' // tab became disengaged via visibilitychange (hidden), blur, or pagehide (persisted=true / BFCache freeze)
-  | 'web_hard_navigation' // hard-nav unload (pagehide with persisted=false): user navigated away, closed the tab, or reloaded
+  | 'web_background' // tab became disengaged via visibilitychange (hidden) or blur; also covers hard-nav unload and BFCache freeze, since blur or an earlier visibilitychange-to-hidden ends the part before pagehide fires
   | 'inactivity' // no keyboard/mouse/scroll input during the active part for the configured inactivity window; also ends the enclosing user session, with the part span end timestamp anchored to the last activity
   | 'user_session_ended'; // closed because the enclosing user session ended (manual endUserSession, max-duration); stamped on the span by the manager
 

--- a/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
@@ -956,21 +956,13 @@ describe('EmbraceLogManager', () => {
     );
   });
 
-  // Non-visible visibilityState values (prerender, unloaded, undefined) are
-  // "not actively viewing" per the emb.state contract and must map to
-  // background. Pins the getVisibilityState semantics for log attributes.
-  it('should record emb.state as background for non-visible visibilityState values', () => {
+  // When visibilityState is missing, emb.state must fall back to background
+  // per the getVisibilityState contract. Pins the semantics for log attributes.
+  it('should record emb.state as background when visibilityState is missing', () => {
     const cases: Array<{
       name: string;
       visibilityDoc: VisibilityStateDocument;
     }> = [
-      {
-        name: 'prerender',
-        visibilityDoc: {
-          visibilityState: 'prerender' as DocumentVisibilityState,
-          hasFocus: () => false,
-        },
-      },
       {
         name: 'missing visibilityState',
         visibilityDoc: {} as VisibilityStateDocument,

--- a/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
@@ -956,6 +956,46 @@ describe('EmbraceLogManager', () => {
     );
   });
 
+  // Non-visible visibilityState values (prerender, unloaded, undefined) are
+  // "not actively viewing" per the emb.state contract and must map to
+  // background. Pins the getVisibilityState semantics for log attributes.
+  it('should record emb.state as background for non-visible visibilityState values', () => {
+    const cases: Array<{
+      name: string;
+      visibilityDoc: VisibilityStateDocument;
+    }> = [
+      {
+        name: 'prerender',
+        visibilityDoc: {
+          visibilityState: 'prerender' as DocumentVisibilityState,
+          hasFocus: () => false,
+        },
+      },
+      {
+        name: 'missing visibilityState',
+        visibilityDoc: {} as VisibilityStateDocument,
+      },
+    ];
+
+    for (const { visibilityDoc } of cases) {
+      const localManager = new EmbraceLogManager({
+        perf,
+        userSessionManager,
+        limitManager,
+        storage,
+        visibilityDoc,
+      });
+
+      localManager.message('info log', 'info');
+    }
+
+    const finishedLogs = memoryExporter.getFinishedLogRecords();
+    expect(finishedLogs).to.have.lengthOf(cases.length);
+    for (const log of finishedLogs) {
+      expect(log.attributes).to.have.property('emb.state', 'background');
+    }
+  });
+
   it('should record an attribute when there is an error.cause available', () => {
     expect(() => {
       manager.logException(

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -116,8 +116,8 @@ describe('EmbraceUserSessionManager browser activity', () => {
 
   // Real Chrome active-tab unload (hard nav OR BFCache freeze): blur fires
   // first while still 'visible', then visibilitychange to 'hidden'.
-  // pagehide also fires between them per spec but the SDK does not listen
-  // for it because blur has already ended the part by then.
+  // pagehide also fires between them, but the SDK does not listen for it
+  // because blur has already ended the part by then.
   const fireActiveTabUnload = () => {
     visibilityDoc.hasFocus = () => false;
     target.dispatchEvent(new Event('blur'));
@@ -138,8 +138,8 @@ describe('EmbraceUserSessionManager browser activity', () => {
   // is still 'hidden', then visibilitychange to 'visible'. focus alone
   // doesn't satisfy the engagement gate (which requires visible AND
   // focused), so visibilitychange-to-'visible' is what actually starts
-  // the new part. pageshow also fires last per spec but the SDK does not
-  // listen for it.
+  // the new part. pageshow also fires last, but the SDK does not listen
+  // for it.
   const fireBfcacheRestore = () => {
     visibilityDoc.hasFocus = () => true;
     target.dispatchEvent(new Event('focus'));

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -114,32 +114,31 @@ describe('EmbraceUserSessionManager browser activity', () => {
     target.dispatchEvent(new Event('focus'));
   };
 
-  // Real Chrome active-tab unload (hard nav OR BFCache freeze): blur fires
-  // first while still 'visible', then visibilitychange to 'hidden'.
-  // pagehide also fires between them, but the SDK does not listen for it
-  // because blur has already ended the part by then.
-  const fireActiveTabUnload = () => {
+  // Focus-shifting active-tab unload (URL-bar typing, alt-tab-then-close):
+  // blur fires first, then visibilitychange to 'hidden'. The programmatic
+  // nav variant fires no blur and is exercised by fireVisibilityChange('hidden')
+  // directly. See README for the verified cross-engine ordering.
+  const fireFocusShiftingUnload = () => {
     visibilityDoc.hasFocus = () => false;
     target.dispatchEvent(new Event('blur'));
     visibilityDoc.visibilityState = 'hidden';
     visibilityDoc.dispatchEvent(new Event('visibilitychange'));
   };
 
-  // Real Chrome already-backgrounded-tab unload: visibilitychange-to-
-  // 'hidden' fired earlier (when the user originally switched tabs).
-  // pagehide is not listened to.
-  const fireAlreadyHiddenTabUnload = () => {
+  // Tab becomes hidden. Covers two real Chrome scenarios that look
+  // identical to the SDK: the user switching to another tab, and an
+  // already-backgrounded tab unloading. In both cases the SDK only
+  // observes visibilitychange-to-'hidden' since pagehide is not listened to.
+  const fireTabHidden = () => {
     visibilityDoc.visibilityState = 'hidden';
     visibilityDoc.hasFocus = () => false;
     visibilityDoc.dispatchEvent(new Event('visibilitychange'));
   };
 
-  // Real Chrome BFCache restore: focus fires first while visibilityState
-  // is still 'hidden', then visibilitychange to 'visible'. focus alone
-  // doesn't satisfy the engagement gate (which requires visible AND
-  // focused), so visibilitychange-to-'visible' is what actually starts
-  // the new part. pageshow also fires last, but the SDK does not listen
-  // for it.
+  // BFCache restore per Chrome's page-lifecycle docs (Playwright suppresses
+  // BFCache, so this is doc-derived not empirically observed): focus fires
+  // first while still 'hidden', then visibilitychange to 'visible' starts
+  // the part. The trailing pageshow has no listener.
   const fireBfcacheRestore = () => {
     visibilityDoc.hasFocus = () => true;
     target.dispatchEvent(new Event('focus'));
@@ -313,7 +312,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   it('ends the active part exactly once as web_background on a real active-tab unload sequence', () => {
     manager.startSessionPartInternal('init');
 
-    fireActiveTabUnload();
+    fireFocusShiftingUnload();
 
     expect(endReasons()).to.deep.equal(['web_background']);
     expect(endSpy.callCount).to.equal(1);
@@ -323,7 +322,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   it('ends on visibilitychange-to-hidden for an already-backgrounded tab unload', () => {
     manager.startSessionPartInternal('init');
 
-    fireAlreadyHiddenTabUnload();
+    fireTabHidden();
 
     expect(endReasons()).to.deep.equal(['web_background']);
     expect(endSpy.callCount).to.equal(1);
@@ -332,7 +331,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
 
   it('starts the new part exactly once as web_foreground on a real BFCache restore sequence', () => {
     manager.startSessionPartInternal('init');
-    fireAlreadyHiddenTabUnload();
+    fireTabHidden();
     startSpy.resetHistory();
     endSpy.resetHistory();
 
@@ -346,7 +345,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   it('nets to one end and one start across a full active-tab unload then BFCache restore round-trip', () => {
     manager.startSessionPartInternal('init');
 
-    fireActiveTabUnload();
+    fireFocusShiftingUnload();
     fireBfcacheRestore();
 
     expect(endReasons()).to.deep.equal(['web_background']);

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -104,19 +104,6 @@ describe('EmbraceUserSessionManager browser activity', () => {
     visibilityDoc.dispatchEvent(new Event('visibilitychange'));
   };
 
-  // Per the Page Lifecycle spec, visibilityState is already 'hidden' by the
-  // time pagehide fires (visibilitychange to 'hidden' fires first), so the
-  // helper mirrors that ordering. persisted=true is the BFCache-freeze
-  // variant; persisted=false (the default here) is hard-nav unload.
-  const firePageHide = (persisted = false) => {
-    visibilityDoc.visibilityState = 'hidden';
-    target.dispatchEvent(new PageTransitionEvent('pagehide', { persisted }));
-  };
-
-  const firePageShow = () => {
-    target.dispatchEvent(new Event('pageshow'));
-  };
-
   const fireBlur = () => {
     visibilityDoc.hasFocus = () => false;
     target.dispatchEvent(new Event('blur'));
@@ -125,6 +112,39 @@ describe('EmbraceUserSessionManager browser activity', () => {
   const fireFocus = () => {
     visibilityDoc.hasFocus = () => true;
     target.dispatchEvent(new Event('focus'));
+  };
+
+  // Real Chrome active-tab unload (hard nav OR BFCache freeze): blur fires
+  // first while still 'visible', then visibilitychange to 'hidden'.
+  // pagehide also fires between them per spec but the SDK does not listen
+  // for it because blur has already ended the part by then.
+  const fireActiveTabUnload = () => {
+    visibilityDoc.hasFocus = () => false;
+    target.dispatchEvent(new Event('blur'));
+    visibilityDoc.visibilityState = 'hidden';
+    visibilityDoc.dispatchEvent(new Event('visibilitychange'));
+  };
+
+  // Real Chrome already-backgrounded-tab unload: visibilitychange-to-
+  // 'hidden' fired earlier (when the user originally switched tabs).
+  // pagehide is not listened to.
+  const fireAlreadyHiddenTabUnload = () => {
+    visibilityDoc.visibilityState = 'hidden';
+    visibilityDoc.hasFocus = () => false;
+    visibilityDoc.dispatchEvent(new Event('visibilitychange'));
+  };
+
+  // Real Chrome BFCache restore: focus fires first while visibilityState
+  // is still 'hidden', then visibilitychange to 'visible'. focus alone
+  // doesn't satisfy the engagement gate (which requires visible AND
+  // focused), so visibilitychange-to-'visible' is what actually starts
+  // the new part. pageshow also fires last per spec but the SDK does not
+  // listen for it.
+  const fireBfcacheRestore = () => {
+    visibilityDoc.hasFocus = () => true;
+    target.dispatchEvent(new Event('focus'));
+    visibilityDoc.visibilityState = 'visible';
+    visibilityDoc.dispatchEvent(new Event('visibilitychange'));
   };
 
   it('arms the part-inactivity timer when a part starts', () => {
@@ -231,46 +251,25 @@ describe('EmbraceUserSessionManager browser activity', () => {
     void expect(manager.getSessionPartId()).to.not.be.null;
   });
 
-  it('ends the active part with reason web_hard_navigation on pagehide unload', () => {
+  it('ignores pagehide and pageshow events (no listeners registered)', () => {
     manager.startSessionPartInternal('init');
 
-    firePageHide();
-
-    expect(endReasons()).to.deep.equal(['web_hard_navigation']);
-    void expect(manager.getSessionPartId()).to.be.null;
-  });
-
-  it('ends the active part with reason web_background on BFCache pagehide', () => {
-    manager.startSessionPartInternal('init');
-
-    firePageHide(true);
-
-    expect(endReasons()).to.deep.equal(['web_background']);
-    void expect(manager.getSessionPartId()).to.be.null;
-  });
-
-  it('ends the active part on pagehide even when the document is still visible and focused', () => {
-    // Chrome hard-nav: pagehide fires before any visibilitychange to
-    // 'hidden' and while the window still reports focus. Without an explicit
-    // end here, the Embrace processor's pending spans would never get
-    // pushed to the exporter before the page is gone.
-    manager.startSessionPartInternal('init');
-
-    visibilityDoc.visibilityState = 'visible';
-    visibilityDoc.hasFocus = () => true;
     target.dispatchEvent(
       new PageTransitionEvent('pagehide', { persisted: false }),
     );
-
-    expect(endReasons()).to.deep.equal(['web_hard_navigation']);
-    void expect(manager.getSessionPartId()).to.be.null;
-  });
-
-  it('is a no-op on pagehide when no part is active', () => {
-    firePageHide();
+    target.dispatchEvent(
+      new PageTransitionEvent('pagehide', { persisted: true }),
+    );
+    target.dispatchEvent(
+      new PageTransitionEvent('pageshow', { persisted: false }),
+    );
+    target.dispatchEvent(
+      new PageTransitionEvent('pageshow', { persisted: true }),
+    );
 
     expect(endReasons()).to.deep.equal([]);
-    expect(startReasons()).to.deep.equal([]);
+    expect(startReasons()).to.deep.equal(['init']);
+    void expect(manager.getSessionPartId()).to.not.be.null;
   });
 
   it('ends the active part with reason background when the window loses focus', () => {
@@ -306,49 +305,55 @@ describe('EmbraceUserSessionManager browser activity', () => {
     expect(startReasons()).to.deep.equal(['init']);
   });
 
-  it('starts a new part with reason foreground on pageshow (BFCache restore)', () => {
+  // The tests below assert the real-Chrome event sequences. Each helper
+  // dispatches the events in shipping-browser order with the correct
+  // intermediate state transitions, pinning down which listener "wins"
+  // in production.
+
+  it('ends the active part exactly once as web_background on a real active-tab unload sequence', () => {
     manager.startSessionPartInternal('init');
 
-    // BFCache restore path: pagehide with persisted=true freezes the tab and
-    // ends the prior part as web_background, then pageshow signals the
-    // canonical restore. No part is active when pageshow fires.
-    firePageHide(true);
+    fireActiveTabUnload();
+
+    expect(endReasons()).to.deep.equal(['web_background']);
+    expect(endSpy.callCount).to.equal(1);
     void expect(manager.getSessionPartId()).to.be.null;
+  });
 
-    // Document is restored visible on BFCache restore.
-    visibilityDoc.visibilityState = 'visible';
-    firePageShow();
+  it('ends on visibilitychange-to-hidden for an already-backgrounded tab unload', () => {
+    manager.startSessionPartInternal('init');
 
-    expect(startReasons()).to.deep.equal(['init', 'web_foreground']);
+    fireAlreadyHiddenTabUnload();
+
+    expect(endReasons()).to.deep.equal(['web_background']);
+    expect(endSpy.callCount).to.equal(1);
+    void expect(manager.getSessionPartId()).to.be.null;
+  });
+
+  it('starts the new part exactly once as web_foreground on a real BFCache restore sequence', () => {
+    manager.startSessionPartInternal('init');
+    fireAlreadyHiddenTabUnload();
+    startSpy.resetHistory();
+    endSpy.resetHistory();
+
+    fireBfcacheRestore();
+
+    expect(startReasons()).to.deep.equal(['web_foreground']);
+    expect(startSpy.callCount).to.equal(1);
     void expect(manager.getSessionPartId()).to.not.be.null;
   });
 
-  it('does not start a part on pageshow (BFCache restore) when the tab is disengaged at restore', () => {
+  it('nets to one end and one start across a full active-tab unload then BFCache restore round-trip', () => {
     manager.startSessionPartInternal('init');
 
-    // Tab freezes while disengaged: pagehide with persisted=true ends the
-    // prior part, then by the time pageshow fires, the document has restored
-    // hidden (the user restored a backgrounded tab without bringing it to
-    // focus).
-    firePageHide(true);
-    visibilityDoc.visibilityState = 'hidden';
-    firePageShow();
+    fireActiveTabUnload();
+    fireBfcacheRestore();
 
-    // No new part. Only 'init' is in the start log.
-    expect(startReasons()).to.deep.equal(['init']);
-    void expect(manager.getSessionPartId()).to.be.null;
-  });
-
-  it('swallows errors thrown by endSessionPartInternal during pagehide', () => {
-    manager.startSessionPartInternal('init');
-
-    // The pagehide handler wraps endSessionPartInternal in try/catch because
-    // a throw at unload would skip the keepalive flush. Stub the dependency
-    // to throw and assert the handler does not propagate.
-    endSpy.restore();
-    sinon.stub(manager, 'endSessionPartInternal').throws(new Error('boom'));
-
-    expect(() => firePageHide()).to.not.throw();
+    expect(endReasons()).to.deep.equal(['web_background']);
+    expect(startReasons()).to.deep.equal(['init', 'web_foreground']);
+    expect(endSpy.callCount).to.equal(1);
+    expect(startSpy.callCount).to.equal(2);
+    void expect(manager.getSessionPartId()).to.not.be.null;
   });
 
   it('re-arms the part-inactivity timer when an engagement event fires while already engaged and active', () => {
@@ -390,8 +395,8 @@ describe('EmbraceUserSessionManager browser activity', () => {
     manager.startSessionPartInternal('init');
 
     expect(target.listenerCount('keydown')).to.equal(1);
-    expect(target.listenerCount('pagehide')).to.equal(1);
-    expect(target.listenerCount('pageshow')).to.equal(1);
+    expect(target.listenerCount('focus')).to.equal(1);
+    expect(target.listenerCount('blur')).to.equal(1);
 
     manager._shutdown();
 
@@ -399,8 +404,8 @@ describe('EmbraceUserSessionManager browser activity', () => {
     expect(target.listenerCount('mousedown')).to.equal(0);
     expect(target.listenerCount('mousemove')).to.equal(0);
     expect(target.listenerCount('scroll')).to.equal(0);
-    expect(target.listenerCount('pagehide')).to.equal(0);
-    expect(target.listenerCount('pageshow')).to.equal(0);
+    expect(target.listenerCount('focus')).to.equal(0);
+    expect(target.listenerCount('blur')).to.equal(0);
 
     // visibilitychange listens on `visibilityDoc`, not `target`. Verify the
     // listener was unsubscribed by dispatching hidden and asserting no end.

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
@@ -253,11 +253,6 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       visibilityState: 'visible',
       hasFocus: false,
     },
-    {
-      name: 'prerender with focus',
-      visibilityState: 'prerender' as DocumentVisibilityState,
-      hasFocus: true,
-    },
   ];
 
   for (const { name, visibilityState, hasFocus } of disengagedCases) {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
@@ -239,45 +239,47 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     );
   });
 
-  it('should skip starting a session part when the document is hidden', () => {
-    const visibilityDoc: VisibilityStateDocument = {
-      visibilityState: 'hidden',
-      hasFocus: () => false,
-    };
-    const localManager = new EmbraceUserSessionManager({
-      visibilityDoc,
-      limitManager,
-      perf,
-      storage,
-    });
-    localManager.startSessionPartInternal('init');
-    void expect(localManager.getSessionPartId()).to.be.null;
-    void expect(localManager.getSessionPartSpan()).to.be.null;
-
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(0);
-  });
-
-  it('should skip starting a session part when the document is visible but unfocused', () => {
-    // Multi-monitor / DevTools-undocked case: tab is on-screen but another
-    // window has focus. Engagement gate must close on `!hasFocus()` alone.
-    const visibilityDoc: VisibilityStateDocument = {
+  // Engagement gate is visibilityState === 'visible' && hasFocus(). Any
+  // other combination must block startSessionPartInternal. Visible+hasFocus
+  // is the happy path tested above.
+  const disengagedCases: Array<{
+    name: string;
+    visibilityState: DocumentVisibilityState;
+    hasFocus: boolean;
+  }> = [
+    { name: 'hidden', visibilityState: 'hidden', hasFocus: false },
+    {
+      name: 'visible but unfocused',
       visibilityState: 'visible',
-      hasFocus: () => false,
-    };
-    const localManager = new EmbraceUserSessionManager({
-      visibilityDoc,
-      limitManager,
-      perf,
-      storage,
-    });
-    localManager.startSessionPartInternal('init');
-    void expect(localManager.getSessionPartId()).to.be.null;
-    void expect(localManager.getSessionPartSpan()).to.be.null;
+      hasFocus: false,
+    },
+    {
+      name: 'prerender with focus',
+      visibilityState: 'prerender' as DocumentVisibilityState,
+      hasFocus: true,
+    },
+  ];
 
-    const finishedSpans = memoryExporter.getFinishedSpans();
-    expect(finishedSpans).to.have.lengthOf(0);
-  });
+  for (const { name, visibilityState, hasFocus } of disengagedCases) {
+    it(`should skip starting a session part when the document is ${name}`, () => {
+      const visibilityDoc: VisibilityStateDocument = {
+        visibilityState,
+        hasFocus: () => hasFocus,
+      };
+      const localManager = new EmbraceUserSessionManager({
+        visibilityDoc,
+        limitManager,
+        perf,
+        storage,
+      });
+      localManager.startSessionPartInternal('init');
+      void expect(localManager.getSessionPartId()).to.be.null;
+      void expect(localManager.getSessionPartSpan()).to.be.null;
+
+      const finishedSpans = memoryExporter.getFinishedSpans();
+      expect(finishedSpans).to.have.lengthOf(0);
+    });
+  }
 
   it('should call the session start listener when starting a session', () => {
     const listener = sinon.stub();

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -384,9 +384,8 @@ describe('EmbraceUserSessionManager', () => {
 
   it('should not resurrect cleared state on a part-end-driven persist', () => {
     // If a user wipes site data (or the browser evicts it) while a part
-    // is active, the visibility-change pagehide flow used to re-persist
-    // the in-memory state and silently restore everything. Honor the
-    // clear instead.
+    // is active, an end-driven persist could re-write the in-memory
+    // state and silently restore everything. Honor the clear instead.
     const manager = createManager();
     manager.startSessionPartInternal('init');
     expect(inMemoryStorage.getItem('embrace_user_session_state')).to.not.be

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -782,16 +782,12 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     this._handleEngagementTransition('focus');
   };
 
-  // Window focus lost (alt-tab away, clicked into DevTools or another window).
-  // hasFocus is now false; engagement transition ends the active part.
-  //
-  // pagehide and pageshow are intentionally not listened to. In shipping
-  // engines, blur fires first on active-tab unload, and the earlier
-  // visibilitychange-to-hidden already ended the part for backgrounded-tab
-  // unload. pagehide always short-circuits. On BFCache restore, focus and
-  // visibilitychange-to-visible fire before pageshow, so pageshow finds
-  // an already-active part. Initial-load part-start is driven directly by
-  // initSDK via the 'init' SessionPartStartReason.
+  // Window focus lost (alt-tab, DevTools, another window). Engagement
+  // transition ends the active part as web_background. pagehide/pageshow
+  // are not listened to: blur or visibilitychange-to-hidden end the part
+  // first (see README "Unload and BFCache handling" for the verified
+  // cross-engine ordering). The part-end doubles as the unload flush via
+  // EmbraceSessionPartBatchedSpanProcessor.onEnd's synchronous keepalive export.
   // https://developer.chrome.com/docs/web-platform/page-lifecycle-api
   private readonly _onBlur = (): void => {
     this._handleEngagementTransition('blur');

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -88,8 +88,8 @@ import {
 
 /**
  * Parts are engagement-gated (visible AND focused), so only one part can
- * be active at a time. That mutex lets us treat storage as a
- * plain shared row read on engagement and written on changes.
+ * be active at a time. Engagement exclusivity lets us treat storage as
+ * a plain shared row read on engagement and written on changes.
  */
 export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   private _state: UserSessionState | null = null;
@@ -105,8 +105,9 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   private _hasStoredState = false;
 
   private _activeSessionPartId: string | null = null;
-  // Snapshotted at part start so a concurrent bump in another tab doesn't
-  // shift this part's value before its span ends.
+  // Held for the part's lifetime so getUserSessionAttributes() reads
+  // during the part return its starting value, even if another tab bumps
+  // the shared counter while this tab is mid-disengagement.
   private _currentSessionPartNumber: number | null = null;
   private _sessionPartSpan: ExtendedSpan | null = null;
   private _activeSessionPartCounts: Record<string, number> | null = null;
@@ -201,8 +202,6 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
       onVisibilityChange: this._onVisibilityChange,
       onFocus: this._onFocus,
       onBlur: this._onBlur,
-      onPageShow: this._onPageShow,
-      onPageHide: this._onPageHide,
     });
     // Eager state init so getUserSessionId() returns a real id before the
     // first part starts, and so other tabs see the row when we create a
@@ -751,8 +750,6 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
       onVisibilityChange: this._onVisibilityChange,
       onFocus: this._onFocus,
       onBlur: this._onBlur,
-      onPageShow: this._onPageShow,
-      onPageHide: this._onPageHide,
     });
     this._clearSessionPartInactivityTimer();
     this._clearMaxDurationTimer();
@@ -787,43 +784,18 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
 
   // Window focus lost (alt-tab away, clicked into DevTools or another window).
   // hasFocus is now false; engagement transition ends the active part.
+  //
+  // pagehide and pageshow are intentionally not listened to. Per the HTML
+  // spec's "unload a document" algorithm (§7.5.9), pagehide fires before
+  // visibilitychange-to-hidden in the same task, but in shipping engines
+  // blur fires first on active-tab unload and the earlier
+  // visibilitychange-to-hidden already ended the part for backgrounded-tab
+  // unload; pagehide always short-circuits. On BFCache restore, focus and
+  // visibilitychange-to-visible fire before pageshow, so pageshow finds
+  // an already-active part. Initial-load part-start is driven directly by
+  // initSDK via the 'init' SessionPartStartReason.
   private readonly _onBlur = (): void => {
     this._handleEngagementTransition('blur');
-  };
-
-  // Initial page load OR BFCache restore. event.persisted only affects the
-  // debug source string; routing is via _handleEngagementTransition, which
-  // keys off engagement state and whether a part is currently active.
-  private readonly _onPageShow = (event: PageTransitionEvent): void => {
-    this._handleEngagementTransition(
-      event.persisted ? 'pageshow-bfcache' : 'pageshow-initial',
-    );
-  };
-
-  // Navigation away (hard nav, tab close) OR BFCache freeze. Both signal the
-  // page is about to stop running, so we always end the active part. Ending
-  // the part flushes its span (and the spans batched against it in
-  // EmbraceSessionPartBatchedSpanProcessor) through the export pipeline while
-  // the page can still issue a keepalive fetch. On BFCache restore, pageshow
-  // will start a fresh part.
-  private readonly _onPageHide = (event: PageTransitionEvent): void => {
-    try {
-      if (this._activeSessionPartId === null) {
-        return;
-      }
-      const reason: SessionPartEndReason = event.persisted
-        ? 'web_background'
-        : 'web_hard_navigation';
-      this._diag.debug(
-        `page hiding (persisted=${event.persisted}); ending current part as ${reason}`,
-      );
-      this.endSessionPartInternal(reason);
-    } catch (e) {
-      this._diag.error(
-        `Error ending session part on pagehide (persisted=${event.persisted})`,
-        e,
-      );
-    }
   };
 
   private _handleEngagementTransition(source: string): void {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -785,15 +785,14 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   // Window focus lost (alt-tab away, clicked into DevTools or another window).
   // hasFocus is now false; engagement transition ends the active part.
   //
-  // pagehide and pageshow are intentionally not listened to. Per the HTML
-  // spec's "unload a document" algorithm (§7.5.9), pagehide fires before
-  // visibilitychange-to-hidden in the same task, but in shipping engines
-  // blur fires first on active-tab unload and the earlier
+  // pagehide and pageshow are intentionally not listened to. In shipping
+  // engines, blur fires first on active-tab unload, and the earlier
   // visibilitychange-to-hidden already ended the part for backgrounded-tab
-  // unload; pagehide always short-circuits. On BFCache restore, focus and
+  // unload. pagehide always short-circuits. On BFCache restore, focus and
   // visibilitychange-to-visible fire before pageshow, so pageshow finds
   // an already-active part. Initial-load part-start is driven directly by
   // initSDK via the 'init' SessionPartStartReason.
+  // https://developer.chrome.com/docs/web-platform/page-lifecycle-api
   private readonly _onBlur = (): void => {
     this._handleEngagementTransition('blur');
   };

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -293,22 +293,45 @@ Several specific edge cases are handled:
 ## Unload and BFCache handling
 
 There is no BFCache-specific code in the manager and no `pagehide`/`pageshow`
-listener. Behavior is absorbed by the engagement-transition events because, per
-the HTML "unload a document" algorithm and the empirically verified ordering in
-shipping Chrome, Gecko, and WebKit:
+listener. Behavior is absorbed by the engagement-transition events the manager
+already listens to (`blur`, `focus`, `visibilitychange`), per the HTML
+[unload a document][unload-spec] algorithm and the event ordering observed in
+the browsers below:
 
-- **Active-tab unload** (hard nav OR BFCache freeze). `blur` fires first while
-  `visibilityState` is still `'visible'`, ending the part as `web_background`.
-  `pagehide` and `visibilitychange` to hidden follow but find no active part.
+- **Active-tab unload** (hard nav OR BFCache freeze). On a focus-shifting nav
+  (address-bar typing, omnibox suggestion), `blur` fires first while
+  `visibilityState` is still `'visible'` and ends the part as `web_background`.
+  On a programmatic `location.href` nav, no `blur` fires; instead `pagehide`
+  and `visibilitychange` to hidden fire in the same task at navigation commit,
+  and the `visibilitychange` listener ends the part as `web_background`. In
+  both cases the part is ended before any `pagehide` handler could run.
 - **Backgrounded-tab unload**. `visibilitychange` to hidden already fired
   earlier (when the user switched away), ending the part as `web_background`
   at that moment. The later `pagehide` is on an already-ended part.
-- **BFCache restore**. `focus` fires first, then `visibilitychange` to
-  `'visible'`. The combined visible+focused transition starts a new part as
-  `web_foreground`. `pageshow` fires last and would be redundant.
+- **BFCache restore**. Per the spec, `focus` and `visibilitychange` to
+  `'visible'` fire before `pageshow`. The combined visible+focused transition
+  starts a new part as `web_foreground`; `pageshow` would be redundant. This
+  path is spec-derived rather than empirically verified here because Playwright
+  suppresses BFCache (`pageshow.persisted` is always `false` on `goBack()`).
 
 The in-memory `_state` survives the freeze-restore cycle because BFCache
 preserves the JS heap.
+
+### Verified event ordering
+
+Verified 2026-05 on macOS under Chromium 148, Firefox 150, and WebKit 26.4.
+On a plain `location.href` hard nav, all three engines fire `beforeunload`,
+then `pagehide` (with `visibilityState='visible'`, `hasFocus=true`,
+`persisted=false`), then `visibilitychange` to `hidden`, all within the same
+task. `pagehide` and `visibilitychange` share a `performance.now()` timestamp,
+with `pagehide` ordered first per the HTML spec's unload steps.
+
+No `blur` fires in any engine for the programmatic `location.href` case.
+`blur` is observed on the active-tab path only when the navigation itself
+shifts focus out of the document (URL bar typing, alt-tab away, click into
+another window).
+
+[unload-spec]: https://html.spec.whatwg.org/multipage/document-lifecycle.html#unload-a-document
 
 ## Attributes
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -91,7 +91,7 @@ engagement condition holds, the call is a debug-level no-op.
 | Value | Trigger |
 | --- | --- |
 | `init` | SDK init flow on page load. |
-| `web_foreground` | `visibilitychange` to visible, `focus`, or `pageshow` while no part is active and the tab is engaged. Also covers the BFCache restore path. |
+| `web_foreground` | `visibilitychange` to visible or `focus` while no part is active and the tab is engaged. Also covers the BFCache restore path. |
 | `web_activity` | `keydown`, `mousedown`, `mousemove`, or `scroll` while no part is active and the tab is engaged. Subject to the 30 second activity throttle. |
 | `user_session_rollover` | Called synchronously by `_terminateUserSession` immediately after a user session ends. |
 
@@ -101,8 +101,7 @@ engagement condition holds, the call is a debug-level no-op.
 
 | Value | Trigger |
 | --- | --- |
-| `web_background` | `visibilitychange` to hidden, `blur`, or `pagehide` with `persisted=true` (BFCache freeze). |
-| `web_hard_navigation` | `pagehide` with `persisted=false` (hard navigation away, tab close, or reload). |
+| `web_background` | `visibilitychange` to hidden or `blur`. Also covers hard-nav unload and BFCache freeze, since blur or an earlier `visibilitychange` to hidden ends the part before `pagehide` fires. |
 | `inactivity` | The 30 minute part-inactivity timer fires without any user input event resetting it. |
 | `user_session_ended` | `_terminateUserSession` ending the active part, fired on manual `endUserSession()` or max-duration expiry. |
 
@@ -291,18 +290,22 @@ Several specific edge cases are handled:
   the stale timer fires first, `_terminateUserSession('max_duration_reached')`
   runs benignly against the already-cleared storage row.
 
-## BFCache handling
+## Unload and BFCache handling
 
-There is no BFCache-specific code in the manager. Behavior is absorbed by the
-existing engagement events:
+There is no BFCache-specific code in the manager and no `pagehide`/`pageshow`
+listener. Behavior is absorbed by the engagement-transition events because, per
+the HTML "unload a document" algorithm and the empirically verified ordering in
+shipping Chrome, Gecko, and WebKit:
 
-- **Freeze** (entering BFCache). `pagehide` fires with `persisted=true`.
-  `EmbraceUserSessionManager._onPageHide` ends the active part with reason
-  `web_background`. A `pagehide` with `persisted=false` is a hard navigation,
-  not a BFCache freeze, and ends the part with `web_hard_navigation` instead.
-- **Restore** (leaving BFCache). `pageshow` fires. If the document is visible
-  and focused and no part is active, a new part starts with reason
-  `web_foreground`. If the document restores hidden, no part starts.
+- **Active-tab unload** (hard nav OR BFCache freeze). `blur` fires first while
+  `visibilityState` is still `'visible'`, ending the part as `web_background`.
+  `pagehide` and `visibilitychange` to hidden follow but find no active part.
+- **Backgrounded-tab unload**. `visibilitychange` to hidden already fired
+  earlier (when the user switched away), ending the part as `web_background`
+  at that moment. The later `pagehide` is on an already-ended part.
+- **BFCache restore**. `focus` fires first, then `visibilitychange` to
+  `'visible'`. The combined visible+focused transition starts a new part as
+  `web_foreground`. `pageshow` fires last and would be redundant.
 
 The in-memory `_state` survives the freeze-restore cycle because BFCache
 preserves the JS heap.
@@ -365,8 +368,8 @@ Why it happens:
 2. `initSDK` calls `startSessionPartInternal('init')` next, but the call
    no-ops when `!document.hasFocus()` or `visibilityState === 'background'`
    (parts are foreground-only by design).
-3. Until the next engagement event fires (`pageshow`/`focus`/
-   `visibilitychange`), `_activeSessionPartId === null`. Logs that pass
+3. Until the next engagement event fires (`focus`/`visibilitychange`),
+   `_activeSessionPartId === null`. Logs that pass
    through `UserSessionLogRecordProcessor` in that window end up
    with `emb.session_part_id: ''`. Spans are not affected; only the
    session-part span itself carries IDs, and other spans are correlated

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/utils/activity.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/utils/activity.ts
@@ -11,8 +11,6 @@ export interface ActivityListenersArgs {
   onVisibilityChange: (event: Event) => void;
   onFocus: (event: Event) => void;
   onBlur: (event: Event) => void;
-  onPageShow: (event: PageTransitionEvent) => void;
-  onPageHide: (event: PageTransitionEvent) => void;
 }
 
 export const addActivityListeners = ({
@@ -23,8 +21,6 @@ export const addActivityListeners = ({
   onVisibilityChange,
   onFocus,
   onBlur,
-  onPageShow,
-  onPageHide,
 }: ActivityListenersArgs): void => {
   for (const event of activityEvents) {
     target.addEventListener(event, onActivity);
@@ -34,10 +30,6 @@ export const addActivityListeners = ({
   // Window focus changes (alt-tab, click into DevTools, multi-monitor).
   target.addEventListener('focus', onFocus);
   target.addEventListener('blur', onBlur);
-  // Initial page load AND BFCache restore. Distinguished by event.persisted.
-  target.addEventListener('pageshow', onPageShow as EventListener);
-  // Navigation away AND BFCache freeze. Distinguished by event.persisted.
-  target.addEventListener('pagehide', onPageHide as EventListener);
 };
 
 export const removeActivityListeners = ({
@@ -48,8 +40,6 @@ export const removeActivityListeners = ({
   onVisibilityChange,
   onFocus,
   onBlur,
-  onPageShow,
-  onPageHide,
 }: ActivityListenersArgs): void => {
   for (const event of activityEvents) {
     target.removeEventListener(event, onActivity);
@@ -57,6 +47,4 @@ export const removeActivityListeners = ({
   visibilityDoc.removeEventListener?.('visibilitychange', onVisibilityChange);
   target.removeEventListener('focus', onFocus);
   target.removeEventListener('blur', onBlur);
-  target.removeEventListener('pageshow', onPageShow as EventListener);
-  target.removeEventListener('pagehide', onPageHide as EventListener);
 };

--- a/packages/web-sdk/src/utils/getVisibilityState.test.ts
+++ b/packages/web-sdk/src/utils/getVisibilityState.test.ts
@@ -23,15 +23,6 @@ describe('getVisibilityState', () => {
     ).to.equal('background');
   });
 
-  it('should report background for transitional states like prerender', () => {
-    expect(
-      getVisibilityState({
-        visibilityState: 'prerender' as DocumentVisibilityState,
-        hasFocus: () => false,
-      }),
-    ).to.equal('background');
-  });
-
   it('should report background when document visibility cannot be determined', () => {
     expect(getVisibilityState({} as VisibilityStateDocument)).to.equal(
       'background',

--- a/packages/web-sdk/src/utils/getVisibilityState.test.ts
+++ b/packages/web-sdk/src/utils/getVisibilityState.test.ts
@@ -23,9 +23,18 @@ describe('getVisibilityState', () => {
     ).to.equal('background');
   });
 
-  it('should report foreground when document visibility cannot be determined', () => {
+  it('should report background for transitional states like prerender', () => {
+    expect(
+      getVisibilityState({
+        visibilityState: 'prerender' as DocumentVisibilityState,
+        hasFocus: () => false,
+      }),
+    ).to.equal('background');
+  });
+
+  it('should report background when document visibility cannot be determined', () => {
     expect(getVisibilityState({} as VisibilityStateDocument)).to.equal(
-      'foreground',
+      'background',
     );
   });
 });

--- a/packages/web-sdk/src/utils/getVisibilityState.ts
+++ b/packages/web-sdk/src/utils/getVisibilityState.ts
@@ -1,7 +1,11 @@
 import type { VisibilityStateDocument } from '../common/index.ts';
 import { EMB_STATES } from '../constants/index.ts';
 
+// emb.state describes whether the user is actively viewing the page, not
+// whether visibilityState is literally 'hidden'. Non-visible states
+// (prerender, unloaded, hidden) are not "actively viewing", so they all
+// map to Background.
 export const getVisibilityState = (visibilityDoc: VisibilityStateDocument) =>
-  visibilityDoc.visibilityState === 'hidden'
-    ? EMB_STATES.Background
-    : EMB_STATES.Foreground;
+  visibilityDoc.visibilityState === 'visible'
+    ? EMB_STATES.Foreground
+    : EMB_STATES.Background;

--- a/packages/web-sdk/src/utils/getVisibilityState.ts
+++ b/packages/web-sdk/src/utils/getVisibilityState.ts
@@ -1,10 +1,9 @@
 import type { VisibilityStateDocument } from '../common/index.ts';
 import { EMB_STATES } from '../constants/index.ts';
 
-// emb.state describes whether the user is actively viewing the page, not
-// whether visibilityState is literally 'hidden'. Non-visible states
-// (prerender, unloaded, hidden) are not "actively viewing", so they all
-// map to Background.
+// emb.state describes whether the user is actively viewing the page.
+// Anything other than 'visible' (including the fallback when
+// visibilityState is missing) maps to Background.
 export const getVisibilityState = (visibilityDoc: VisibilityStateDocument) =>
   visibilityDoc.visibilityState === 'visible'
     ? EMB_STATES.Foreground


### PR DESCRIPTION
## What problem is this solving?
The `pagehide` and `pageshow` listeners on `EmbraceUserSessionManager` were dead code in shipping engines. Per the HTML "unload a document" algorithm and verified empirical timings in Chrome, Gecko, and WebKit, `blur` (active-tab unload) or an earlier `visibilitychange`-to-`hidden` (backgrounded-tab unload) always ends the part before `pagehide` fires; on BFCache restore, `focus` and `visibilitychange`-to-`visible` fire before `pageshow`. The `web_hard_navigation` end reason was therefore unreachable in production.

Independent of that, `getVisibilityState` was treating non-visible states (`prerender`, `unloaded`, missing) as `Foreground`, which is wrong for the `emb.state` "actively viewing" contract.

## Short description of changes
- Remove `_onPageHide`/`_onPageShow` handlers and their listener registrations.
- Drop `pagehide`/`pageshow` from `addActivityListeners`/`removeActivityListeners`.
- Drop `web_hard_navigation` from the `SessionPartEndReason` union. All disengagement classifies as `web_background`.
- Invert `getVisibilityState` so anything other than `'visible'` maps to `Background`, fixing `emb.state` stamping for `prerender`/`unloaded`/missing-value cases and tightening the part-start engagement gate.
- Update tests and README to reflect the engagement-transition-only model.

## Testing
- `npm run check` (tsc + eslint, repo root) passes.
- `npm test` from `packages/web-sdk/`: 789 passed, 1 skipped.
- `npm run lint:fix` (repo root) reports no changes.
- No integration golden changes required (no golden pinned `web_hard_navigation`).