### PR TITLE
test: simplify waitForRequest to await each fresh response

### DIFF
--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -114,18 +114,15 @@ const IGNORED_ATTRIBUTES_LIST = [
 
 const testWithMockApi = base.extend<TestWithMockApi>({
   waitForRequest: [
-    async ({ page, requests }, use) => {
+    async ({ page }, use) => {
       await use(async (url) => {
-        await Promise.any([
-          // Wait for the request to be made or
-          page.waitForResponse((request) => request.url().match(url) !== null),
-          // Check if the request has already been made
-          new Promise((resolve) => {
-            if (requests.length > 0 && requests.find((r) => r.url.match(url))) {
-              resolve(undefined);
-            }
-          }),
-        ]);
+        // Wait for the next matching response. The route handler records the
+        // request before responding, so it is present in `requests` once this
+        // resolves. Each call waits for a fresh response, so consecutive waits
+        // don't short-circuit on a request recorded by an earlier call.
+        await page.waitForResponse(
+          (response) => response.url().match(url) !== null,
+        );
       });
     },
     { scope: 'test' },

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -28,7 +28,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const GOLDEN_DIR = path.resolve(__dirname, '../tests/__golden__');
 const INTENDED_CHANGE_MESSAGE = `\n\nIf you intended to change the golden files, run test:integration:update-golden instead.`;
-const shouldUpdateGolden = process.env.UPDATE_GOLDEN === '1';
+const shouldUpdateGolden = process.env['UPDATE_GOLDEN'] === '1';
 const DEFAULT_REMOTE_CONFIG: Record<string, unknown> = {
   threshold: 100, // Default to 100% for tests
 };
@@ -116,10 +116,6 @@ const testWithMockApi = base.extend<TestWithMockApi>({
   waitForRequest: [
     async ({ page }, use) => {
       await use(async (url) => {
-        // Wait for the next matching response. The route handler records the
-        // request before responding, so it is present in `requests` once this
-        // resolves. Each call waits for a fresh response, so consecutive waits
-        // don't short-circuit on a request recorded by an earlier call.
         await page.waitForResponse(
           (response) => response.url().match(url) !== null,
         );
@@ -128,9 +124,16 @@ const testWithMockApi = base.extend<TestWithMockApi>({
     { scope: 'test' },
   ],
   waitForOTelRequest: [
-    async ({ waitForRequest }, use) => {
+    // `requests` only holds OTel requests, so wait on the recorded buffer
+    // rather than the network event. A per-test cursor resolves on a new
+    // request without short-circuiting on one an earlier call consumed.
+    async ({ requests }, use, testInfo) => {
+      let consumed = 0;
       await use(async () => {
-        await waitForRequest(OTEL_REQUEST_REGEX);
+        await expect
+          .poll(() => requests.length, { timeout: testInfo.timeout })
+          .toBeGreaterThan(consumed);
+        consumed += 1;
       });
     },
     { scope: 'test' },
@@ -155,9 +158,8 @@ const testWithMockApi = base.extend<TestWithMockApi>({
           return;
         }
 
-        // Decompress and record synchronously before route.continue() so the
-        // entry is visible in `requests` by the time waitForOTelRequest resolves
-        // on the response.
+        // Record synchronously before route.continue() so the entry is in
+        // `requests` by the time waitForOTelRequest sees it.
         try {
           const json = zlib.gunzipSync(buffer).toString('utf-8');
           requests.push({
@@ -595,12 +597,12 @@ const expect = testWithMockApi.expect.extend({
     const expectedString = fs.readFileSync(filePath, 'utf-8');
 
     try {
-      const expectedResources = received.data.resourceSpans
+      const expectedResources = received.data['resourceSpans']
         ? (JSON.parse(expectedString) as IExportTraceServiceRequest)
             .resourceSpans
         : (JSON.parse(expectedString) as IExportLogsServiceRequest)
             .resourceLogs;
-      const receivedResources = received.data.resourceSpans
+      const receivedResources = received.data['resourceSpans']
         ? (received.data as IExportTraceServiceRequest).resourceSpans
         : (received.data as IExportLogsServiceRequest).resourceLogs;
 


### PR DESCRIPTION
## What problem is this solving?
`waitForOTelRequest` was racy and failed intermittently in CI (passing locally). Two opposite races:

1. The original `Promise.any` short-circuited on *any* already-recorded request, so a second `waitForOTelRequest()` could resolve instantly and assert a request count before the next request arrived.
2. `page.waitForResponse` only observes responses that fire *after* the listener registers. Since the helper is called sequentially after the triggering action, a fast CI response lands in the gap and is missed, hanging the wait until timeout.

## Short description of changes
- Rewrite `waitForOTelRequest` to wait on the recorded `requests` buffer (the route handler records synchronously before `route.continue()`) instead of the network event.
- Use a per-test cursor (`consumed`) so each call waits for a genuinely new request and never short-circuits on one a previous call already awaited.
- Poll with `expect.poll({ timeout: testInfo.timeout })` so the timeout tracks the resolved Playwright config (10s default, 30s under the prebuilt per-project overrides).
- `waitForRemoteConfigRequest` stays on `waitForResponse`: remote-config responses aren't recorded in `requests`, and it's already called via `Promise.all([page.goto(...), ...])`, so its listener registers before navigation.

## Testing
- `npm run test:integration` (passes locally)