### PR TITLE
test: close silent passes and fix orientation in mock-api matchers

### DIFF
--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -114,18 +114,15 @@ const IGNORED_ATTRIBUTES_LIST = [
 
 const testWithMockApi = base.extend<TestWithMockApi>({
   waitForRequest: [
-    async ({ page, requests }, use) => {
+    async ({ page }, use) => {
       await use(async (url) => {
-        await Promise.any([
-          // Wait for the request to be made or
-          page.waitForResponse((request) => request.url().match(url) !== null),
-          // Check if the request has already been made
-          new Promise((resolve) => {
-            if (requests.length > 0 && requests.find((r) => r.url.match(url))) {
-              resolve(undefined);
-            }
-          }),
-        ]);
+        // Wait for the next matching response. The route handler records the
+        // request before responding, so it is present in `requests` once this
+        // resolves. Each call waits for a fresh response, so consecutive waits
+        // don't short-circuit on a request recorded by an earlier call.
+        await page.waitForResponse(
+          (response) => response.url().match(url) !== null,
+        );
       });
     },
     { scope: 'test' },

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -28,7 +28,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const GOLDEN_DIR = path.resolve(__dirname, '../tests/__golden__');
 const INTENDED_CHANGE_MESSAGE = `\n\nIf you intended to change the golden files, run test:integration:update-golden instead.`;
-const shouldUpdateGolden = process.env.UPDATE_GOLDEN === '1';
+const shouldUpdateGolden = process.env['UPDATE_GOLDEN'] === '1';
 const DEFAULT_REMOTE_CONFIG: Record<string, unknown> = {
   threshold: 100, // Default to 100% for tests
 };
@@ -116,10 +116,6 @@ const testWithMockApi = base.extend<TestWithMockApi>({
   waitForRequest: [
     async ({ page }, use) => {
       await use(async (url) => {
-        // Wait for the next matching response. The route handler records the
-        // request before responding, so it is present in `requests` once this
-        // resolves. Each call waits for a fresh response, so consecutive waits
-        // don't short-circuit on a request recorded by an earlier call.
         await page.waitForResponse(
           (response) => response.url().match(url) !== null,
         );
@@ -128,9 +124,16 @@ const testWithMockApi = base.extend<TestWithMockApi>({
     { scope: 'test' },
   ],
   waitForOTelRequest: [
-    async ({ waitForRequest }, use) => {
+    // `requests` only holds OTel requests, so wait on the recorded buffer
+    // rather than the network event. A per-test cursor resolves on a new
+    // request without short-circuiting on one an earlier call consumed.
+    async ({ requests }, use, testInfo) => {
+      let consumed = 0;
       await use(async () => {
-        await waitForRequest(OTEL_REQUEST_REGEX);
+        await expect
+          .poll(() => requests.length, { timeout: testInfo.timeout })
+          .toBeGreaterThan(consumed);
+        consumed += 1;
       });
     },
     { scope: 'test' },
@@ -155,9 +158,8 @@ const testWithMockApi = base.extend<TestWithMockApi>({
           return;
         }
 
-        // Decompress and record synchronously before route.continue() so the
-        // entry is visible in `requests` by the time waitForOTelRequest resolves
-        // on the response.
+        // Record synchronously before route.continue() so the entry is in
+        // `requests` by the time waitForOTelRequest sees it.
         try {
           const json = zlib.gunzipSync(buffer).toString('utf-8');
           requests.push({
@@ -595,12 +597,12 @@ const expect = testWithMockApi.expect.extend({
     const expectedString = fs.readFileSync(filePath, 'utf-8');
 
     try {
-      const expectedResources = received.data.resourceSpans
+      const expectedResources = received.data['resourceSpans']
         ? (JSON.parse(expectedString) as IExportTraceServiceRequest)
             .resourceSpans
         : (JSON.parse(expectedString) as IExportLogsServiceRequest)
             .resourceLogs;
-      const receivedResources = received.data.resourceSpans
+      const receivedResources = received.data['resourceSpans']
         ? (received.data as IExportTraceServiceRequest).resourceSpans
         : (received.data as IExportLogsServiceRequest).resourceLogs;
 

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -269,9 +269,13 @@ const expect = testWithMockApi.expect.extend({
       };
     }
 
-    // Sort both arrays by key
-    const sortedReceived = received.sort((a, b) => a.key.localeCompare(b.key));
-    const sortedExpected = expected.sort((a, b) => a.key.localeCompare(b.key));
+    // Sort copies by key so we don't mutate the caller's arrays
+    const sortedReceived = [...received].sort((a, b) =>
+      a.key.localeCompare(b.key),
+    );
+    const sortedExpected = [...expected].sort((a, b) =>
+      a.key.localeCompare(b.key),
+    );
 
     // Compare each attribute
     for (const [index, receivedAttr] of sortedReceived.entries()) {
@@ -407,11 +411,11 @@ const expect = testWithMockApi.expect.extend({
       message: `Attributes mismatch for span ${received.name}`,
     });
 
-    const sortedReceivedEvents = received.events.sort((a, b) =>
+    const sortedReceivedEvents = [...(received.events ?? [])].sort((a, b) =>
       a.name.localeCompare(b.name),
     );
 
-    const sortedExpectedEvents = expected.events.sort((a, b) =>
+    const sortedExpectedEvents = [...(expected.events ?? [])].sort((a, b) =>
       a.name.localeCompare(b.name),
     );
 
@@ -457,6 +461,14 @@ const expect = testWithMockApi.expect.extend({
       return {
         pass: true,
         message: () => `Entities matched`,
+      };
+    }
+
+    if (!expected || !received) {
+      return {
+        pass: false,
+        message: () =>
+          `Expected entities to be ${expected ? 'present' : 'absent'}, but received was ${received ? 'present' : 'absent'}${INTENDED_CHANGE_MESSAGE}`,
       };
     }
 
@@ -519,10 +531,10 @@ const expect = testWithMockApi.expect.extend({
                   pass: false,
                   message: () =>
                     `Expected ${chalk.green(filteredExpected.length)} entities in scope ${resourceIndex.toString()}, but got ${chalk.red(filteredReceived.length)}${INTENDED_CHANGE_MESSAGE}\n${
-                      diff(filteredReceived, filteredExpected, {
+                      diff(filteredExpected, filteredReceived, {
                         expand: true,
-                        aAnnotation: 'Received',
-                        bAnnotation: 'Expected',
+                        aAnnotation: 'Expected',
+                        bAnnotation: 'Received',
                       }) || ''
                     }`,
                 };
@@ -552,6 +564,10 @@ const expect = testWithMockApi.expect.extend({
                     !isSpan(expectedEntity)
                   ) {
                     expect(receivedEntity).toMatchLog(expectedEntity);
+                  } else {
+                    throw new Error(
+                      `Entity type mismatch: received is ${isSpan(receivedEntity) ? 'a span' : 'a log'} but expected is ${isSpan(expectedEntity) ? 'a span' : 'a log'}`,
+                    );
                   }
                 } catch (e) {
                   const entityName = isSpan(receivedEntity)
@@ -606,7 +622,7 @@ const expect = testWithMockApi.expect.extend({
         ? (received.data as IExportTraceServiceRequest).resourceSpans
         : (received.data as IExportLogsServiceRequest).resourceLogs;
 
-      expect(expectedResources).toMatchOTelEntities(receivedResources);
+      expect(receivedResources).toMatchOTelEntities(expectedResources);
     } catch (e) {
       // If we are updating the golden file, and the comparison fails for any reason,
       // we will write the actual data to the golden file


### PR DESCRIPTION
## What problem is this solving?
The golden-comparison matchers in the integration test harness had several latent correctness and reporting issues. Most importantly, a few comparison paths could pass silently when they should fail, defeating the purpose of golden tests.

## Short description of changes
- `toMatchOTelEntities`: fail explicitly when exactly one of received/expected is `undefined` (previously fell through to `pass: true`).
- `toMatchOTelEntities`: fail on span-vs-log entity type mismatches instead of skipping the comparison silently.
- Fix the actual/expected orientation at the `toMatchOTelEntities` call site so every "Expected X, got Y" message (and the delegated span/log/resource matchers) reads in the correct direction; align the two `diff()` calls to use a consistent argument order and annotations.
- Stop mutating matcher inputs: sort spread copies in `toMatchAttributes` and `toMatchSpan`, and guard against a missing `events` array.

## Testing
- `npm run lint` and `npm run check` pass from the repo root.
- Integration test behavior is unchanged for passing runs; the changes only affect how mismatches are detected and reported.

Stacked on #1344 work (branch `overbalance/fix-integration-test-otel-request-race`).
