### PR TITLE
refactor(sessions): rename inactivity part-end reason to web_inactivity

### DIFF
--- a/packages/web-sdk/src/api-sessions/manager/types.ts
+++ b/packages/web-sdk/src/api-sessions/manager/types.ts
@@ -112,8 +112,8 @@ export type StartSessionOptions = {
 // `manual`, `inactivity`, `max_duration_reached`, `user_session_rollover`,
 // `user_session_ended`) are emitted unprefixed so the backend can correlate
 // them across platforms. Reasons that describe behaviour specific to the web
-// environment (`web_foreground`, `web_background`, `web_activity`) are stamped
-// with a `web_` prefix.
+// environment (`web_foreground`, `web_background`, `web_activity`,
+// `web_inactivity`) are stamped with a `web_` prefix.
 
 export type SessionPartStartReason =
   | 'init' // first part on SDK init (page load); covers the hard-nav load side
@@ -123,7 +123,7 @@ export type SessionPartStartReason =
 
 export type SessionPartEndReason =
   | 'web_background' // tab disengaged via visibilitychange (hidden) or blur. Also covers hard-nav unload and BFCache freeze (pagehide is not listened to)
-  | 'inactivity' // no keyboard/mouse/scroll input during the active part for the configured inactivity window; also ends the enclosing user session, with the part span end timestamp anchored to the last activity
+  | 'web_inactivity' // no keyboard/mouse/scroll input during the active part for the configured inactivity window; also ends the enclosing user session, with the part span end timestamp anchored to the last activity
   | 'user_session_ended'; // closed because the enclosing user session ended (manual endUserSession, max-duration); stamped on the span by the manager
 
 export type UserSessionEndReason =

--- a/packages/web-sdk/src/api-sessions/manager/types.ts
+++ b/packages/web-sdk/src/api-sessions/manager/types.ts
@@ -109,11 +109,16 @@ export type StartSessionOptions = {
 };
 
 // Reasons that describe SDK-agnostic, cross-platform concepts (`init`,
-// `manual`, `inactivity`, `max_duration_reached`, `user_session_rollover`,
-// `user_session_ended`) are emitted unprefixed so the backend can correlate
+// `manual`, `max_duration_reached`, `user_session_rollover`,
+// `user_session_ended`, and the user-session-level `inactivity` on
+// `UserSessionEndReason`) are emitted unprefixed so the backend can correlate
 // them across platforms. Reasons that describe behaviour specific to the web
 // environment (`web_foreground`, `web_background`, `web_activity`,
-// `web_inactivity`) are stamped with a `web_` prefix.
+// `web_inactivity`) are stamped with a `web_` prefix. The part-level
+// `web_inactivity` and the user-session-level `inactivity` are distinct: when
+// the part-inactivity timer fires it stamps `web_inactivity` as the part end
+// reason and `inactivity` as the enclosing user session's termination reason
+// on the same final part span.
 
 export type SessionPartStartReason =
   | 'init' // first part on SDK init (page load); covers the hard-nav load side

--- a/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
@@ -58,7 +58,7 @@ describe('ClicksInstrumentation', () => {
     testContainer.append(target);
 
     target.click();
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -84,7 +84,7 @@ describe('ClicksInstrumentation', () => {
     target.disabled = true;
     testContainer.append(target);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -102,7 +102,7 @@ describe('ClicksInstrumentation', () => {
     testContainer.append(target);
 
     target.click();
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -129,7 +129,7 @@ describe('ClicksInstrumentation', () => {
     testContainer.append(target);
 
     target.click();
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -163,7 +163,7 @@ describe('ClicksInstrumentation', () => {
     t2.click();
     t1.click();
     t2.click();
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -219,7 +219,7 @@ describe('ClicksInstrumentation', () => {
     t2.click();
     instrumentation.disable();
     t1.click();
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -250,7 +250,7 @@ describe('ClicksInstrumentation', () => {
     testContainer.append(t2);
 
     t2.click();
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     t1.click();
 
     const finishedSpans = memoryExporter.getFinishedSpans();
@@ -284,7 +284,7 @@ describe('ClicksInstrumentation', () => {
 
     target1.click();
     target2.click();
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -321,7 +321,7 @@ describe('ClicksInstrumentation', () => {
 
     target1.click();
     target2.click();
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);

--- a/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
@@ -65,7 +65,7 @@ describe('EmptyInstrumentation', () => {
     await new Promise((r) => setTimeout(r, 1));
 
     // The instrumentation shouldn't immediately emit the event
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     let finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -78,7 +78,7 @@ describe('EmptyInstrumentation', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     // Should now emit if the node is still empty after the timeout
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     sessionSpan = finishedSpans[0];
@@ -113,7 +113,7 @@ describe('EmptyInstrumentation', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     // Should not emit the event
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -145,7 +145,7 @@ describe('EmptyInstrumentation', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     // Should not emit the event
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -173,7 +173,7 @@ describe('EmptyInstrumentation', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     // Should not emit the event
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -198,7 +198,7 @@ describe('EmptyInstrumentation', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     // Should not emit the event
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
@@ -168,7 +168,7 @@ describe('LoafInstrumentation', () => {
       }),
     ]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const logs = memoryExporter.getFinishedLogRecords();
     const report = logs.find((l) => l.eventName === 'emb-loaf-report');
@@ -204,7 +204,7 @@ describe('LoafInstrumentation', () => {
       makeEntry({ startTime: 200, duration: 80, renderStart: 0 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -227,7 +227,7 @@ describe('LoafInstrumentation', () => {
       makeEntry({ startTime: 200, duration: 80, styleAndLayoutStart: 0 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -251,7 +251,7 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 30, firstUIEventTimestamp: 0 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -274,7 +274,7 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 30, firstUIEventTimestamp: 12345 }), // interaction-driven
     ]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -291,7 +291,7 @@ describe('LoafInstrumentation', () => {
     });
     instrumentation.setUserSessionManager(userSessionManager);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const logs = memoryExporter.getFinishedLogRecords();
     const reports = logs.filter((l) => l.eventName === 'emb-loaf-report');
@@ -332,7 +332,7 @@ describe('LoafInstrumentation', () => {
 
     // Re-create a session to trigger end
     userSessionManager.startSessionPartInternal('init');
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const reports = memoryExporter
       .getFinishedLogRecords()
@@ -357,7 +357,7 @@ describe('LoafInstrumentation', () => {
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([makeEntry({ duration: 100 })]);
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -381,7 +381,7 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 200 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -403,7 +403,7 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 201 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -427,7 +427,7 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 600 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -451,7 +451,7 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 601 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -472,7 +472,7 @@ describe('LoafInstrumentation', () => {
     instrumentation.enable();
 
     triggerEntries([makeEntry({ duration: 60 })]);
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const reports = memoryExporter
       .getFinishedLogRecords()
@@ -511,7 +511,7 @@ describe('LoafInstrumentation', () => {
     instrumentation.setUserSessionManager(userSessionManager2);
 
     triggerEntries([makeEntry({ duration: 90 })]);
-    userSessionManager2.endSessionPartInternal('inactivity');
+    userSessionManager2.endSessionPartInternal('web_inactivity');
 
     const reports = memoryExporter
       .getFinishedLogRecords()
@@ -543,7 +543,7 @@ describe('LoafInstrumentation', () => {
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([makeEntry({ duration: 100 })]);
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const firstReport = memoryExporter
       .getFinishedLogRecords()
@@ -555,7 +555,7 @@ describe('LoafInstrumentation', () => {
     userSessionManager.startSessionPartInternal('init');
 
     triggerEntries([makeEntry({ duration: 80 })]);
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const secondReport = memoryExporter
       .getFinishedLogRecords()
@@ -575,7 +575,7 @@ describe('LoafInstrumentation', () => {
 
     triggerEntries([makeEntry({ duration: 100 }), makeEntry({ duration: 80 })]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const firstReport = memoryExporter
       .getFinishedLogRecords()
@@ -592,7 +592,7 @@ describe('LoafInstrumentation', () => {
 
     triggerEntries([makeEntry({ duration: 60 }), makeEntry({ duration: 40 })]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const secondReport = memoryExporter
       .getFinishedLogRecords()
@@ -624,7 +624,7 @@ describe('LoafInstrumentation', () => {
       }),
     ]);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -674,7 +674,7 @@ describe('LoafInstrumentation', () => {
       throw new Error('emit failed');
     };
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     expect(diagLogger.getErrorLogs().length).to.be.greaterThan(0);
 
@@ -727,7 +727,7 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('inactivity');
+      userSessionManager.endSessionPartInternal('web_inactivity');
 
       const logs = memoryExporter.getFinishedLogRecords();
       const summary = logs.find((l) => l.eventName === 'emb-loaf-scripts');
@@ -775,7 +775,7 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('inactivity');
+      userSessionManager.endSessionPartInternal('web_inactivity');
 
       const summary = memoryExporter
         .getFinishedLogRecords()
@@ -804,7 +804,7 @@ describe('LoafInstrumentation', () => {
       ) as unknown as PerformanceLongAnimationFrameTiming['scripts'];
 
       triggerEntries([makeEntry({ scripts })]);
-      userSessionManager.endSessionPartInternal('inactivity');
+      userSessionManager.endSessionPartInternal('web_inactivity');
 
       const summary = memoryExporter
         .getFinishedLogRecords()
@@ -823,7 +823,7 @@ describe('LoafInstrumentation', () => {
 
       triggerEntries([makeEntry({ scripts: [] })]);
 
-      userSessionManager.endSessionPartInternal('inactivity');
+      userSessionManager.endSessionPartInternal('web_inactivity');
 
       const summaries = memoryExporter
         .getFinishedLogRecords()
@@ -849,7 +849,7 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('inactivity');
+      userSessionManager.endSessionPartInternal('web_inactivity');
       memoryExporter.reset();
 
       userSessionManager.startSessionPartInternal('init');
@@ -866,7 +866,7 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('inactivity');
+      userSessionManager.endSessionPartInternal('web_inactivity');
 
       const summary = memoryExporter
         .getFinishedLogRecords()
@@ -902,7 +902,7 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('inactivity');
+      userSessionManager.endSessionPartInternal('web_inactivity');
 
       const summary = memoryExporter
         .getFinishedLogRecords()
@@ -936,7 +936,7 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('inactivity');
+      userSessionManager.endSessionPartInternal('web_inactivity');
 
       const logs = memoryExporter.getFinishedLogRecords();
       const report = logs.find((l) => l.eventName === 'emb-loaf-report');
@@ -973,7 +973,7 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('inactivity');
+      userSessionManager.endSessionPartInternal('web_inactivity');
 
       const summary = memoryExporter
         .getFinishedLogRecords()

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
@@ -202,7 +202,7 @@ describe('NavigationInstrumentation', () => {
     expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(0);
     // Start and end session to test that listeners are cleaned up
     userSessionManager.startSessionPartInternal('init');
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     navigationInstrumentation.setCurrentRoute({
       path: '/test/:id',
@@ -229,7 +229,7 @@ describe('NavigationInstrumentation', () => {
 
     expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(0);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     // Session part span and route span
@@ -264,14 +264,14 @@ describe('NavigationInstrumentation', () => {
 
     expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(0);
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     // At this point we should have two spans: one for the session and one for the route
     expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(2);
 
     // Start and finish another session without changing the route
     userSessionManager.startSessionPartInternal('init');
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     // 2 sessions and 2 route spans
@@ -326,7 +326,7 @@ describe('NavigationInstrumentation', () => {
       url: '/second',
     });
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     const navigationSpans = finishedSpans.filter(

--- a/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
@@ -542,7 +542,7 @@ describe('EmbraceLogManager', () => {
       handled: true,
     });
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -561,7 +561,7 @@ describe('EmbraceLogManager', () => {
     }).to.not.throw();
 
     userSessionManager.startSessionPartInternal('init');
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
 
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -598,7 +598,7 @@ describe('EmbraceLogManager', () => {
       expect(finishedLogs[i].body).to.equal('this is an error log');
     }
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -642,7 +642,7 @@ describe('EmbraceLogManager', () => {
       'this is an info log which has a message longer than the allo',
     );
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -691,7 +691,7 @@ describe('EmbraceLogManager', () => {
     // Seems to be deterministic that this is always the one to be removed, adding sorting if the test becomes flaky
     expect(finishedLogs[1].attributes).not.to.have.property('key3');
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -724,7 +724,7 @@ describe('EmbraceLogManager', () => {
       'a-very-long-',
     );
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -762,7 +762,7 @@ describe('EmbraceLogManager', () => {
       expect(finishedLogs[i].body).to.equal('this is an exception');
     }
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -802,7 +802,7 @@ describe('EmbraceLogManager', () => {
       'this is an exception which has a message longer th',
     );
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -854,7 +854,7 @@ describe('EmbraceLogManager', () => {
     expect(finishedLogs[1].attributes['key3']).to.be.equal('3');
     expect(finishedLogs[1].attributes).not.to.have.property('key4');
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -888,7 +888,7 @@ describe('EmbraceLogManager', () => {
       'a-very-long-',
     );
 
-    userSessionManager.endSessionPartInternal('inactivity');
+    userSessionManager.endSessionPartInternal('web_inactivity');
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -153,7 +153,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
     expect(endReasons()).to.deep.equal([]);
 
     clock.tick(1);
-    expect(endReasons()).to.deep.equal(['inactivity']);
+    expect(endReasons()).to.deep.equal(['web_inactivity']);
   });
 
   it('resets the part-inactivity timer on activity', () => {
@@ -166,7 +166,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
     expect(endReasons()).to.deep.equal([]);
 
     clock.tick(1);
-    expect(endReasons()).to.deep.equal(['inactivity']);
+    expect(endReasons()).to.deep.equal(['web_inactivity']);
   });
 
   it('throttles activity events within the throttle window', () => {
@@ -179,7 +179,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
     clock.tick(SESSION_PART_INACTIVITY_MS - (THROTTLE_MS - 1) - 1);
     expect(endReasons()).to.deep.equal([]);
     clock.tick(1);
-    expect(endReasons()).to.deep.equal(['inactivity']);
+    expect(endReasons()).to.deep.equal(['web_inactivity']);
   });
 
   it('ends the part with reason inactivity when the part-inactivity window elapses', () => {
@@ -187,7 +187,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
 
     clock.tick(SESSION_PART_INACTIVITY_MS);
 
-    expect(endReasons()).to.deep.equal(['inactivity']);
+    expect(endReasons()).to.deep.equal(['web_inactivity']);
     void expect(manager.getSessionPartId()).to.be.null;
   });
 
@@ -203,7 +203,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
     void expect(manager.getSessionPartId()).to.not.be.null;
 
     clock.tick(SESSION_PART_INACTIVITY_MS);
-    expect(endReasons()).to.deep.equal(['inactivity', 'inactivity']);
+    expect(endReasons()).to.deep.equal(['web_inactivity', 'web_inactivity']);
   });
 
   it('starts a part with reason activity when input arrives and no part is active', () => {
@@ -370,7 +370,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
     clock.tick(SESSION_PART_INACTIVITY_MS - 1);
     expect(endReasons()).to.deep.equal([]);
     clock.tick(1);
-    expect(endReasons()).to.deep.equal(['inactivity']);
+    expect(endReasons()).to.deep.equal(['web_inactivity']);
     // No additional part starts: still only the initial 'init'.
     expect(startReasons()).to.deep.equal(['init']);
   });
@@ -381,7 +381,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
     // Inactivity expires; the part finalizes. Then user activity resumes;
     // the next event must start a new part with reason 'web_activity'.
     clock.tick(SESSION_PART_INACTIVITY_MS);
-    expect(endReasons()).to.deep.equal(['inactivity']);
+    expect(endReasons()).to.deep.equal(['web_inactivity']);
     void expect(manager.getSessionPartId()).to.be.null;
 
     fireActivity();
@@ -413,7 +413,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
     expect(endSpy.callCount).to.equal(endCallsBeforeVisibility);
 
     // The internal part-inactivity timer was cleared on shutdown, so no
-    // further endSessionPartInternal('inactivity') calls fire.
+    // further endSessionPartInternal('web_inactivity') calls fire.
     const endCallsBefore = endSpy.callCount;
     clock.tick(SESSION_PART_INACTIVITY_MS * 2);
     expect(endSpy.callCount).to.equal(endCallsBefore);

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -182,12 +182,15 @@ describe('EmbraceUserSessionManager browser activity', () => {
     expect(endReasons()).to.deep.equal(['web_inactivity']);
   });
 
-  it('ends the part with reason inactivity when the part-inactivity window elapses', () => {
+  it('ends the part with reason web_inactivity when the part-inactivity window elapses', () => {
     manager.startSessionPartInternal('init');
 
     clock.tick(SESSION_PART_INACTIVITY_MS);
 
     expect(endReasons()).to.deep.equal(['web_inactivity']);
+    // The part end reason is web-prefixed, but the enclosing user session's
+    // termination reason stays unprefixed for cross-platform correlation.
+    expect(endSpy.lastCall.args[1]).to.equal('inactivity');
     void expect(manager.getSessionPartId()).to.be.null;
   });
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
@@ -1278,15 +1278,15 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       );
     });
 
-    it('should stamp "inactivity" when the inactivity timer ends the part', () => {
+    it('should stamp "web_inactivity" when the inactivity timer ends the part', () => {
       manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('inactivity');
+      manager.endSessionPartInternal('web_inactivity');
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(1);
       expect(finishedSpans[0].attributes).to.have.property(
         'emb.session_part_end_reason',
-        'inactivity',
+        'web_inactivity',
       );
     });
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -359,7 +359,8 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
 
     this._clearSessionPartInactivityTimer();
 
-    const isFinal = reason === 'user_session_ended' || reason === 'inactivity';
+    const isFinal =
+      reason === 'user_session_ended' || reason === 'web_inactivity';
 
     // Capture the end stamp upfront. SpanProcessor.onEnd can run unbounded
     // and must not push it forward.
@@ -827,7 +828,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
       this._diag.debug(
         'inactivity timer fired; ending current part and user session',
       );
-      this.endSessionPartInternal('inactivity', 'inactivity');
+      this.endSessionPartInternal('web_inactivity', 'inactivity');
     } catch (e) {
       this._diag.warn('Error handling inactivity timer', e);
     }

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -102,7 +102,7 @@ engagement condition holds, the call is a debug-level no-op.
 | Value | Trigger |
 | --- | --- |
 | `web_background` | `visibilitychange` to hidden or `blur`. Also covers hard-nav unload and BFCache freeze, since blur or an earlier `visibilitychange` to hidden ends the part before `pagehide` fires. |
-| `inactivity` | The 30 minute part-inactivity timer fires without any user input event resetting it. |
+| `web_inactivity` | The 30 minute part-inactivity timer fires without any user input event resetting it. |
 | `user_session_ended` | `_terminateUserSession` ending the active part, fired on manual `endUserSession()` or max-duration expiry. |
 
 ### End behavior
@@ -187,7 +187,7 @@ silently no-ops if not (the next engagement event will create it).
 | --- | --- | --- | --- | --- |
 | Max duration | `DEFAULT_USER_SESSION_MAX_DURATION_SECONDS` | 12 hours | `MIN_USER_SESSION_MAX_DURATION_SECONDS` (1h) to `MAX_USER_SESSION_MAX_DURATION_SECONDS` (24h) | `_terminateUserSession('max_duration_reached')` |
 | User-session inactivity (lazy) | `DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` | 30 minutes | `MIN_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (30s) to `MAX_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (24h) | Not a live timer. The configured value is written into the state blob as `inactivityTimeoutSeconds`, and `_continueUserSessionAfterPartEnd` records `partEndTs + inactivityTimeoutSeconds * 1000` into `inactivityDeadlineTs`. Checked on the next part start by `_isExpired`. |
-| Part inactivity | `PART_INACTIVITY_TIMEOUT_MS` | 30 minutes | n/a | `endSessionPartInternal('inactivity')` |
+| Part inactivity | `PART_INACTIVITY_TIMEOUT_MS` | 30 minutes | n/a | `endSessionPartInternal('web_inactivity')` |
 | Activity throttle | `ACTIVITY_THROTTLE_MS` | 30 seconds | n/a | At most one inactivity-timer reset per 30 seconds of input. |
 | `endUserSession` cooldown | `END_USER_SESSION_COOLDOWN_MS` | 5 seconds | n/a | Calls within 5 seconds of the last call are silently ignored. |
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -105,6 +105,8 @@ engagement condition holds, the call is a debug-level no-op.
 | `web_inactivity` | The 30 minute part-inactivity timer fires without any user input event resetting it. |
 | `user_session_ended` | `_terminateUserSession` ending the active part, fired on manual `endUserSession()` or max-duration expiry. |
 
+The part-level `web_inactivity` is distinct from the user-session-level `inactivity` reason in the [`UserSessionEndReason`](#termination) table below: when the part-inactivity timer fires it stamps `web_inactivity` as the part end reason and `inactivity` as the enclosing user session's termination reason on the same final part span.
+
 ### End behavior
 
 On end, the manager:
@@ -172,7 +174,7 @@ is called from:
 | --- | --- | --- |
 | `manual` | `endUserSession()` API call. | Yes |
 | `max_duration_reached` | Max-duration timer fires. | Yes |
-| `inactivity` | Reserved value. | No. Inactivity is detected lazily at next part start, after the prior part span is already exported. |
+| `inactivity` | Part-inactivity timer fires while a part is active. | Yes, stamped as the user-session termination reason on the final part span, paired with that part's `web_inactivity` end reason. When inactivity is instead detected lazily at the next part start (no part was active to run the timer), the prior part span has already been exported, so no reason is stamped. |
 
 On termination the manager calls
 `endSessionPartInternal('user_session_ended', reason)`, saves

--- a/packages/web-sdk/src/processors/EmbraceSessionPartBatchedSpanProcessor/EmbraceSessionPartBatchedSpanProcessor.test.ts
+++ b/packages/web-sdk/src/processors/EmbraceSessionPartBatchedSpanProcessor/EmbraceSessionPartBatchedSpanProcessor.test.ts
@@ -176,10 +176,10 @@ describe('EmbraceSessionPartBatchedSpanProcessor', () => {
 
       await Promise.resolve();
 
-      userSessionManager.endSessionPartInternal('inactivity');
+      userSessionManager.endSessionPartInternal('web_inactivity');
 
       userSessionManager.startSessionPartInternal('init');
-      userSessionManager.endSessionPartInternal('inactivity');
+      userSessionManager.endSessionPartInternal('web_inactivity');
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);

--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -846,7 +846,7 @@ describe('initSDK', () => {
       // shouldn't get exported
       embtrace.startSpan('my unfinished performance span');
 
-      session.getUserSessionManager().endSessionPartInternal('inactivity');
+      session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
       const exportedSpans = await getLastSessionExportedSpans(1);
 
@@ -877,7 +877,7 @@ describe('initSDK', () => {
         embtrace.startSpan(`my-span-${i.toString()}`).end();
       }
 
-      session.getUserSessionManager().endSessionPartInternal('inactivity');
+      session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
       const exportedSpans = await getLastSessionExportedSpans(1);
       expect(exportedSpans).to.have.lengthOf(1000);
@@ -894,7 +894,7 @@ describe('initSDK', () => {
         embtrace.startSpan(`my-next-session-span-${i.toString()}`).end();
       }
 
-      session.getUserSessionManager().endSessionPartInternal('inactivity');
+      session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
       const nextSessionExportedSpans = await getLastSessionExportedSpans(0);
       expect(nextSessionExportedSpans).to.have.lengthOf(100);
@@ -932,7 +932,7 @@ describe('initSDK', () => {
       }
 
       span.end();
-      session.getUserSessionManager().endSessionPartInternal('inactivity');
+      session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
       const exportedSpans = await getLastSessionExportedSpans(1);
       expect(exportedSpans).to.have.lengthOf(1);
@@ -978,7 +978,7 @@ describe('initSDK', () => {
       }
 
       span.end();
-      session.getUserSessionManager().endSessionPartInternal('inactivity');
+      session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
       const exportedSpans = await getLastSessionExportedSpans(1);
       expect(exportedSpans).to.have.lengthOf(1);
@@ -1045,7 +1045,7 @@ describe('initSDK', () => {
 
       span.addEvent('span-event', spanEventAttributes);
       span.end();
-      session.getUserSessionManager().endSessionPartInternal('inactivity');
+      session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
       const exportedSpans = await getLastSessionExportedSpans(1);
       expect(exportedSpans).to.have.lengthOf(1);
@@ -1097,7 +1097,7 @@ describe('initSDK', () => {
         },
       });
 
-      session.getUserSessionManager().endSessionPartInternal('inactivity');
+      session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
       if (result) {
         await result.flush();
@@ -1174,7 +1174,7 @@ describe('initSDK', () => {
         },
       });
 
-      session.getUserSessionManager().endSessionPartInternal('inactivity');
+      session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
       if (result) {
         await result.flush();
@@ -1254,7 +1254,7 @@ describe('initSDK', () => {
         },
       });
 
-      session.getUserSessionManager().endSessionPartInternal('inactivity');
+      session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
       if (result) {
         await result.flush();
@@ -1758,7 +1758,9 @@ describe('initSDK', () => {
           }
         }
 
-        session.getUserSessionManager().endSessionPartInternal('inactivity');
+        session
+          .getUserSessionManager()
+          .endSessionPartInternal('web_inactivity');
 
         // Need to restore the clock here so that the setTimeout in `getLastSessionExportedSpans` works
         clock.restore();
@@ -1889,9 +1891,9 @@ describe('isolated instances', () => {
     // Deprecated public path — must be a no-op against the unregistered global.
     session.endSessionSpan();
     // New internal path through the proxy's underlying manager — also a no-op.
-    session.getUserSessionManager().endSessionPartInternal('inactivity');
+    session.getUserSessionManager().endSessionPartInternal('web_inactivity');
     session.getUserSessionManager().startSessionPartInternal('web_activity');
-    session.getUserSessionManager().endSessionPartInternal('inactivity');
+    session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
     await result.flush();
 
@@ -1945,9 +1947,9 @@ describe('isolated instances', () => {
 
       sdkInstance.log.message('some log', 'info');
       sdkInstance.trace.startSpan('some span').end();
-      internalSessionManager.endSessionPartInternal('inactivity');
+      internalSessionManager.endSessionPartInternal('web_inactivity');
       internalSessionManager.startSessionPartInternal('web_activity');
-      internalSessionManager.endSessionPartInternal('inactivity');
+      internalSessionManager.endSessionPartInternal('web_inactivity');
       instrumentation.emit();
 
       await sdkInstance.flush();
@@ -1972,14 +1974,14 @@ describe('isolated instances', () => {
       ).to.equal('init');
       expect(
         finishedSpans[1].attributes['emb.session_part_end_reason'],
-      ).to.equal('inactivity');
+      ).to.equal('web_inactivity');
       expect(finishedSpans[2].name).to.equal('emb-session-part');
       expect(
         finishedSpans[2].attributes['emb.session_part_start_reason'],
       ).to.equal('web_activity');
       expect(
         finishedSpans[2].attributes['emb.session_part_end_reason'],
-      ).to.equal('inactivity');
+      ).to.equal('web_inactivity');
       expect(finishedSpans[3].name).to.equal('my span');
     };
 


### PR DESCRIPTION
## What problem is this solving?

The `SessionPartEndReason` value `inactivity` described web-specific behaviour (the part-inactivity timer firing) but was emitted unprefixed, breaking the convention where web-specific reasons carry a `web_` prefix and only cross-platform concepts stay unprefixed.

## Short description of changes

- Rename the `SessionPartEndReason` union value `inactivity` to `web_inactivity` (types, `isFinal` check, call site, README tables, and all affected test assertions).
- Keep `UserSessionEndReason.inactivity` unprefixed: it is a cross-platform concept the backend correlates across SDKs. The part-inactivity timer now stamps `web_inactivity` on the part and `inactivity` on the enclosing user session.
- Disambiguate the categorization comment in `types.ts` so the two same-named-but-distinct reasons are no longer conflated.
- Correct the README `inactivity` row: it is emitted as the user-session termination reason when the live part-inactivity timer fires (the old "reserved / not emitted" note only covered the lazy next-part-start path).
- Add a test assertion locking the invariant that the part reason is `web_` prefixed while the user-session reason stays unprefixed.

## Testing

- `npm run check` (tsc + eslint, max-warnings 0): pass
- Affected unit test files run green (21/21 in `EmbraceSessionPartActivity.test.ts`, plus the updated wire-value assertions across instrumentations, managers, processor, and initSDK suites).