### PR TITLE
feat(sessions): source user-session durations from remote config

### DIFF
--- a/demo/frontend/src/otel-base.ts
+++ b/demo/frontend/src/otel-base.ts
@@ -32,9 +32,6 @@ const setupSDK = (instrumentations?: Instrumentation[]) => {
     ...(instrumentations ? { instrumentations } : {}),
     embraceDataURL: DATA_URL ?? undefined,
     embraceConfigURL: CONFIG_URL ?? undefined,
-    inactivityTimeoutSeconds: 45,
-    // default is 1 hour
-    // maxUserSessionDurationSeconds: 1 * 60 * 60,
   });
 
   if (result) {

--- a/packages/web-sdk/src/api-logs/logAPI.test.ts
+++ b/packages/web-sdk/src/api-logs/logAPI.test.ts
@@ -1,5 +1,8 @@
 import { expect } from 'chai';
-import { setupTestStorage } from '../../tests/utils/index.ts';
+import {
+  setupTestStorage,
+  TEST_DYNAMIC_CONFIG_MANAGER,
+} from '../../tests/utils/index.ts';
 import {
   DEFAULT_LIMITS,
   EmbraceLimitManager,
@@ -38,6 +41,7 @@ describe('logAPI', () => {
       const perf = new OTelPerformanceManager();
       manager = new EmbraceLogManager({
         userSessionManager: new EmbraceUserSessionManager({
+          dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
           limitManager,
           perf,
           storage,

--- a/packages/web-sdk/src/api-sessions/sessionAPI.test.ts
+++ b/packages/web-sdk/src/api-sessions/sessionAPI.test.ts
@@ -1,5 +1,8 @@
 import { expect } from 'chai';
-import { setupTestStorage } from '../../tests/utils/index.ts';
+import {
+  setupTestStorage,
+  TEST_DYNAMIC_CONFIG_MANAGER,
+} from '../../tests/utils/index.ts';
 import {
   DEFAULT_LIMITS,
   EmbraceLimitManager,
@@ -48,6 +51,7 @@ describe('sessionAPI', () => {
 
     beforeEach(() => {
       manager = new EmbraceUserSessionManager({
+        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
         limitManager: new EmbraceLimitManager({ ...DEFAULT_LIMITS }),
         perf: new OTelPerformanceManager(),
         storage: setupTestStorage(),

--- a/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
@@ -5,6 +5,7 @@ import {
   InMemoryDiagLogger,
   setupTestStorage,
   setupTestTraceExporter,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../tests/utils/index.ts';
 import { session } from '../../../api-sessions/index.ts';
 import type { UserSessionManagerInternal } from '../../../managers/index.ts';
@@ -33,6 +34,7 @@ describe('ClicksInstrumentation', () => {
     memoryExporter.reset();
     diag = new InMemoryDiagLogger();
     userSessionManager = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
       perf: new OTelPerformanceManager(),
       storage: setupTestStorage(),

--- a/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
@@ -4,6 +4,7 @@ import {
   InMemoryDiagLogger,
   setupTestStorage,
   setupTestTraceExporter,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../tests/utils/index.ts';
 import { session } from '../../../api-sessions/index.ts';
 import type { UserSessionManagerInternal } from '../../../managers/index.ts';
@@ -31,6 +32,7 @@ describe('EmptyInstrumentation', () => {
     memoryExporter.reset();
     diag = new InMemoryDiagLogger();
     userSessionManager = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
       perf: new OTelPerformanceManager(),
       storage: setupTestStorage(),

--- a/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.test.ts
@@ -7,6 +7,7 @@ import {
   MockPerformanceManager,
   setupTestLogExporter,
   setupTestStorage,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../tests/utils/index.ts';
 import type { LogManager } from '../../../api-logs/index.ts';
 import { log } from '../../../api-logs/index.ts';
@@ -50,6 +51,7 @@ describe('GlobalExceptionInstrumentation', () => {
     perf = new MockPerformanceManager(clock);
     logManager = new EmbraceLogManager({
       userSessionManager: new EmbraceUserSessionManager({
+        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
         limitManager,
         perf,
         storage,

--- a/packages/web-sdk/src/instrumentations/exceptions/react/EmbraceErrorBoundary/EmbraceErrorBoundary.test.ts
+++ b/packages/web-sdk/src/instrumentations/exceptions/react/EmbraceErrorBoundary/EmbraceErrorBoundary.test.ts
@@ -5,6 +5,7 @@ import type React from 'react';
 import {
   setupTestLogExporter,
   setupTestStorage,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../../tests/utils/index.ts';
 import type { LogManager } from '../../../../api-logs/index.ts';
 import { log } from '../../../../api-logs/index.ts';
@@ -45,6 +46,7 @@ describe('EmbraceErrorBoundary', () => {
     const perf = new OTelPerformanceManager();
     logManager = new EmbraceLogManager({
       userSessionManager: new EmbraceUserSessionManager({
+        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
         limitManager,
         perf,
         storage,

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
@@ -8,6 +8,7 @@ import {
   setupTestLogExporter,
   setupTestStorage,
   setupTestTraceExporter,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../tests/utils/index.ts';
 import { log } from '../../../api-logs/index.ts';
 import type { UserSessionManagerInternal } from '../../../managers/index.ts';
@@ -103,6 +104,7 @@ describe('LoafInstrumentation', () => {
     const limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
     const storage = setupTestStorage();
     userSessionManager = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager,
       perf,
       storage,
@@ -494,6 +496,7 @@ describe('LoafInstrumentation', () => {
     const limitManager2 = new EmbraceLimitManager(DEFAULT_LIMITS);
     const storage2 = setupTestStorage();
     const userSessionManager2 = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager: limitManager2,
       perf,
       storage: storage2,

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
@@ -4,6 +4,7 @@ import {
   InMemoryDiagLogger,
   setupTestStorage,
   setupTestTraceExporter,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../tests/utils/index.ts';
 import { page } from '../../../api-page/index.ts';
 import { session } from '../../../api-sessions/index.ts';
@@ -36,6 +37,7 @@ describe('NavigationInstrumentation', () => {
     diag = new InMemoryDiagLogger();
 
     userSessionManager = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
       perf: new OTelPerformanceManager(),
       storage: setupTestStorage(),

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV5/ReactRouterV5.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV5/ReactRouterV5.test.tsx
@@ -5,6 +5,7 @@ import { Route, Router, Switch, useHistory } from 'react-router-domv4v5';
 import {
   setupTestStorage,
   setupTestTraceExporter,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../../../tests/utils/index.ts';
 import { render } from '../../../../../../tests/utils/react/reactTestUtils.ts';
 import { runReactRouterTest } from '../../../../../../tests/utils/react/sharedTests.ts';
@@ -74,6 +75,7 @@ describe('ReactRouterV5Legacy', () => {
 
   before(() => {
     userSessionManager = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
       perf: new OTelPerformanceManager(),
       storage: setupTestStorage(),

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Data/ReactRouterV6Data.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Data/ReactRouterV6Data.test.tsx
@@ -11,6 +11,7 @@ import {
 import {
   setupTestStorage,
   setupTestTraceExporter,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../../../tests/utils/index.ts';
 import { render } from '../../../../../../tests/utils/react/reactTestUtils.ts';
 import { runReactRouterTest } from '../../../../../../tests/utils/react/sharedTests.ts';
@@ -111,6 +112,7 @@ describe('ReactRouterV6Data', () => {
 
   before(() => {
     userSessionManager = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
       perf: new OTelPerformanceManager(),
       storage: setupTestStorage(),

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Declarative/ReactRouterV6Declarative.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Declarative/ReactRouterV6Declarative.test.tsx
@@ -10,6 +10,7 @@ import {
 import {
   setupTestStorage,
   setupTestTraceExporter,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../../../tests/utils/index.ts';
 import { render } from '../../../../../../tests/utils/react/reactTestUtils.ts';
 import { runReactRouterTest } from '../../../../../../tests/utils/react/sharedTests.ts';
@@ -86,6 +87,7 @@ describe('ReactRouterV6Declarative', () => {
 
   before(() => {
     userSessionManager = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
       perf: new OTelPerformanceManager(),
       storage: setupTestStorage(),

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
@@ -6,6 +6,7 @@ import {
   MockPerformanceManager,
   setupTestLogExporter,
   setupTestStorage,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../tests/utils/index.ts';
 import { log } from '../../../api-logs/index.ts';
 import {
@@ -53,6 +54,7 @@ describe('ServerTimingInstrumentation', () => {
     limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
     const storage = setupTestStorage();
     const userSessionManager = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager,
       perf,
       storage,

--- a/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
@@ -10,6 +10,7 @@ import {
   setupTestLogExporter,
   setupTestStorage,
   setupTestTraceExporter,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../tests/utils/index.ts';
 import { log } from '../../../api-logs/index.ts';
 import {
@@ -118,6 +119,7 @@ describe('UserTimingInstrumentation', () => {
     limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
     const storage = setupTestStorage();
     const userSessionManager = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager,
       perf,
       storage,

--- a/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.test.ts
@@ -103,6 +103,70 @@ describe('EmbraceDynamicConfigManager', () => {
     });
   });
 
+  it('should parse user-session durations from remote config', () => {
+    storage.setItem(
+      LOCAL_STORAGE_REMOTE_CONFIG_KEY,
+      JSON.stringify({
+        etag: null,
+        config: {
+          threshold: 100,
+          user_session: {
+            max_duration_seconds: 7200,
+            inactivity_timeout_seconds: 120,
+          },
+        },
+      }),
+    );
+
+    const configManager = new EmbraceDynamicConfigManager({ storage });
+
+    const config = configManager.getConfig();
+
+    expect(config.maxUserSessionDurationSeconds).to.equal(7200);
+    expect(config.inactivityTimeoutSeconds).to.equal(120);
+  });
+
+  it('should leave the omitted user-session field undefined when only one is sent', () => {
+    storage.setItem(
+      LOCAL_STORAGE_REMOTE_CONFIG_KEY,
+      JSON.stringify({
+        etag: null,
+        config: {
+          threshold: 100,
+          user_session: {
+            max_duration_seconds: 7200,
+          },
+        },
+      }),
+    );
+
+    const configManager = new EmbraceDynamicConfigManager({ storage });
+
+    const config = configManager.getConfig();
+
+    expect(config.maxUserSessionDurationSeconds).to.equal(7200);
+    void expect(config.inactivityTimeoutSeconds).to.be.undefined;
+  });
+
+  it('should leave both user-session fields undefined when the block is absent', () => {
+    storage.setItem(
+      LOCAL_STORAGE_REMOTE_CONFIG_KEY,
+      JSON.stringify({
+        etag: null,
+        config: {
+          threshold: 100,
+        },
+      }),
+    );
+
+    const configManager = new EmbraceDynamicConfigManager({ storage });
+
+    const config = configManager.getConfig();
+
+    void expect(config.maxUserSessionDurationSeconds).to.be.undefined;
+    void expect(config.inactivityTimeoutSeconds).to.be.undefined;
+  });
+
   it('should not fail if storage is not available', () => {
     const configManager = new EmbraceDynamicConfigManager({
       storage: new NamespacedStorage({

--- a/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.test.ts
@@ -122,8 +122,8 @@ describe('EmbraceDynamicConfigManager', () => {
 
     const config = configManager.getConfig();
 
-    expect(config.maxUserSessionDurationSeconds).to.equal(7200);
-    expect(config.inactivityTimeoutSeconds).to.equal(120);
+    expect(config.userSessionMaxDurationSeconds).to.equal(7200);
+    expect(config.userSessionInactivityTimeoutSeconds).to.equal(120);
   });
 
   it('should leave the omitted user-session field undefined when only one is sent', () => {
@@ -144,8 +144,8 @@ describe('EmbraceDynamicConfigManager', () => {
 
     const config = configManager.getConfig();
 
-    expect(config.maxUserSessionDurationSeconds).to.equal(7200);
-    void expect(config.inactivityTimeoutSeconds).to.be.undefined;
+    expect(config.userSessionMaxDurationSeconds).to.equal(7200);
+    void expect(config.userSessionInactivityTimeoutSeconds).to.be.undefined;
   });
 
   it('should leave both user-session fields undefined when the block is absent', () => {
@@ -163,8 +163,8 @@ describe('EmbraceDynamicConfigManager', () => {
 
     const config = configManager.getConfig();
 
-    void expect(config.maxUserSessionDurationSeconds).to.be.undefined;
-    void expect(config.inactivityTimeoutSeconds).to.be.undefined;
+    void expect(config.userSessionMaxDurationSeconds).to.be.undefined;
+    void expect(config.userSessionInactivityTimeoutSeconds).to.be.undefined;
   });
 
   it('should not fail if storage is not available', () => {

--- a/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.ts
@@ -26,6 +26,16 @@ const parseRemoteConfig = (remoteConfig: RemoteConfig): DynamicSDKConfig => {
       remoteConfig.network_span_forwarding.pct_enabled;
   }
 
+  if (remoteConfig.user_session?.max_duration_seconds !== undefined) {
+    parsed.maxUserSessionDurationSeconds =
+      remoteConfig.user_session.max_duration_seconds;
+  }
+
+  if (remoteConfig.user_session?.inactivity_timeout_seconds !== undefined) {
+    parsed.inactivityTimeoutSeconds =
+      remoteConfig.user_session.inactivity_timeout_seconds;
+  }
+
   return parsed;
 };
 

--- a/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceConfigManager/EmbraceDynamicConfigManager.ts
@@ -27,12 +27,12 @@ const parseRemoteConfig = (remoteConfig: RemoteConfig): DynamicSDKConfig => {
   }
 
   if (remoteConfig.user_session?.max_duration_seconds !== undefined) {
-    parsed.maxUserSessionDurationSeconds =
+    parsed.userSessionMaxDurationSeconds =
       remoteConfig.user_session.max_duration_seconds;
   }
 
   if (remoteConfig.user_session?.inactivity_timeout_seconds !== undefined) {
-    parsed.inactivityTimeoutSeconds =
+    parsed.userSessionInactivityTimeoutSeconds =
       remoteConfig.user_session.inactivity_timeout_seconds;
   }
 

--- a/packages/web-sdk/src/managers/EmbraceConfigManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceConfigManager/types.ts
@@ -9,12 +9,15 @@ export type RemoteConfigURLParams = {
   deviceId: string;
 };
 
-// All numbers from remote config are ranges from 0.0 to 100.0 that represent the % of devices which should be enabled
-// for that particular feature / option
+// Percentage fields hold a 0.0-100.0 value: the % of devices a feature / option is enabled for.
 export type RemoteConfig = {
   threshold: number; // Main traffic control %, devices that fall outside of this should not emit any telemetry at all
   network_span_forwarding?: {
     pct_enabled: number;
+  };
+  user_session?: {
+    max_duration_seconds?: number;
+    inactivity_timeout_seconds?: number;
   };
 };
 

--- a/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
@@ -19,6 +19,7 @@ import {
   setupTestLogExporter,
   setupTestStorage,
   setupTestTraceExporter,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../tests/utils/index.ts';
 import type { VisibilityStateDocument } from '../../common/index.ts';
 import {
@@ -101,6 +102,7 @@ describe('EmbraceLogManager', () => {
 
     storage = setupTestStorage();
     userSessionManager = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager,
       perf,
       storage,

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -5,6 +5,7 @@ import sinonChai from 'sinon-chai';
 import {
   MockPerformanceManager,
   setupTestStorage,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../tests/utils/index.ts';
 import type {
   SessionPartEndReason,
@@ -81,6 +82,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
       visibilityDoc,
       target,
       activityThrottleMs: THROTTLE_MS,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
     // Browser-activity listeners attach inside setTracerProvider; activity
     // tests need them live, so wire a tracer provider before spying.

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
@@ -7,11 +7,13 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import {
+  createTestDynamicConfigManager,
   FailingStorage,
   InMemoryDiagLogger,
   InMemoryStorage,
   MockPerformanceManager,
   setupTestTraceExporter,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../tests/utils/index.ts';
 import type { VisibilityStateDocument } from '../../common/index.ts';
 import { NamespacedStorage } from '../../utils/NamespacedStorage/NamespacedStorage.ts';
@@ -73,6 +75,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       limitManager,
       perf,
       visibilityDoc: window.document,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
   });
 
@@ -226,6 +229,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       limitManager,
       perf,
       storage,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
     localManager.startSessionPartInternal('init');
     localManager.endSessionPartInternal('web_background');
@@ -266,6 +270,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         limitManager,
         perf,
         storage,
+        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
       localManager.startSessionPartInternal('init');
       void expect(localManager.getSessionPartId()).to.be.null;
@@ -283,6 +288,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       perf,
       storage,
       visibilityDoc: window.document,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
     const removeListener = localManager.addSessionPartStartedListener(listener);
 
@@ -305,6 +311,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       perf,
       storage,
       visibilityDoc: window.document,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
 
     const listener = () => {
@@ -576,6 +583,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       limitManager,
       perf,
       visibilityDoc: window.document,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
     secondManager.startSessionPartInternal('init');
     secondManager.endSessionPartInternal('web_background');
@@ -616,6 +624,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         diag,
       }),
       visibilityDoc: window.document,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
     flipManager.startSessionPartInternal('init');
     flipManager.addProperty('cart', '3');
@@ -645,6 +654,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         diag,
       }),
       visibilityDoc: window.document,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
     failingManager.startSessionPartInternal('init');
 
@@ -807,6 +817,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         diag,
       }),
       visibilityDoc: window.document,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
 
     failingManager.startSessionPartInternal('init');
@@ -831,6 +842,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         diag,
       }),
       visibilityDoc: window.document,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
     failingManager.startSessionPartInternal('init');
 
@@ -878,6 +890,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       perf,
       storage: new NamespacedStorage({ storage: flakyStorage, diag }),
       visibilityDoc: window.document,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
     flakyManager.startSessionPartInternal('init');
 
@@ -943,7 +956,9 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         storage,
         limitManager,
         perf,
-        config: { maxUserSessionDurationSeconds: 3600 },
+        dynamicConfigManager: createTestDynamicConfigManager({
+          maxUserSessionDurationSeconds: 3600,
+        }),
         visibilityDoc: window.document,
       });
 
@@ -1004,6 +1019,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         limitManager,
         perf,
         visibilityDoc: window.document,
+        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
 
       localManager.startSessionPartInternal('init');
@@ -1023,10 +1039,10 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         storage,
         limitManager,
         perf,
-        config: {
+        dynamicConfigManager: createTestDynamicConfigManager({
           maxUserSessionDurationSeconds: 3600,
           inactivityTimeoutSeconds: 3600,
-        },
+        }),
         visibilityDoc: window.document,
       });
 
@@ -1075,10 +1091,10 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         // first (timers registered earlier fire first when set to the same
         // delay; max-duration is armed in _ensureUserSessionState before
         // the inactivity timer is armed by startSessionPartInternal).
-        config: {
+        dynamicConfigManager: createTestDynamicConfigManager({
           maxUserSessionDurationSeconds: 3600,
           inactivityTimeoutSeconds: 3600,
-        },
+        }),
       });
 
       localManager.startSessionPartInternal('init');
@@ -1128,7 +1144,9 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         perf,
         storage,
         limitManager,
-        config: { inactivityTimeoutSeconds: 60 },
+        dynamicConfigManager: createTestDynamicConfigManager({
+          inactivityTimeoutSeconds: 60,
+        }),
         visibilityDoc: window.document,
       });
 
@@ -1166,6 +1184,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         limitManager,
         perf,
         visibilityDoc: window.document,
+        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
       localManager.setTracerProvider(tracerProvider);
 
@@ -1239,10 +1258,10 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         storage,
         limitManager,
         perf,
-        config: {
+        dynamicConfigManager: createTestDynamicConfigManager({
           maxUserSessionDurationSeconds: 3600,
           inactivityTimeoutSeconds: 3600,
-        },
+        }),
         visibilityDoc: window.document,
       });
 
@@ -1335,7 +1354,9 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         perf,
         storage,
         limitManager,
-        config: { inactivityTimeoutSeconds: 60 },
+        dynamicConfigManager: createTestDynamicConfigManager({
+          inactivityTimeoutSeconds: 60,
+        }),
         visibilityDoc: window.document,
       });
 
@@ -1464,6 +1485,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         limitManager,
         perf,
         visibilityDoc: window.document,
+        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
       secondManager.startSessionPartInternal('init');
       secondManager.endSessionPartInternal('web_background');

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
@@ -957,7 +957,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         limitManager,
         perf,
         dynamicConfigManager: createTestDynamicConfigManager({
-          maxUserSessionDurationSeconds: 3600,
+          userSessionMaxDurationSeconds: 3600,
         }),
         visibilityDoc: window.document,
       });
@@ -1040,8 +1040,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         limitManager,
         perf,
         dynamicConfigManager: createTestDynamicConfigManager({
-          maxUserSessionDurationSeconds: 3600,
-          inactivityTimeoutSeconds: 3600,
+          userSessionMaxDurationSeconds: 3600,
+          userSessionInactivityTimeoutSeconds: 3600,
         }),
         visibilityDoc: window.document,
       });
@@ -1092,8 +1092,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         // delay; max-duration is armed in _ensureUserSessionState before
         // the inactivity timer is armed by startSessionPartInternal).
         dynamicConfigManager: createTestDynamicConfigManager({
-          maxUserSessionDurationSeconds: 3600,
-          inactivityTimeoutSeconds: 3600,
+          userSessionMaxDurationSeconds: 3600,
+          userSessionInactivityTimeoutSeconds: 3600,
         }),
       });
 
@@ -1145,7 +1145,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         storage,
         limitManager,
         dynamicConfigManager: createTestDynamicConfigManager({
-          inactivityTimeoutSeconds: 60,
+          userSessionInactivityTimeoutSeconds: 60,
         }),
         visibilityDoc: window.document,
       });
@@ -1259,8 +1259,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         limitManager,
         perf,
         dynamicConfigManager: createTestDynamicConfigManager({
-          maxUserSessionDurationSeconds: 3600,
-          inactivityTimeoutSeconds: 3600,
+          userSessionMaxDurationSeconds: 3600,
+          userSessionInactivityTimeoutSeconds: 3600,
         }),
         visibilityDoc: window.document,
       });
@@ -1355,7 +1355,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         storage,
         limitManager,
         dynamicConfigManager: createTestDynamicConfigManager({
-          inactivityTimeoutSeconds: 60,
+          userSessionInactivityTimeoutSeconds: 60,
         }),
         visibilityDoc: window.document,
       });

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -58,8 +58,8 @@ describe('EmbraceUserSessionManager', () => {
   });
 
   const createManager = (config?: {
-    maxUserSessionDurationSeconds?: number;
-    inactivityTimeoutSeconds?: number;
+    userSessionMaxDurationSeconds?: number;
+    userSessionInactivityTimeoutSeconds?: number;
   }) =>
     new EmbraceUserSessionManager({
       diag,
@@ -151,7 +151,7 @@ describe('EmbraceUserSessionManager', () => {
   });
 
   it('should start a session when max duration expires', () => {
-    const manager = createManager({ maxUserSessionDurationSeconds: 3600 });
+    const manager = createManager({ userSessionMaxDurationSeconds: 3600 });
 
     manager.startSessionPartInternal('init');
     const attrs1 = manager.getUserSessionAttributes();
@@ -174,8 +174,8 @@ describe('EmbraceUserSessionManager', () => {
     // max is armed first (in _ensureUserSessionState during part start)
     // so it fires first and finalizes via _rolloverUserSession.
     const manager = createManager({
-      maxUserSessionDurationSeconds: 3600,
-      inactivityTimeoutSeconds: 3600,
+      userSessionMaxDurationSeconds: 3600,
+      userSessionInactivityTimeoutSeconds: 3600,
     });
 
     const endSpy = sinon.spy(manager, 'endSessionPartInternal');
@@ -194,8 +194,8 @@ describe('EmbraceUserSessionManager', () => {
 
   it('should provide termination info when max duration fires', () => {
     const manager = createManager({
-      maxUserSessionDurationSeconds: 3600,
-      inactivityTimeoutSeconds: 3600,
+      userSessionMaxDurationSeconds: 3600,
+      userSessionInactivityTimeoutSeconds: 3600,
     });
 
     const endSpy = sinon.spy(manager, 'endSessionPartInternal');
@@ -304,7 +304,7 @@ describe('EmbraceUserSessionManager', () => {
   it('should clamp max duration to the maximum', () => {
     // 25 hours exceeds 24 hour max
     const manager = createManager({
-      maxUserSessionDurationSeconds: 25 * 60 * 60,
+      userSessionMaxDurationSeconds: 25 * 60 * 60,
     });
     manager.startSessionPartInternal('init');
     const attrs = manager.getUserSessionAttributes();
@@ -313,7 +313,9 @@ describe('EmbraceUserSessionManager', () => {
 
   it('should clamp inactivity timeout to the maximum', () => {
     // 25 hours exceeds 24 hour max
-    const manager = createManager({ inactivityTimeoutSeconds: 25 * 60 * 60 });
+    const manager = createManager({
+      userSessionInactivityTimeoutSeconds: 25 * 60 * 60,
+    });
     manager.startSessionPartInternal('init');
     const attrs = manager.getUserSessionAttributes();
     expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
@@ -350,7 +352,7 @@ describe('EmbraceUserSessionManager', () => {
     // The user-session max-duration timer must fire even while no part is
     // active. When the rollover runs with no active part, state is cleared
     // directly so the next part start lazily creates a fresh user session.
-    const manager = createManager({ maxUserSessionDurationSeconds: 3600 });
+    const manager = createManager({ userSessionMaxDurationSeconds: 3600 });
 
     manager.startSessionPartInternal('init');
     const firstSessionId = manager.getUserSessionId();
@@ -486,7 +488,7 @@ describe('EmbraceUserSessionManager', () => {
   });
 
   it('should expose the dying user session id via getPreviousUserSessionId on max-duration rollover', () => {
-    const manager = createManager({ maxUserSessionDurationSeconds: 3600 });
+    const manager = createManager({ userSessionMaxDurationSeconds: 3600 });
     manager.startSessionPartInternal('init');
     const attrs = manager.getUserSessionAttributes();
     const dyingId = attrs?.['emb.user_session_id'];
@@ -578,31 +580,33 @@ describe('EmbraceUserSessionManager', () => {
   });
 
   describe('config clamp min-boundary', () => {
-    it('should fall back to default when maxUserSessionDurationSeconds is below minimum', () => {
+    it('should fall back to default when userSessionMaxDurationSeconds is below minimum', () => {
       // MIN is 1 hour (3600s); 60s is below minimum
-      const manager = createManager({ maxUserSessionDurationSeconds: 60 });
+      const manager = createManager({ userSessionMaxDurationSeconds: 60 });
       manager.startSessionPartInternal('init');
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(43200);
     });
 
-    it('should fall back to default when maxUserSessionDurationSeconds is zero', () => {
-      const manager = createManager({ maxUserSessionDurationSeconds: 0 });
+    it('should fall back to default when userSessionMaxDurationSeconds is zero', () => {
+      const manager = createManager({ userSessionMaxDurationSeconds: 0 });
       manager.startSessionPartInternal('init');
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(43200);
     });
 
-    it('should fall back to default when maxUserSessionDurationSeconds is negative', () => {
-      const manager = createManager({ maxUserSessionDurationSeconds: -60 });
+    it('should fall back to default when userSessionMaxDurationSeconds is negative', () => {
+      const manager = createManager({ userSessionMaxDurationSeconds: -60 });
       manager.startSessionPartInternal('init');
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(43200);
     });
 
-    it('should fall back to default when inactivityTimeoutSeconds is below minimum', () => {
+    it('should fall back to default when userSessionInactivityTimeoutSeconds is below minimum', () => {
       // MIN is 30s; 10s is below minimum
-      const manager = createManager({ inactivityTimeoutSeconds: 10 });
+      const manager = createManager({
+        userSessionInactivityTimeoutSeconds: 10,
+      });
       manager.startSessionPartInternal('init');
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
@@ -610,8 +614,8 @@ describe('EmbraceUserSessionManager', () => {
       );
     });
 
-    it('should fall back to default when inactivityTimeoutSeconds is zero', () => {
-      const manager = createManager({ inactivityTimeoutSeconds: 0 });
+    it('should fall back to default when userSessionInactivityTimeoutSeconds is zero', () => {
+      const manager = createManager({ userSessionInactivityTimeoutSeconds: 0 });
       manager.startSessionPartInternal('init');
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
@@ -619,8 +623,10 @@ describe('EmbraceUserSessionManager', () => {
       );
     });
 
-    it('should fall back to default when inactivityTimeoutSeconds is negative', () => {
-      const manager = createManager({ inactivityTimeoutSeconds: -60 });
+    it('should fall back to default when userSessionInactivityTimeoutSeconds is negative', () => {
+      const manager = createManager({
+        userSessionInactivityTimeoutSeconds: -60,
+      });
       manager.startSessionPartInternal('init');
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
@@ -628,29 +634,31 @@ describe('EmbraceUserSessionManager', () => {
       );
     });
 
-    it('should fall back to default when maxUserSessionDurationSeconds is NaN', () => {
+    it('should fall back to default when userSessionMaxDurationSeconds is NaN', () => {
       // NaN slips both range gates (NaN < x and NaN > x both return false), so
       // without the finite-number guard the manager would persist NaN as
-      // _maxUserSessionDurationSeconds and JSON.stringify would write `null` to storage.
+      // _userSessionMaxDurationSeconds and JSON.stringify would write `null` to storage.
       const manager = createManager({
-        maxUserSessionDurationSeconds: Number.NaN,
+        userSessionMaxDurationSeconds: Number.NaN,
       });
       manager.startSessionPartInternal('init');
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(43200);
     });
 
-    it('should fall back to default when maxUserSessionDurationSeconds is Infinity', () => {
+    it('should fall back to default when userSessionMaxDurationSeconds is Infinity', () => {
       const manager = createManager({
-        maxUserSessionDurationSeconds: Number.POSITIVE_INFINITY,
+        userSessionMaxDurationSeconds: Number.POSITIVE_INFINITY,
       });
       manager.startSessionPartInternal('init');
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(43200);
     });
 
-    it('should fall back to default when inactivityTimeoutSeconds is NaN', () => {
-      const manager = createManager({ inactivityTimeoutSeconds: Number.NaN });
+    it('should fall back to default when userSessionInactivityTimeoutSeconds is NaN', () => {
+      const manager = createManager({
+        userSessionInactivityTimeoutSeconds: Number.NaN,
+      });
       manager.startSessionPartInternal('init');
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
@@ -660,8 +668,8 @@ describe('EmbraceUserSessionManager', () => {
 
     it('should diag.warn when a config value is rejected so dropped config is visible to developers', () => {
       const manager = createManager({
-        maxUserSessionDurationSeconds: 60,
-        inactivityTimeoutSeconds: Number.NaN,
+        userSessionMaxDurationSeconds: 60,
+        userSessionInactivityTimeoutSeconds: Number.NaN,
       });
       // Durations are resolved lazily at user-session creation, so the
       // clamp warnings only fire once a part starts.
@@ -683,8 +691,8 @@ describe('EmbraceUserSessionManager', () => {
     it('should fall back to default inactivity when configured inactivity exceeds max duration', () => {
       // max = 1h, inactivity = 2h (both inside their own min/max range, but inactivity > max)
       const manager = createManager({
-        maxUserSessionDurationSeconds: 3600,
-        inactivityTimeoutSeconds: 7200,
+        userSessionMaxDurationSeconds: 3600,
+        userSessionInactivityTimeoutSeconds: 7200,
       });
       manager.startSessionPartInternal('init');
       const attrs = manager.getUserSessionAttributes();
@@ -696,15 +704,15 @@ describe('EmbraceUserSessionManager', () => {
 
     it('should diag.warn when configured inactivity exceeds max duration so the fallback is visible', () => {
       const manager = createManager({
-        maxUserSessionDurationSeconds: 3600,
-        inactivityTimeoutSeconds: 7200,
+        userSessionMaxDurationSeconds: 3600,
+        userSessionInactivityTimeoutSeconds: 7200,
       });
       manager.startSessionPartInternal('init');
 
       expect(
         diag
           .getWarnLogs()
-          .some((l) => l.includes('exceeds maxUserSessionDurationSeconds')),
+          .some((l) => l.includes('exceeds userSessionMaxDurationSeconds')),
         'expected diag.warn when inactivity exceeds max duration',
       ).to.equal(true);
     });
@@ -756,8 +764,8 @@ describe('EmbraceUserSessionManager', () => {
       // Equal max + inactivity so the max-duration timer (armed first) fires
       // before the part-inactivity timer, matching the lifecycle suite.
       const { manager, refreshRemoteConfig } = createManagerWithLiveConfig({
-        maxUserSessionDurationSeconds: 3600,
-        inactivityTimeoutSeconds: 3600,
+        userSessionMaxDurationSeconds: 3600,
+        userSessionInactivityTimeoutSeconds: 3600,
       });
 
       manager.startSessionPartInternal('init');
@@ -830,7 +838,9 @@ describe('EmbraceUserSessionManager', () => {
     });
 
     it('should write the inactivity deadline onto the state row when a non-final part ends', () => {
-      const manager = createManager({ inactivityTimeoutSeconds: 120 });
+      const manager = createManager({
+        userSessionInactivityTimeoutSeconds: 120,
+      });
       manager.startSessionPartInternal('init');
       clock.tick(10 * 1000);
       // web_background keeps the user session alive and writes the
@@ -855,7 +865,7 @@ describe('EmbraceUserSessionManager', () => {
 
     it('should not expire on inactivity when recovering a session with no prior part-end', () => {
       const manager1 = createManager({
-        maxUserSessionDurationSeconds: 12 * 60 * 60,
+        userSessionMaxDurationSeconds: 12 * 60 * 60,
       });
       manager1.startSessionPartInternal('init');
       const attrs1 = manager1.getUserSessionAttributes();
@@ -869,7 +879,7 @@ describe('EmbraceUserSessionManager', () => {
       clock.tick(60 * 60 * 1000);
 
       const manager2 = createManager({
-        maxUserSessionDurationSeconds: 12 * 60 * 60,
+        userSessionMaxDurationSeconds: 12 * 60 * 60,
       });
       manager2.startSessionPartInternal('init');
       const attrs2 = manager2.getUserSessionAttributes();
@@ -883,7 +893,7 @@ describe('EmbraceUserSessionManager', () => {
   describe('durations frozen per user session', () => {
     it('keeps the active session on its frozen inactivity timeout but applies config changes to the next session', () => {
       const { manager, config } = createManagerWithLiveConfig({
-        inactivityTimeoutSeconds: 120,
+        userSessionInactivityTimeoutSeconds: 120,
       });
 
       manager.startSessionPartInternal('init');
@@ -894,7 +904,7 @@ describe('EmbraceUserSessionManager', () => {
       ).to.equal(120);
 
       // A mid-session remote-config change must not shift the active session.
-      config.inactivityTimeoutSeconds = 600;
+      config.userSessionInactivityTimeoutSeconds = 600;
       clock.tick(10 * 1000);
       manager.endSessionPartInternal('web_background');
       // The persisted deadline uses the frozen 120s, not the live 600s.
@@ -915,7 +925,7 @@ describe('EmbraceUserSessionManager', () => {
 
     it('keeps the active session on its frozen max duration but applies config changes to the next session', () => {
       const { manager, config } = createManagerWithLiveConfig({
-        maxUserSessionDurationSeconds: 3600,
+        userSessionMaxDurationSeconds: 3600,
       });
 
       manager.startSessionPartInternal('init');
@@ -926,7 +936,7 @@ describe('EmbraceUserSessionManager', () => {
       ).to.equal(3600);
 
       // A mid-session remote-config change must not shift the active session.
-      config.maxUserSessionDurationSeconds = 7200;
+      config.userSessionMaxDurationSeconds = 7200;
       expect(
         manager.getUserSessionAttributes()?.[
           'emb.user_session_max_duration_seconds'
@@ -975,7 +985,7 @@ describe('EmbraceUserSessionManager', () => {
   describe('clock anomaly: jump forward past userSessionMaxEndTs', () => {
     it('should detect a forward clock jump as an expired session on the next part start', () => {
       const manager1 = createManager({
-        maxUserSessionDurationSeconds: 60 * 60,
+        userSessionMaxDurationSeconds: 60 * 60,
       });
       manager1.startSessionPartInternal('init');
       const attrs1 = manager1.getUserSessionAttributes();
@@ -989,7 +999,7 @@ describe('EmbraceUserSessionManager', () => {
       clock.tick(60 * 60 * 1000 + 1);
 
       const manager2 = createManager({
-        maxUserSessionDurationSeconds: 60 * 60,
+        userSessionMaxDurationSeconds: 60 * 60,
       });
       manager2.startSessionPartInternal('init');
       const attrs2 = manager2.getUserSessionAttributes();

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -1,15 +1,19 @@
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import {
+  createTestDynamicConfigManager,
   InMemoryDiagLogger,
   InMemoryStorage,
   MockPerformanceManager,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../tests/utils/index.ts';
 import type {
   SessionPartEndReason,
   UserSessionEndReason,
 } from '../../api-sessions/index.ts';
+import type { DynamicSDKConfig } from '../../sdk/index.ts';
 import { NamespacedStorage } from '../../utils/NamespacedStorage/NamespacedStorage.ts';
 import {
   DEFAULT_LIMITS,
@@ -63,8 +67,30 @@ describe('EmbraceUserSessionManager', () => {
       storage,
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
       visibilityDoc: window.document,
-      config,
+      dynamicConfigManager: createTestDynamicConfigManager(config),
     });
+
+  // Builds a manager whose getConfig() reads a live, mutable config object so a
+  // test can change remote-config values mid-session. getConfig returns a fresh
+  // copy each call so mutations are picked up at the next session creation.
+  const createManagerWithLiveConfig = (
+    config: Partial<DynamicSDKConfig> = {},
+  ) => {
+    const refreshRemoteConfig = sinon.stub();
+    const manager = new EmbraceUserSessionManager({
+      diag,
+      perf: new MockPerformanceManager(clock),
+      storage,
+      limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      visibilityDoc: window.document,
+      dynamicConfigManager: {
+        refreshRemoteConfig,
+        setConfig: sinon.stub(),
+        getConfig: () => ({ samplingPct: 100, ...config }),
+      },
+    });
+    return { manager, config, refreshRemoteConfig };
+  };
 
   it('should create a session on first part start', () => {
     const manager = createManager();
@@ -260,6 +286,7 @@ describe('EmbraceUserSessionManager', () => {
       storage: safeFailing,
       limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
       visibilityDoc: window.document,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
 
     manager.startSessionPartInternal('init');
@@ -632,10 +659,13 @@ describe('EmbraceUserSessionManager', () => {
     });
 
     it('should diag.warn when a config value is rejected so dropped config is visible to developers', () => {
-      createManager({
+      const manager = createManager({
         maxUserSessionDurationSeconds: 60,
         inactivityTimeoutSeconds: Number.NaN,
       });
+      // Durations are resolved lazily at user-session creation, so the
+      // clamp warnings only fire once a part starts.
+      manager.startSessionPartInternal('init');
 
       const warnLogs = diag.getWarnLogs();
       expect(
@@ -662,6 +692,89 @@ describe('EmbraceUserSessionManager', () => {
       expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
         1800,
       );
+    });
+
+    it('should diag.warn when configured inactivity exceeds max duration so the fallback is visible', () => {
+      const manager = createManager({
+        maxUserSessionDurationSeconds: 3600,
+        inactivityTimeoutSeconds: 7200,
+      });
+      manager.startSessionPartInternal('init');
+
+      expect(
+        diag
+          .getWarnLogs()
+          .some((l) => l.includes('exceeds maxUserSessionDurationSeconds')),
+        'expected diag.warn when inactivity exceeds max duration',
+      ).to.equal(true);
+    });
+  });
+
+  describe('remote config refresh on new user session', () => {
+    it('refreshes remote config for each new user session after cold start, but not on cold start itself', () => {
+      const { manager, refreshRemoteConfig } = createManagerWithLiveConfig();
+
+      // The cold-start user session relies on initSDK's startup refresh, so
+      // the manager must not issue its own redundant fetch here.
+      manager.startSessionPartInternal('init');
+      expect(refreshRemoteConfig.callCount).to.equal(0);
+
+      // Ending the user session rolls over into a fresh one, which should
+      // trigger a refresh so the new session can pick up updated values.
+      manager.endUserSession();
+      expect(refreshRemoteConfig.callCount).to.equal(1);
+
+      // A third user session refreshes again (cooldown cleared first).
+      clock.tick(6 * 1000);
+      manager.endUserSession();
+      expect(refreshRemoteConfig.callCount).to.equal(2);
+    });
+
+    it('does not refresh on a continuing part within the same user session', () => {
+      const { manager, refreshRemoteConfig } = createManagerWithLiveConfig();
+
+      manager.startSessionPartInternal('init');
+      manager.endSessionPartInternal('web_background');
+      clock.tick(60 * 1000); // within the default inactivity timeout
+      manager.startSessionPartInternal('init'); // same session continues
+
+      expect(refreshRemoteConfig.callCount).to.equal(0);
+    });
+
+    it('refreshes when the inactivity timeout expires into a new user session', () => {
+      const { manager, refreshRemoteConfig } = createManagerWithLiveConfig();
+
+      manager.startSessionPartInternal('init');
+      manager.endSessionPartInternal('web_background');
+      clock.tick(31 * 60 * 1000); // past the default 30 min inactivity timeout
+      manager.startSessionPartInternal('init'); // fresh session
+
+      expect(refreshRemoteConfig.callCount).to.equal(1);
+    });
+
+    it('refreshes when the max-duration timer rolls the session over', () => {
+      // Equal max + inactivity so the max-duration timer (armed first) fires
+      // before the part-inactivity timer, matching the lifecycle suite.
+      const { manager, refreshRemoteConfig } = createManagerWithLiveConfig({
+        maxUserSessionDurationSeconds: 3600,
+        inactivityTimeoutSeconds: 3600,
+      });
+
+      manager.startSessionPartInternal('init');
+      clock.tick(3601 * 1000); // fire max-duration timer -> rollover
+
+      expect(refreshRemoteConfig.callCount).to.equal(1);
+    });
+
+    it('does not refresh on the cold-start session created eagerly by setTracerProvider', () => {
+      const { manager, refreshRemoteConfig } = createManagerWithLiveConfig();
+
+      // setTracerProvider eagerly creates the cold-start session before any
+      // part starts. That creation must rely on initSDK's startup refresh, not
+      // issue its own redundant fetch.
+      manager.setTracerProvider(new WebTracerProvider());
+
+      expect(refreshRemoteConfig.callCount).to.equal(0);
     });
   });
 
@@ -764,6 +877,75 @@ describe('EmbraceUserSessionManager', () => {
       expect(attrs2?.['emb.user_session_id']).to.equal(
         attrs1?.['emb.user_session_id'],
       );
+    });
+  });
+
+  describe('durations frozen per user session', () => {
+    it('keeps the active session on its frozen inactivity timeout but applies config changes to the next session', () => {
+      const { manager, config } = createManagerWithLiveConfig({
+        inactivityTimeoutSeconds: 120,
+      });
+
+      manager.startSessionPartInternal('init');
+      expect(
+        manager.getUserSessionAttributes()?.[
+          'emb.user_session_inactivity_timeout_seconds'
+        ],
+      ).to.equal(120);
+
+      // A mid-session remote-config change must not shift the active session.
+      config.inactivityTimeoutSeconds = 600;
+      clock.tick(10 * 1000);
+      manager.endSessionPartInternal('web_background');
+      // The persisted deadline uses the frozen 120s, not the live 600s.
+      expect(readStoredDeadline()).to.equal(10 * 1000 + 120 * 1000);
+
+      // Rolling into a fresh session resolves durations again, picking up 600s.
+      clock.tick(3 * 60 * 1000); // past the frozen 120s deadline -> expired
+      manager.startSessionPartInternal('init');
+      expect(
+        manager.getUserSessionAttributes()?.[
+          'emb.user_session_inactivity_timeout_seconds'
+        ],
+      ).to.equal(600);
+      expect(
+        manager.getUserSessionAttributes()?.['emb.user_session_number'],
+      ).to.equal(2);
+    });
+
+    it('keeps the active session on its frozen max duration but applies config changes to the next session', () => {
+      const { manager, config } = createManagerWithLiveConfig({
+        maxUserSessionDurationSeconds: 3600,
+      });
+
+      manager.startSessionPartInternal('init');
+      expect(
+        manager.getUserSessionAttributes()?.[
+          'emb.user_session_max_duration_seconds'
+        ],
+      ).to.equal(3600);
+
+      // A mid-session remote-config change must not shift the active session.
+      config.maxUserSessionDurationSeconds = 7200;
+      expect(
+        manager.getUserSessionAttributes()?.[
+          'emb.user_session_max_duration_seconds'
+        ],
+      ).to.equal(3600);
+
+      // Inactivity expiry rolls into a fresh session, which resolves durations
+      // again and picks up the changed 7200s max.
+      manager.endSessionPartInternal('web_background');
+      clock.tick(31 * 60 * 1000); // past the default 30 min inactivity timeout
+      manager.startSessionPartInternal('init');
+      expect(
+        manager.getUserSessionAttributes()?.[
+          'emb.user_session_max_duration_seconds'
+        ],
+      ).to.equal(7200);
+      expect(
+        manager.getUserSessionAttributes()?.['emb.user_session_number'],
+      ).to.equal(2);
     });
   });
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -168,38 +168,42 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
    * state.
    */
   private _resolveUserSessionDurations(): {
-    maxUserSessionDurationSeconds: number;
-    inactivityTimeoutSeconds: number;
+    userSessionMaxDurationSeconds: number;
+    userSessionInactivityTimeoutSeconds: number;
   } {
     const config = this._dynamicConfigManager.getConfig();
 
-    const maxUserSessionDurationSeconds = clampNumber({
+    const userSessionMaxDurationSeconds = clampNumber({
       diag: this._diag,
-      value: config.maxUserSessionDurationSeconds,
+      value: config.userSessionMaxDurationSeconds,
       defaultValue: DEFAULT_USER_SESSION_MAX_DURATION_SECONDS,
       min: MIN_USER_SESSION_MAX_DURATION_SECONDS,
       max: MAX_USER_SESSION_MAX_DURATION_SECONDS,
     });
-    const inactivityTimeoutSeconds = clampNumber({
+    const userSessionInactivityTimeoutSeconds = clampNumber({
       diag: this._diag,
-      value: config.inactivityTimeoutSeconds,
+      value: config.userSessionInactivityTimeoutSeconds,
       defaultValue: DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
       min: MIN_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
       max: MAX_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
     });
 
-    if (inactivityTimeoutSeconds <= maxUserSessionDurationSeconds) {
-      return { maxUserSessionDurationSeconds, inactivityTimeoutSeconds };
+    if (userSessionInactivityTimeoutSeconds <= userSessionMaxDurationSeconds) {
+      return {
+        userSessionMaxDurationSeconds,
+        userSessionInactivityTimeoutSeconds,
+      };
     }
 
     this._diag.warn(
-      `inactivityTimeoutSeconds (${inactivityTimeoutSeconds.toString()}s) ` +
-        `exceeds maxUserSessionDurationSeconds (${maxUserSessionDurationSeconds.toString()}s); ` +
+      `userSessionInactivityTimeoutSeconds (${userSessionInactivityTimeoutSeconds.toString()}s) ` +
+        `exceeds userSessionMaxDurationSeconds (${userSessionMaxDurationSeconds.toString()}s); ` +
         `falling back to default inactivity timeout (${DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS.toString()}s).`,
     );
     return {
-      maxUserSessionDurationSeconds,
-      inactivityTimeoutSeconds: DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
+      userSessionMaxDurationSeconds,
+      userSessionInactivityTimeoutSeconds:
+        DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
     };
   }
 
@@ -263,9 +267,9 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
       [KEY_EMB_SESSION_PART_NUMBER]: this._currentSessionPartNumber ?? 0,
       [KEY_EMB_USER_SESSION_START_TS]: this._state.userSessionStartTs,
       [KEY_EMB_USER_SESSION_MAX_DURATION_SECONDS]:
-        this._state.maxUserSessionDurationSeconds,
+        this._state.userSessionMaxDurationSeconds,
       [KEY_EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS]:
-        this._state.inactivityTimeoutSeconds,
+        this._state.userSessionInactivityTimeoutSeconds,
     };
   }
 
@@ -632,13 +636,15 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
       if (!this._coldStart) {
         void this._dynamicConfigManager.refreshRemoteConfig();
       }
-      const { maxUserSessionDurationSeconds, inactivityTimeoutSeconds } =
-        this._resolveUserSessionDurations();
+      const {
+        userSessionMaxDurationSeconds,
+        userSessionInactivityTimeoutSeconds,
+      } = this._resolveUserSessionDurations();
       state = createUserSessionState({
         now,
         previousUserSessionId: this._previousUserSessionId,
-        maxUserSessionDurationSeconds,
-        inactivityTimeoutSeconds,
+        userSessionMaxDurationSeconds,
+        userSessionInactivityTimeoutSeconds,
         userSessionNumber,
       });
       created = true;
@@ -709,7 +715,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     this._state = {
       ...this._state,
       inactivityDeadlineTs:
-        partEndTs + this._state.inactivityTimeoutSeconds * 1000,
+        partEndTs + this._state.userSessionInactivityTimeoutSeconds * 1000,
     };
     this._storeState();
   }
@@ -867,7 +873,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     }
     this._sessionPartInactivityTimer = setTimeout(
       this._onSessionPartInactivity,
-      this._state.inactivityTimeoutSeconds * 1000,
+      this._state.userSessionInactivityTimeoutSeconds * 1000,
     );
   }
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -39,6 +39,7 @@ import {
   KEY_PREFIX_EMB_PROPERTIES,
 } from '../../constants/index.ts';
 import type { ExtendedSpan } from '../../index.ts';
+import type { DynamicConfigManager } from '../../sdk/index.ts';
 import type {
   NamespacedStorage,
   PerformanceManager,
@@ -94,8 +95,6 @@ import {
 export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   private _state: UserSessionState | null = null;
   private _previousUserSessionId: string | null = null;
-  private readonly _maxUserSessionDurationSeconds: number;
-  private readonly _inactivityTimeoutSeconds: number;
   private _maxDurationTimeout: ReturnType<typeof setTimeout> | null = null;
   // Bare keys; the wire-format prefix is applied at stamp time.
   private _permanentProperties: Record<string, string> = {};
@@ -125,13 +124,14 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   private readonly _storage: NamespacedStorage;
   private readonly _visibilityDoc: VisibilityStateDocument;
   private readonly _limitManager: LimitManagerInternal;
+  private readonly _dynamicConfigManager: DynamicConfigManager;
   private readonly _target: EventTarget;
   private readonly _activityEvents: ReadonlyArray<string>;
   private readonly _onActivityThrottled: (event: Event) => void;
   private _sessionPartInactivityTimer: TimeoutRef | null = null;
 
   public constructor({
-    config,
+    dynamicConfigManager,
     diag: diagParam,
     perf,
     visibilityDoc,
@@ -150,6 +150,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     this._visibilityDoc = visibilityDoc;
     this._storage = storage;
     this._limitManager = limitManager;
+    this._dynamicConfigManager = dynamicConfigManager;
     this._permanentProperties = readPermanentProperties(
       this._storage,
       this._diag,
@@ -158,34 +159,48 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     this._target = target;
     this._activityEvents = activityEvents;
     this._onActivityThrottled = throttle(this._onActivity, activityThrottleMs);
+  }
+
+  /**
+   * Reads the user-session durations from remote config, clamps each to its
+   * allowed range, and enforces inactivity <= max duration. Called once per
+   * user-session creation; the resolved values are frozen into that session's
+   * state.
+   */
+  private _resolveUserSessionDurations(): {
+    maxUserSessionDurationSeconds: number;
+    inactivityTimeoutSeconds: number;
+  } {
+    const config = this._dynamicConfigManager.getConfig();
 
     const maxUserSessionDurationSeconds = clampNumber({
       diag: this._diag,
-      value: config?.maxUserSessionDurationSeconds,
+      value: config.maxUserSessionDurationSeconds,
       defaultValue: DEFAULT_USER_SESSION_MAX_DURATION_SECONDS,
       min: MIN_USER_SESSION_MAX_DURATION_SECONDS,
       max: MAX_USER_SESSION_MAX_DURATION_SECONDS,
     });
     const inactivityTimeoutSeconds = clampNumber({
       diag: this._diag,
-      value: config?.inactivityTimeoutSeconds,
+      value: config.inactivityTimeoutSeconds,
       defaultValue: DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
       min: MIN_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
       max: MAX_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
     });
 
-    this._maxUserSessionDurationSeconds = maxUserSessionDurationSeconds;
     if (inactivityTimeoutSeconds <= maxUserSessionDurationSeconds) {
-      this._inactivityTimeoutSeconds = inactivityTimeoutSeconds;
-    } else {
-      this._diag.warn(
-        `inactivityTimeoutSeconds (${inactivityTimeoutSeconds.toString()}s) ` +
-          `exceeds maxUserSessionDurationSeconds (${maxUserSessionDurationSeconds.toString()}s); ` +
-          `falling back to default inactivity timeout (${DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS.toString()}s).`,
-      );
-      this._inactivityTimeoutSeconds =
-        DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS;
+      return { maxUserSessionDurationSeconds, inactivityTimeoutSeconds };
     }
+
+    this._diag.warn(
+      `inactivityTimeoutSeconds (${inactivityTimeoutSeconds.toString()}s) ` +
+        `exceeds maxUserSessionDurationSeconds (${maxUserSessionDurationSeconds.toString()}s); ` +
+        `falling back to default inactivity timeout (${DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS.toString()}s).`,
+    );
+    return {
+      maxUserSessionDurationSeconds,
+      inactivityTimeoutSeconds: DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
+    };
   }
 
   public setTracerProvider(tracerProvider: TracerProvider): void {
@@ -610,11 +625,20 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
         EMBRACE_USER_SESSION_NUMBER_KEY,
         this._diag,
       );
+      // Refresh remote config for the next user session. The fetch is async,
+      // so it lands in the cache after this session's durations are frozen
+      // below; this session uses the currently cached config. Skipped on cold
+      // start, where initSDK already refreshes at startup.
+      if (!this._coldStart) {
+        void this._dynamicConfigManager.refreshRemoteConfig();
+      }
+      const { maxUserSessionDurationSeconds, inactivityTimeoutSeconds } =
+        this._resolveUserSessionDurations();
       state = createUserSessionState({
         now,
         previousUserSessionId: this._previousUserSessionId,
-        maxUserSessionDurationSeconds: this._maxUserSessionDurationSeconds,
-        inactivityTimeoutSeconds: this._inactivityTimeoutSeconds,
+        maxUserSessionDurationSeconds,
+        inactivityTimeoutSeconds,
         userSessionNumber,
       });
       created = true;
@@ -836,9 +860,14 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
 
   private _startSessionPartInactivityTimer(): void {
     this._clearSessionPartInactivityTimer();
+    // Callers only arm this with an active part, so the early return is a type
+    // guard rather than a live path.
+    if (!this._state) {
+      return;
+    }
     this._sessionPartInactivityTimer = setTimeout(
       this._onSessionPartInactivity,
-      this._inactivityTimeoutSeconds * 1000,
+      this._state.inactivityTimeoutSeconds * 1000,
     );
   }
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -193,11 +193,12 @@ silently no-ops if not (the next engagement event will create it).
 | Activity throttle | `ACTIVITY_THROTTLE_MS` | 30 seconds | n/a | At most one inactivity-timer reset per 30 seconds of input. |
 | `endUserSession` cooldown | `END_USER_SESSION_COOLDOWN_MS` | 5 seconds | n/a | Calls within 5 seconds of the last call are silently ignored. |
 
-Both `maxUserSessionDurationSeconds` and `inactivityTimeoutSeconds` are clamped to their
-respective ranges at construction; out-of-range values fall back to the
-default and emit a warning. In addition, `inactivityTimeoutSeconds` must be
-`<=` `maxUserSessionDurationSeconds`; if a caller violates that, the inactivity timeout falls
-back to its **default**, not to the max-duration value.
+Both `maxUserSessionDurationSeconds` and `inactivityTimeoutSeconds` are driven by
+remote config (`DynamicConfigManager.getConfig()`), read at each user-session
+creation. Each value is clamped to its respective range; out-of-range values fall
+back to the default and emit a warning. In addition, `inactivityTimeoutSeconds`
+must be `<=` `maxUserSessionDurationSeconds`; if remote config violates that, the
+inactivity timeout falls back to its **default**, not to the max-duration value.
 
 The max-duration timer is armed on session-part start AND re-armed after
 session-part end, so it runs even between parts. The delay is computed as
@@ -218,8 +219,12 @@ The part-inactivity timer is restarted on every activity event, subject to the
 | `emb.properties.<key>` | String value. | Persisted across visits. Survives user-session boundaries. |
 
 `maxUserSessionDurationSeconds` and `inactivityTimeoutSeconds` are frozen into the state blob at
-session creation. A config change between page loads does not affect a user
-session already in progress.
+session creation. A remote-config change does not affect a user session already
+in progress. It takes effect when the next user session is created. To keep the
+cached config current, the manager fires a remote-config refresh whenever it
+creates a new user session (except on cold start, where `initSDK` already
+refreshes at startup). That fetch is async, so its result lands in the cache for
+the following user session rather than the one being created.
 
 ### Failure handling
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -120,7 +120,7 @@ On end, the manager:
    `_activeSessionPartId`, and `_activeSessionPartCounts`.
 4. If `reason !== 'user_session_ended'`, calls
    `_continueUserSessionAfterPartEnd(partEndTs)` which writes
-   `partEndTs + inactivityTimeoutSeconds * 1000` into the state blob's
+   `partEndTs + userSessionInactivityTimeoutSeconds * 1000` into the state blob's
    `inactivityDeadlineTs` and re-arms the max-duration timer.
 
 When `reason === 'user_session_ended'` the manager also stamps
@@ -188,16 +188,16 @@ silently no-ops if not (the next engagement event will create it).
 | Timer | Constant | Default | Range | Effect on fire |
 | --- | --- | --- | --- | --- |
 | Max duration | `DEFAULT_USER_SESSION_MAX_DURATION_SECONDS` | 12 hours | `MIN_USER_SESSION_MAX_DURATION_SECONDS` (1h) to `MAX_USER_SESSION_MAX_DURATION_SECONDS` (24h) | `_terminateUserSession('max_duration_reached')` |
-| User-session inactivity (lazy) | `DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` | 30 minutes | `MIN_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (30s) to `MAX_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (24h) | Not a live timer. The configured value is written into the state blob as `inactivityTimeoutSeconds`, and `_continueUserSessionAfterPartEnd` records `partEndTs + inactivityTimeoutSeconds * 1000` into `inactivityDeadlineTs`. Checked on the next part start by `_isExpired`. |
+| User-session inactivity (lazy) | `DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` | 30 minutes | `MIN_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (30s) to `MAX_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (24h) | Not a live timer. The configured value is written into the state blob as `userSessionInactivityTimeoutSeconds`, and `_continueUserSessionAfterPartEnd` records `partEndTs + userSessionInactivityTimeoutSeconds * 1000` into `inactivityDeadlineTs`. Checked on the next part start by `_isExpired`. |
 | Part inactivity | `PART_INACTIVITY_TIMEOUT_MS` | 30 minutes | n/a | `endSessionPartInternal('web_inactivity')` |
 | Activity throttle | `ACTIVITY_THROTTLE_MS` | 30 seconds | n/a | At most one inactivity-timer reset per 30 seconds of input. |
 | `endUserSession` cooldown | `END_USER_SESSION_COOLDOWN_MS` | 5 seconds | n/a | Calls within 5 seconds of the last call are silently ignored. |
 
-Both `maxUserSessionDurationSeconds` and `inactivityTimeoutSeconds` are driven by
+Both `userSessionMaxDurationSeconds` and `userSessionInactivityTimeoutSeconds` are driven by
 remote config (`DynamicConfigManager.getConfig()`), read at each user-session
 creation. Each value is clamped to its respective range; out-of-range values fall
-back to the default and emit a warning. In addition, `inactivityTimeoutSeconds`
-must be `<=` `maxUserSessionDurationSeconds`; if remote config violates that, the
+back to the default and emit a warning. In addition, `userSessionInactivityTimeoutSeconds`
+must be `<=` `userSessionMaxDurationSeconds`; if remote config violates that, the
 inactivity timeout falls back to its **default**, not to the max-duration value.
 
 The max-duration timer is armed on session-part start AND re-armed after
@@ -218,7 +218,7 @@ The part-inactivity timer is restarted on every activity event, subject to the
 | `embrace_session_part_number` | Monotonic integer string. | Persisted across visits. Bumped at every session-part start. |
 | `emb.properties.<key>` | String value. | Persisted across visits. Survives user-session boundaries. |
 
-`maxUserSessionDurationSeconds` and `inactivityTimeoutSeconds` are frozen into the state blob at
+`userSessionMaxDurationSeconds` and `userSessionInactivityTimeoutSeconds` are frozen into the state blob at
 session creation. A remote-config change does not affect a user session already
 in progress. It takes effect when the next user session is created. To keep the
 cached config current, the manager fires a remote-config refresh whenever it

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/index.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/index.ts
@@ -1,9 +1,2 @@
-export {
-  DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
-  DEFAULT_USER_SESSION_MAX_DURATION_SECONDS,
-} from './constants.ts';
 export { EmbraceUserSessionManager } from './EmbraceUserSessionManager.ts';
-export type {
-  UserSessionConfig,
-  UserSessionManagerInternal,
-} from './types.ts';
+export type { UserSessionManagerInternal } from './types.ts';

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
@@ -36,11 +36,11 @@ export interface UserSessionState {
    * Configured values captured and locked at session creation, persisted
    * so they survive page reloads.
    */
-  readonly maxUserSessionDurationSeconds: number;
-  readonly inactivityTimeoutSeconds: number;
+  readonly userSessionMaxDurationSeconds: number;
+  readonly userSessionInactivityTimeoutSeconds: number;
   /**
    * Absolute timestamp after which the session expires from inactivity
-   * (`part_end_ts + inactivityTimeoutSeconds * 1000`). Set on part-end;
+   * (`part_end_ts + userSessionInactivityTimeoutSeconds * 1000`). Set on part-end;
    * null while a part is active. Checked lazily on the next part start.
    */
   readonly inactivityDeadlineTs: number | null;

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../api-sessions/manager/types.ts';
 import type { VisibilityStateDocument } from '../../common/index.ts';
 import type { ExtendedSpan } from '../../index.ts';
+import type { DynamicConfigManager } from '../../sdk/index.ts';
 import type {
   NamespacedStorage,
   PerformanceManager,
@@ -52,11 +53,6 @@ export interface UserSessionState {
    * when stamping the part span. Cleared on user-session end.
    */
   readonly userSessionProperties: Record<string, string>;
-}
-
-export interface UserSessionConfig {
-  maxUserSessionDurationSeconds?: number;
-  inactivityTimeoutSeconds?: number;
 }
 
 /** Attributes emitted by the user-session layer. */
@@ -135,7 +131,11 @@ export interface EmbraceUserSessionManagerArgs {
   diag?: DiagLogger;
   perf: PerformanceManager;
   storage: NamespacedStorage;
-  config?: UserSessionConfig;
+  /**
+   * Source of the user-session durations (max duration, inactivity timeout),
+   * which are driven by remote config and resolved at each session creation.
+   */
+  dynamicConfigManager: DynamicConfigManager;
   /**
    * Document-shaped object used to gate part start/end on visibility +
    * focus.

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/utils/state.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/utils/state.ts
@@ -26,27 +26,27 @@ export const isUserSessionExpired = (
 export interface CreateUserSessionStateArgs {
   now: number;
   previousUserSessionId: string | null;
-  maxUserSessionDurationSeconds: number;
-  inactivityTimeoutSeconds: number;
+  userSessionMaxDurationSeconds: number;
+  userSessionInactivityTimeoutSeconds: number;
   userSessionNumber: number;
 }
 
 export const createUserSessionState = ({
   now,
   previousUserSessionId,
-  maxUserSessionDurationSeconds,
-  inactivityTimeoutSeconds,
+  userSessionMaxDurationSeconds,
+  userSessionInactivityTimeoutSeconds,
   userSessionNumber,
 }: CreateUserSessionStateArgs): UserSessionState => ({
   schemaVersion: USER_SESSION_STATE_SCHEMA_VERSION,
   userSessionId: generateUUID(),
   previousUserSessionId,
   userSessionStartTs: now,
-  userSessionMaxEndTs: now + maxUserSessionDurationSeconds * 1000,
+  userSessionMaxEndTs: now + userSessionMaxDurationSeconds * 1000,
   userSessionNumber,
   userSessionPartIndex: 0,
-  maxUserSessionDurationSeconds,
-  inactivityTimeoutSeconds,
+  userSessionMaxDurationSeconds,
+  userSessionInactivityTimeoutSeconds,
   inactivityDeadlineTs: null,
   userSessionProperties: {},
 });

--- a/packages/web-sdk/src/managers/index.ts
+++ b/packages/web-sdk/src/managers/index.ts
@@ -15,8 +15,5 @@ export {
   EmbraceTraceManager,
 } from './EmbraceTraceManager/index.ts';
 export { EmbraceUserManager } from './EmbraceUserManager/index.ts';
-export type {
-  UserSessionConfig,
-  UserSessionManagerInternal,
-} from './EmbraceUserSessionManager/index.ts';
+export type { UserSessionManagerInternal } from './EmbraceUserSessionManager/index.ts';
 export { EmbraceUserSessionManager } from './EmbraceUserSessionManager/index.ts';

--- a/packages/web-sdk/src/processors/EmbraceSessionPartBatchedSpanProcessor/EmbraceSessionPartBatchedSpanProcessor.test.ts
+++ b/packages/web-sdk/src/processors/EmbraceSessionPartBatchedSpanProcessor/EmbraceSessionPartBatchedSpanProcessor.test.ts
@@ -9,6 +9,7 @@ import {
   InMemoryDiagLogger,
   setupTestStorage,
   setupTestTraceExporter,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../tests/utils/index.ts';
 import {
   mockNetworkRequestSpan,
@@ -69,6 +70,7 @@ describe('EmbraceSessionPartBatchedSpanProcessor', () => {
     });
 
     userSessionManager = new EmbraceUserSessionManager({
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       limitManager,
       perf: new OTelPerformanceManager(),
       storage: setupTestStorage(),

--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -22,9 +22,9 @@ import {
   FakeInstrumentation,
   FakeLogRecordProcessor,
   FakeSpanProcessor,
-  fakeFetchGetBody,
-  fakeFetchGetRequestHeaders,
-  fakeFetchGetUrl,
+  fakeFetchGetConfigUrl,
+  fakeFetchGetSpansBody,
+  fakeFetchGetSpansRequestHeaders,
   fakeFetchInstall,
   fakeFetchResetHistory,
   fakeFetchRespondWith,
@@ -108,13 +108,15 @@ const otlpAttrsToRecord = (
 };
 
 const getLastSessionExportedSpans = async (
-  callNumber = 0,
+  spansExportNumber = 0,
   scope: SpanScope = { name: 'embrace-web-sdk-traces' },
 ) => {
   // Needed to allow the transport to actually send its data off to fetch
   await new Promise((r) => setTimeout(r, 1));
 
-  const body = fakeFetchGetBody(callNumber);
+  // Address the export by its position among spans sends, skipping interleaved
+  // remote-config fetches and logs sends.
+  const body = fakeFetchGetSpansBody(spansExportNumber);
   void expect(body).not.to.be.null;
   const decompressedStream = new Response(body).body?.pipeThrough(
     new DecompressionStream('gzip'),
@@ -713,10 +715,10 @@ describe('initSDK', () => {
       // Needed to allow the transport to actually send its data off to fetch
       await new Promise((r) => setTimeout(r, 1));
 
-      const headers = fakeFetchGetRequestHeaders(1);
+      const headers = fakeFetchGetSpansRequestHeaders();
       expect((headers as Record<string, string>)['X-EM-AID']).to.equal('abc12');
 
-      const body = fakeFetchGetBody(1);
+      const body = fakeFetchGetSpansBody();
 
       void expect(body).not.to.be.null;
       const decompressedStream = new Response(body).body?.pipeThrough(
@@ -837,7 +839,7 @@ describe('initSDK', () => {
       // Needed to allow the transport to actually send its data off to fetch
       await new Promise((r) => setTimeout(r, 1));
 
-      const body = fakeFetchGetBody(1);
+      const body = fakeFetchGetSpansBody();
       void expect(body).not.to.be.null;
       const decompressedStream = new Response(body).body?.pipeThrough(
         new DecompressionStream('gzip'),
@@ -886,7 +888,7 @@ describe('initSDK', () => {
 
       session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
 
       expect(exportedSpans[0]['name']).to.be.equal('my performance span');
     });
@@ -917,7 +919,7 @@ describe('initSDK', () => {
 
       session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1000);
       for (let i = 0; i < exportedSpans.length; i++) {
         expect(exportedSpans[i]['name']).to.equal(`my-span-${i.toString()}`);
@@ -972,7 +974,7 @@ describe('initSDK', () => {
       span.end();
       session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
 
       const exportedEvents = exportedSpans[0].events;
@@ -1018,7 +1020,7 @@ describe('initSDK', () => {
       span.end();
       session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
 
       const exportedAttributes = exportedSpans[0].attributes;
@@ -1085,7 +1087,7 @@ describe('initSDK', () => {
       span.end();
       session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
 
       const exportedEvents = exportedSpans[0].events;
@@ -1141,7 +1143,7 @@ describe('initSDK', () => {
         await result.flush();
       }
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
       expect(exportedSpans[0].attributes[0]).to.deep.equal({
         key: 'url.full',
@@ -1218,7 +1220,7 @@ describe('initSDK', () => {
         await result.flush();
       }
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
       expect(exportedSpans[0].attributes[0]).to.deep.equal({
         key: 'url.full',
@@ -1298,7 +1300,7 @@ describe('initSDK', () => {
         await result.flush();
       }
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
       expect(exportedSpans[0].attributes[0]).to.deep.equal({
         key: 'url.full',
@@ -1349,7 +1351,7 @@ describe('initSDK', () => {
       void expect(result).not.to.be.false;
 
       void expect(fakeFetchWasCalled()).to.be.true;
-      expect(fakeFetchGetUrl()).to.contain(
+      expect(fakeFetchGetConfigUrl()).to.contain(
         'https://a-abc12.config.emb-api.com/v2/config?appId=abc12&osVersion=1&appVersion=my-app-version&deviceId=',
       );
     });
@@ -1375,7 +1377,7 @@ describe('initSDK', () => {
       void expect(result).not.to.be.false;
 
       void expect(fakeFetchWasCalled()).to.be.true;
-      expect(fakeFetchGetUrl()).to.contain(
+      expect(fakeFetchGetConfigUrl()).to.contain(
         'https://a-abc12.config.emb-api.com/v2/config?appId=abc12&osVersion=1&appVersion=EmbIOAppVersionX.X.X&deviceId=',
       );
     });
@@ -1802,16 +1804,13 @@ describe('initSDK', () => {
 
         // Need to restore the clock here so that the setTimeout in `getLastSessionExportedSpans` works
         clock.restore();
-        const exportedSpans = await getLastSessionExportedSpans(
-          test.networkType === 'fetch' ? 1 : 0,
-          {
-            name:
-              test.networkType === 'fetch'
-                ? '@opentelemetry/instrumentation-fetch'
-                : '@opentelemetry/instrumentation-xml-http-request',
-            version: '0.218.0',
-          },
-        );
+        const exportedSpans = await getLastSessionExportedSpans(0, {
+          name:
+            test.networkType === 'fetch'
+              ? '@opentelemetry/instrumentation-fetch'
+              : '@opentelemetry/instrumentation-xml-http-request',
+          version: '0.218.0',
+        });
         expect(exportedSpans).to.have.lengthOf(1);
         const networkSpan = exportedSpans[0];
         const expectedTraceparent = `00-${networkSpan.traceId}-${networkSpan.spanId}-01`;

--- a/packages/web-sdk/src/sdk/initSDK.ts
+++ b/packages/web-sdk/src/sdk/initSDK.ts
@@ -24,10 +24,6 @@ import {
   EmbraceTraceExporter,
 } from '../exporters/index.ts';
 import {
-  DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
-  DEFAULT_USER_SESSION_MAX_DURATION_SECONDS,
-} from '../managers/EmbraceUserSessionManager/index.ts';
-import {
   DEFAULT_LIMITS,
   EmbraceDynamicConfigManager,
   EmbraceLimitManager,
@@ -106,8 +102,6 @@ export const initSDK = (
     blockNetworkSpanForwarding = false,
     restrictedProtocols = new Set(['file:']),
     useDocumentTitleAsPageLabel = true,
-    maxUserSessionDurationSeconds = DEFAULT_USER_SESSION_MAX_DURATION_SECONDS,
-    inactivityTimeoutSeconds = DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
   }: SDKInitConfig = {} as SDKInitConfig,
 ): SDKControl | false => {
   try {
@@ -235,10 +229,7 @@ export const initSDK = (
       registerGlobally,
       sdkLocalStorage,
       visibilityDoc: window.document,
-      userSessionConfig: {
-        maxUserSessionDurationSeconds,
-        inactivityTimeoutSeconds,
-      },
+      dynamicConfigManager,
     });
 
     let embraceSpanProcessor:
@@ -386,14 +377,14 @@ const setupUserSession = ({
   registerGlobally,
   sdkLocalStorage,
   visibilityDoc,
-  userSessionConfig,
+  dynamicConfigManager,
 }: SetupUserSessionArgs) => {
   const embraceUserSessionManager = new EmbraceUserSessionManager({
     limitManager,
     perf,
     storage: sdkLocalStorage,
     visibilityDoc,
-    config: userSessionConfig,
+    dynamicConfigManager,
   });
 
   if (registerGlobally) {

--- a/packages/web-sdk/src/sdk/types.ts
+++ b/packages/web-sdk/src/sdk/types.ts
@@ -66,7 +66,7 @@ export interface DynamicSDKConfig {
    *
    * **default**: 43200 seconds (12 hours)
    */
-  maxUserSessionDurationSeconds?: number;
+  userSessionMaxDurationSeconds?: number;
 
   /**
    * Inactivity timeout that ends a user session, in seconds. Driven by remote
@@ -74,7 +74,7 @@ export interface DynamicSDKConfig {
    *
    * **default**: 1800 seconds (30 minutes)
    */
-  inactivityTimeoutSeconds?: number;
+  userSessionInactivityTimeoutSeconds?: number;
 }
 
 export interface DynamicConfigManager {

--- a/packages/web-sdk/src/sdk/types.ts
+++ b/packages/web-sdk/src/sdk/types.ts
@@ -37,7 +37,6 @@ import type {
 } from '../instrumentations/index.ts';
 import type {
   LimitManagerInternal,
-  UserSessionConfig,
   UserSessionManagerInternal,
 } from '../managers/index.ts';
 import type { NamespacedStorage, PerformanceManager } from '../utils/index.ts';
@@ -61,6 +60,21 @@ export interface DynamicSDKConfig {
    * @deprecated The empty session avoidance feature has been removed. This field is ignored and will be removed in a future major version.
    */
   emptySessionAvoidanceEnabledPct?: number;
+
+  /**
+   * Maximum duration of a user session, in seconds. Driven by remote config.
+   *
+   * **default**: 43200 seconds (12 hours)
+   */
+  maxUserSessionDurationSeconds?: number;
+
+  /**
+   * Inactivity timeout that ends a user session, in seconds. Driven by remote
+   * config.
+   *
+   * **default**: 1800 seconds (30 minutes)
+   */
+  inactivityTimeoutSeconds?: number;
 }
 
 export interface DynamicConfigManager {
@@ -232,20 +246,6 @@ type BaseSDKInitConfig = {
    * **default**: true
    */
   useDocumentTitleAsPageLabel?: boolean;
-
-  /**
-   * maxUserSessionDurationSeconds overrides the default maximum user session duration (12 hours).
-   *
-   * **default**: 43200 seconds (12 hours)
-   */
-  maxUserSessionDurationSeconds?: number;
-
-  /**
-   * inactivityTimeoutSeconds overrides the default inactivity timeout (30 minutes).
-   *
-   * **Default**: 1800 seconds (30 minutes)
-   */
-  inactivityTimeoutSeconds?: number;
 };
 
 /*
@@ -329,7 +329,7 @@ export interface SetupUserSessionArgs {
   registerGlobally?: boolean;
   sdkLocalStorage: NamespacedStorage;
   visibilityDoc: VisibilityStateDocument;
-  userSessionConfig?: UserSessionConfig;
+  dynamicConfigManager: DynamicConfigManager;
 }
 
 export interface SetupTracesArgs {

--- a/packages/web-sdk/tests/utils/constants.ts
+++ b/packages/web-sdk/tests/utils/constants.ts
@@ -1,5 +1,8 @@
 import * as sinon from 'sinon';
-import type { DynamicConfigManager } from '../../src/sdk/index.ts';
+import type {
+  DynamicConfigManager,
+  DynamicSDKConfig,
+} from '../../src/sdk/index.ts';
 
 export const SAMPLED_UUID = '12345678-1234-1234-1234-000000000001';
 export const NOT_SAMPLED_UUID = 'abcdefab-cdef-abcd-efab-ffffffffffff';
@@ -12,3 +15,20 @@ export const TEST_DYNAMIC_CONFIG_MANAGER: DynamicConfigManager = {
     networkSpansForwardingThreshold: 50,
   }),
 };
+
+/**
+ * Builds a DynamicConfigManager stub whose getConfig() returns the given
+ * overrides. Lets tests drive remote-config-sourced values (e.g. user-session
+ * durations) through the same channel production uses.
+ */
+export const createTestDynamicConfigManager = (
+  config: Partial<DynamicSDKConfig> = {},
+): DynamicConfigManager => ({
+  refreshRemoteConfig: sinon.stub(),
+  setConfig: sinon.stub(),
+  getConfig: () => ({
+    samplingPct: 50,
+    networkSpansForwardingThreshold: 50,
+    ...config,
+  }),
+});

--- a/packages/web-sdk/tests/utils/fakeFetch.ts
+++ b/packages/web-sdk/tests/utils/fakeFetch.ts
@@ -5,7 +5,41 @@ import * as sinon from 'sinon';
 
 const withRequest = (arg: unknown) => arg instanceof window.Request;
 
+// Embrace endpoints by path: spans and logs are separate telemetry exports, and
+// remote config is its own fetch. Config fetches interleave with telemetry on
+// the same stub, so tests must address a call by its endpoint rather than by its
+// absolute position in the fetch history.
+const SPANS_PATH = '/v2/spans';
+const CONFIG_PATH = '/v2/config';
+
 let fetchStub: SinonStub | undefined;
+
+const callUrl = (callNumber: number): string | undefined => {
+  const firstArg = fetchStub?.getCall(callNumber)?.args[0] as
+    | Parameters<typeof window.fetch>[0]
+    | undefined;
+  if (firstArg === undefined) {
+    return undefined;
+  }
+  return withRequest(firstArg) ? firstArg.url : (firstArg as string);
+};
+
+// Absolute fetch-call index of the Nth call whose URL hits `path`. Returns -1
+// when there is no such call, so callers fail with a clear out-of-range read
+// rather than silently addressing the wrong endpoint.
+const nthCallToPath = (path: string, n: number) => {
+  const total = fetchStub?.callCount ?? 0;
+  let seen = 0;
+  for (let i = 0; i < total; i++) {
+    if (callUrl(i)?.includes(path)) {
+      if (seen === n) {
+        return i;
+      }
+      seen++;
+    }
+  }
+  return -1;
+};
 
 export const fakeFetchGetOptions = (callNumber = 0) =>
   (fetchStub?.getCall(callNumber).args[1] || {}) as Parameters<
@@ -78,3 +112,16 @@ export const fakeFetchGetKeepalive = (callNumber = 0) =>
 
 export const fakeFetchWasCalled = (callNumber = 0) =>
   !!fetchStub?.getCall(callNumber);
+
+// Endpoint-addressed reads. Config fetches and telemetry exports share the fetch
+// stub, so tests ask for "the Nth spans export" or "the Nth config fetch" by
+// endpoint instead of by absolute fetch position.
+
+export const fakeFetchGetSpansBody = (spansExportNumber = 0) =>
+  fakeFetchGetBody(nthCallToPath(SPANS_PATH, spansExportNumber));
+
+export const fakeFetchGetSpansRequestHeaders = (spansExportNumber = 0) =>
+  fakeFetchGetRequestHeaders(nthCallToPath(SPANS_PATH, spansExportNumber));
+
+export const fakeFetchGetConfigUrl = (configCallNumber = 0) =>
+  fakeFetchGetUrl(nthCallToPath(CONFIG_PATH, configCallNumber));

--- a/packages/web-sdk/tests/utils/index.ts
+++ b/packages/web-sdk/tests/utils/index.ts
@@ -1,4 +1,5 @@
 export {
+  createTestDynamicConfigManager,
   NOT_SAMPLED_UUID,
   SAMPLED_UUID,
   TEST_DYNAMIC_CONFIG_MANAGER,

--- a/packages/web-sdk/tests/utils/index.ts
+++ b/packages/web-sdk/tests/utils/index.ts
@@ -9,10 +9,13 @@ export { FakeLogRecordProcessor } from './FakeLogRecordProcessor.ts';
 export { FakeSpanProcessor } from './FakeSpanProcessor.ts';
 export {
   fakeFetchGetBody,
+  fakeFetchGetConfigUrl,
   fakeFetchGetKeepalive,
   fakeFetchGetMethod,
   fakeFetchGetOptions,
   fakeFetchGetRequestHeaders,
+  fakeFetchGetSpansBody,
+  fakeFetchGetSpansRequestHeaders,
   fakeFetchGetUrl,
   fakeFetchInstall,
   fakeFetchResetHistory,


### PR DESCRIPTION
## What problem is this solving?

The user-session max-duration and inactivity-timeout were local `initSDK` options. They now come from remote config and refresh per user session, so the backend can tune them without an SDK change.

## Short description of changes

- Remove the local `initSDK` options and the `UserSessionConfig` plumbing.
- Parse `max_duration_seconds` / `inactivity_timeout_seconds` from the remote `user_session` payload into `DynamicSDKConfig`.
- Resolve the durations (clamp + inactivity-<=-max) from the `DynamicConfigManager` at each user-session creation and freeze them into that session, so a mid-session config change only affects the next session.
- Refresh remote config on each new user session, skipping cold start (already refreshed by `initSDK`). The async fetch lands for the following session.
- Name the resolved fields entity-first (`userSessionMaxDurationSeconds`, `userSessionInactivityTimeoutSeconds`) to match the `USER_SESSION_*` constants and `emb.user_session_*` attribute keys.

## Testing

- `npm run check` (tsc + eslint) passes.
- Unit tests pass, including new coverage for remote `user_session` parsing, the per-session refresh and cold-start skip (including the `setTracerProvider` eager-create path), and duration freezing across config changes.

---

> Stacked on #1355 (fake-fetch test-helper refactor). Review/merge that first.
