### PR TITLE
EMBR-12221 fix(rage-click): use `emb.otel_log` for rage click type

### DIFF
--- a/packages/web-sdk/src/constants/attributes.ts
+++ b/packages/web-sdk/src/constants/attributes.ts
@@ -55,7 +55,7 @@ export enum EMB_TYPES {
   UserTiming = 'ux.user_timing',
   ElementTiming = 'ux.element_timing',
   ServerTiming = 'ux.server_timing',
-  RageClick = 'ux.rage_click',
+  OTelLog = 'emb.otel_log',
 }
 
 export enum EMB_STATES {

--- a/packages/web-sdk/src/instrumentations/rage-click/RageClickInstrumentation/RageClickInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/rage-click/RageClickInstrumentation/RageClickInstrumentation.test.ts
@@ -69,7 +69,7 @@ describe('RageClickInstrumentation', () => {
     expect(logs[0].eventName).to.equal('rage-click');
     expect(logs[0].severityNumber).to.equal(SeverityNumber.INFO);
     expect(logs[0].attributes).to.include({
-      'emb.type': 'ux.rage_click',
+      'emb.type': 'emb.otel_log',
       'rage_click.element_type': 'button',
       'rage_click.element_selector': '#checkout-btn',
       'rage_click.interaction_type': 'click',

--- a/packages/web-sdk/src/instrumentations/rage-click/RageClickInstrumentation/RageClickInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/rage-click/RageClickInstrumentation/RageClickInstrumentation.ts
@@ -133,7 +133,7 @@ export class RageClickInstrumentation extends EmbraceInstrumentationBase {
       eventName: RAGE_CLICK_EVENT_NAME,
       severityNumber: SeverityNumber.INFO,
       attributes: {
-        [KEY_EMB_TYPE]: EMB_TYPES.RageClick,
+        [KEY_EMB_TYPE]: EMB_TYPES.OTelLog,
         [ATTR_RAGE_CLICK_ELEMENT_TYPE]:
           eventWindow.target.tagName.toLowerCase(),
         [ATTR_RAGE_CLICK_ELEMENT_SELECTOR]: getSelector(eventWindow.target),


### PR DESCRIPTION
This will allow rage clicks to be ingested by the generic log loader.