### PR TITLE
test(sdk): address fake-fetch reads by endpoint instead of call index

### DIFF
--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -22,9 +22,9 @@ import {
   FakeInstrumentation,
   FakeLogRecordProcessor,
   FakeSpanProcessor,
-  fakeFetchGetBody,
-  fakeFetchGetRequestHeaders,
-  fakeFetchGetUrl,
+  fakeFetchGetConfigUrl,
+  fakeFetchGetSpansBody,
+  fakeFetchGetSpansRequestHeaders,
   fakeFetchInstall,
   fakeFetchResetHistory,
   fakeFetchRespondWith,
@@ -108,13 +108,15 @@ const otlpAttrsToRecord = (
 };
 
 const getLastSessionExportedSpans = async (
-  callNumber = 0,
+  spansExportNumber = 0,
   scope: SpanScope = { name: 'embrace-web-sdk-traces' },
 ) => {
   // Needed to allow the transport to actually send its data off to fetch
   await new Promise((r) => setTimeout(r, 1));
 
-  const body = fakeFetchGetBody(callNumber);
+  // Address the export by its position among spans sends, skipping interleaved
+  // remote-config fetches and logs sends.
+  const body = fakeFetchGetSpansBody(spansExportNumber);
   void expect(body).not.to.be.null;
   const decompressedStream = new Response(body).body?.pipeThrough(
     new DecompressionStream('gzip'),
@@ -713,10 +715,10 @@ describe('initSDK', () => {
       // Needed to allow the transport to actually send its data off to fetch
       await new Promise((r) => setTimeout(r, 1));
 
-      const headers = fakeFetchGetRequestHeaders(1);
+      const headers = fakeFetchGetSpansRequestHeaders();
       expect((headers as Record<string, string>)['X-EM-AID']).to.equal('abc12');
 
-      const body = fakeFetchGetBody(1);
+      const body = fakeFetchGetSpansBody();
 
       void expect(body).not.to.be.null;
       const decompressedStream = new Response(body).body?.pipeThrough(
@@ -837,7 +839,7 @@ describe('initSDK', () => {
       // Needed to allow the transport to actually send its data off to fetch
       await new Promise((r) => setTimeout(r, 1));
 
-      const body = fakeFetchGetBody(1);
+      const body = fakeFetchGetSpansBody();
       void expect(body).not.to.be.null;
       const decompressedStream = new Response(body).body?.pipeThrough(
         new DecompressionStream('gzip'),
@@ -886,7 +888,7 @@ describe('initSDK', () => {
 
       session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
 
       expect(exportedSpans[0]['name']).to.be.equal('my performance span');
     });
@@ -917,7 +919,7 @@ describe('initSDK', () => {
 
       session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1000);
       for (let i = 0; i < exportedSpans.length; i++) {
         expect(exportedSpans[i]['name']).to.equal(`my-span-${i.toString()}`);
@@ -972,7 +974,7 @@ describe('initSDK', () => {
       span.end();
       session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
 
       const exportedEvents = exportedSpans[0].events;
@@ -1018,7 +1020,7 @@ describe('initSDK', () => {
       span.end();
       session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
 
       const exportedAttributes = exportedSpans[0].attributes;
@@ -1085,7 +1087,7 @@ describe('initSDK', () => {
       span.end();
       session.getUserSessionManager().endSessionPartInternal('web_inactivity');
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
 
       const exportedEvents = exportedSpans[0].events;
@@ -1141,7 +1143,7 @@ describe('initSDK', () => {
         await result.flush();
       }
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
       expect(exportedSpans[0].attributes[0]).to.deep.equal({
         key: 'url.full',
@@ -1218,7 +1220,7 @@ describe('initSDK', () => {
         await result.flush();
       }
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
       expect(exportedSpans[0].attributes[0]).to.deep.equal({
         key: 'url.full',
@@ -1298,7 +1300,7 @@ describe('initSDK', () => {
         await result.flush();
       }
 
-      const exportedSpans = await getLastSessionExportedSpans(1);
+      const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
       expect(exportedSpans[0].attributes[0]).to.deep.equal({
         key: 'url.full',
@@ -1349,7 +1351,7 @@ describe('initSDK', () => {
       void expect(result).not.to.be.false;
 
       void expect(fakeFetchWasCalled()).to.be.true;
-      expect(fakeFetchGetUrl()).to.contain(
+      expect(fakeFetchGetConfigUrl()).to.contain(
         'https://a-abc12.config.emb-api.com/v2/config?appId=abc12&osVersion=1&appVersion=my-app-version&deviceId=',
       );
     });
@@ -1375,7 +1377,7 @@ describe('initSDK', () => {
       void expect(result).not.to.be.false;
 
       void expect(fakeFetchWasCalled()).to.be.true;
-      expect(fakeFetchGetUrl()).to.contain(
+      expect(fakeFetchGetConfigUrl()).to.contain(
         'https://a-abc12.config.emb-api.com/v2/config?appId=abc12&osVersion=1&appVersion=EmbIOAppVersionX.X.X&deviceId=',
       );
     });
@@ -1802,16 +1804,13 @@ describe('initSDK', () => {
 
         // Need to restore the clock here so that the setTimeout in `getLastSessionExportedSpans` works
         clock.restore();
-        const exportedSpans = await getLastSessionExportedSpans(
-          test.networkType === 'fetch' ? 1 : 0,
-          {
-            name:
-              test.networkType === 'fetch'
-                ? '@opentelemetry/instrumentation-fetch'
-                : '@opentelemetry/instrumentation-xml-http-request',
-            version: '0.218.0',
-          },
-        );
+        const exportedSpans = await getLastSessionExportedSpans(0, {
+          name:
+            test.networkType === 'fetch'
+              ? '@opentelemetry/instrumentation-fetch'
+              : '@opentelemetry/instrumentation-xml-http-request',
+          version: '0.218.0',
+        });
         expect(exportedSpans).to.have.lengthOf(1);
         const networkSpan = exportedSpans[0];
         const expectedTraceparent = `00-${networkSpan.traceId}-${networkSpan.spanId}-01`;

--- a/packages/web-sdk/tests/utils/fakeFetch.ts
+++ b/packages/web-sdk/tests/utils/fakeFetch.ts
@@ -5,7 +5,41 @@ import * as sinon from 'sinon';
 
 const withRequest = (arg: unknown) => arg instanceof window.Request;
 
+// Embrace endpoints by path: spans and logs are separate telemetry exports, and
+// remote config is its own fetch. Config fetches interleave with telemetry on
+// the same stub, so tests must address a call by its endpoint rather than by its
+// absolute position in the fetch history.
+const SPANS_PATH = '/v2/spans';
+const CONFIG_PATH = '/v2/config';
+
 let fetchStub: SinonStub | undefined;
+
+const callUrl = (callNumber: number): string | undefined => {
+  const firstArg = fetchStub?.getCall(callNumber)?.args[0] as
+    | Parameters<typeof window.fetch>[0]
+    | undefined;
+  if (firstArg === undefined) {
+    return undefined;
+  }
+  return withRequest(firstArg) ? firstArg.url : (firstArg as string);
+};
+
+// Absolute fetch-call index of the Nth call whose URL hits `path`. Returns -1
+// when there is no such call, so callers fail with a clear out-of-range read
+// rather than silently addressing the wrong endpoint.
+const nthCallToPath = (path: string, n: number) => {
+  const total = fetchStub?.callCount ?? 0;
+  let seen = 0;
+  for (let i = 0; i < total; i++) {
+    if (callUrl(i)?.includes(path)) {
+      if (seen === n) {
+        return i;
+      }
+      seen++;
+    }
+  }
+  return -1;
+};
 
 export const fakeFetchGetOptions = (callNumber = 0) =>
   (fetchStub?.getCall(callNumber).args[1] || {}) as Parameters<
@@ -78,3 +112,16 @@ export const fakeFetchGetKeepalive = (callNumber = 0) =>
 
 export const fakeFetchWasCalled = (callNumber = 0) =>
   !!fetchStub?.getCall(callNumber);
+
+// Endpoint-addressed reads. Config fetches and telemetry exports share the fetch
+// stub, so tests ask for "the Nth spans export" or "the Nth config fetch" by
+// endpoint instead of by absolute fetch position.
+
+export const fakeFetchGetSpansBody = (spansExportNumber = 0) =>
+  fakeFetchGetBody(nthCallToPath(SPANS_PATH, spansExportNumber));
+
+export const fakeFetchGetSpansRequestHeaders = (spansExportNumber = 0) =>
+  fakeFetchGetRequestHeaders(nthCallToPath(SPANS_PATH, spansExportNumber));
+
+export const fakeFetchGetConfigUrl = (configCallNumber = 0) =>
+  fakeFetchGetUrl(nthCallToPath(CONFIG_PATH, configCallNumber));

--- a/packages/web-sdk/tests/utils/index.ts
+++ b/packages/web-sdk/tests/utils/index.ts
@@ -9,10 +9,13 @@ export { FakeLogRecordProcessor } from './FakeLogRecordProcessor.ts';
 export { FakeSpanProcessor } from './FakeSpanProcessor.ts';
 export {
   fakeFetchGetBody,
+  fakeFetchGetConfigUrl,
   fakeFetchGetKeepalive,
   fakeFetchGetMethod,
   fakeFetchGetOptions,
   fakeFetchGetRequestHeaders,
+  fakeFetchGetSpansBody,
+  fakeFetchGetSpansRequestHeaders,
   fakeFetchGetUrl,
   fakeFetchInstall,
   fakeFetchResetHistory,


### PR DESCRIPTION
## What problem is this solving?

The fake-fetch test helpers were addressed by absolute call index (`fakeFetchGetBody(1)`, `getLastSessionExportedSpans(1)`, `test.networkType === 'fetch' ? 1 : 0`). That coupled tests to the exact ordering of fetches, which already mixes remote-config fetches with telemetry exports on the same stub. Any change to how many fetches fire (or in what order) silently shifts the index and makes a test read the wrong endpoint, e.g. piping a config response through `DecompressionStream('gzip')` surfaces a confusing `TypeError: Failed to fetch`.

## Short description of changes

- Add endpoint-addressed fake-fetch reads: `fakeFetchGetSpansBody`, `fakeFetchGetSpansRequestHeaders`, `fakeFetchGetConfigUrl`. Each resolves the Nth call to its endpoint (`/v2/spans`, `/v2/config`) internally via a private `nthCallToPath`, so tests never juggle a raw call index.
- Match the exact endpoint path rather than the `.data.` host, so a spans reader can't accidentally pick up a `/v2/logs` send.
- Update `initSDK.test.ts` to read by endpoint, dropping the positional `fakeFetchGetBody(1)` assumptions and the `? 1 : 0` network-type hack.

## Testing

- `npm run check` (tsc + eslint) passes.
- `initSDK.test.ts`: 57 passed, 0 failed.

---

> Base of the stack. #1353 (remote-config user-session durations) is stacked on top of this.
