### PR TITLE
docs(demo): keep last-ended session part shown after the next part starts

### DIFF
--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -162,7 +162,10 @@ const App = () => {
   const [partStartReason, setPartStartReason] = useState<string | null>(null);
   const [isColdStart, setIsColdStart] = useState<boolean | null>(null);
   const [partEndTs, setPartEndTs] = useState<number | null>(null);
-  const [partEndReason, setPartEndReason] = useState<string | null>(null);
+  const [lastPartEndedTs, setLastPartEndedTs] = useState<number | null>(null);
+  const [lastPartEndedReason, setLastPartEndedReason] = useState<string | null>(
+    null,
+  );
   const [userId, setUserId] = useState<string | null>(null);
   const [embraceUserId, setEmbraceUserId] = useState<string | null>(null);
   const [pageLabel, setPageLabel] = useState<string | null>(null);
@@ -253,19 +256,24 @@ const App = () => {
     }
 
     const handlePartStart = () => {
+      // Release the duration freeze for the part that is starting. Deliberately
+      // leave the "last ended" record alone: clearing it on start would erase
+      // the previous part's end the moment the next part begins, which in the
+      // user-session rollover case is synchronous and would never be seen.
       setPartEndTs(null);
-      setPartEndReason(null);
       setPartStartTs(Date.now());
       updateUserSession();
       updateSessionPart();
     };
     const handlePartEnd = () => {
-      setPartEndTs(Date.now());
+      const endTs = Date.now();
+      setPartEndTs(endTs);
+      setLastPartEndedTs(endTs);
       const endReason =
         userSessionManager.getSessionPartSpan()?.attributes?.[
           'emb.session_part_end_reason'
         ];
-      setPartEndReason(typeof endReason === 'string' ? endReason : null);
+      setLastPartEndedReason(typeof endReason === 'string' ? endReason : null);
       // End listeners fire before the SDK clears the part span, so defer the
       // re-read until after the SDK finishes cleaning up its state.
       queueMicrotask(updateSessionPart);
@@ -630,10 +638,10 @@ const App = () => {
             <tr>
               <th scope="row">Last Ended</th>
               <td>
-                {partEndTs === null
+                {lastPartEndedTs === null
                   ? '—'
-                  : `${formatTimestamp(partEndTs)}${
-                      partEndReason ? ` (${partEndReason})` : ''
+                  : `${formatTimestamp(lastPartEndedTs)}${
+                      lastPartEndedReason ? ` (${lastPartEndedReason})` : ''
                     }`}
               </td>
             </tr>


### PR DESCRIPTION
## What problem is this solving?

The demo's "Last Ended" row in the Session Part panel always showed "—". A part-end is immediately followed by a part-start (rollover on End User Session, `web_foreground` on tab return, `web_activity` after inactivity), and the part-start handler cleared the captured end timestamp/reason before it could render.

## Short description of changes

- Add persistent `lastPartEndedTs` / `lastPartEndedReason` state, recorded in `handlePartEnd` and intentionally not cleared in `handlePartStart`; the "Last Ended" row reads these.
- Keep `partEndTs` solely for the active part's duration freeze.

## Testing

- Verified live on localhost:4847: ending the user session shows `(user_session_ended)`, and a tab background/return shows `(web_background)`, both persisting while the next part runs.
- `npm run lint` and `npm run check` pass.