### PR TITLE
chore(deps): remove fflate override and bump arethetypeswrong/core to 0.18.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "tests/integration"
       ],
       "devDependencies": {
-        "@arethetypeswrong/core": "0.18.2",
+        "@arethetypeswrong/core": "0.18.3",
         "@biomejs/biome": "2.4.15",
         "@commitlint/cli": "21.0.1",
         "@commitlint/config-conventional": "21.0.1",
@@ -103,16 +103,16 @@
       "dev": true
     },
     "node_modules/@arethetypeswrong/core": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.2.tgz",
-      "integrity": "sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.3.tgz",
+      "integrity": "sha512-sWBB/tdIktaT5xMq0Dz6CJyqcf6oMNdmiKiuPU1lWoJLTL6gjRSsksBuSgqot21hylkklBQY1wiSu+PkZhW7sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@andrewbranch/untar.js": "^1.0.3",
         "@loaderkit/resolve": "^1.0.2",
         "cjs-module-lexer": "^1.2.3",
-        "fflate": "^0.8.2",
+        "fflate": "^0.8.3",
         "lru-cache": "^11.0.1",
         "semver": "^7.5.4",
         "typescript": "5.6.1-rc",
@@ -5733,9 +5733,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tests/integration"
   ],
   "devDependencies": {
-    "@arethetypeswrong/core": "0.18.2",
+    "@arethetypeswrong/core": "0.18.3",
     "@biomejs/biome": "2.4.15",
     "@commitlint/cli": "21.0.1",
     "@commitlint/config-conventional": "21.0.1",
@@ -77,11 +77,6 @@
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.4",
     "vite": "8.0.14"
-  },
-  "overrides": {
-    "@arethetypeswrong/core": {
-      "fflate": "0.8.2"
-    }
   },
   "packageManager": "npm@11.9.0",
   "devEngines": {


### PR DESCRIPTION
## What problem is this solving?

The `overrides` block pinning `fflate` to `0.8.2` inside `@arethetypeswrong/core` is no longer needed. Bumping `@arethetypeswrong/core` to `0.18.3` lets it resolve `fflate@^0.8.3` on its own, so the manual override can be dropped.

## Short description of the changes

- Removed the `overrides` block forcing `@arethetypeswrong/core` to use `fflate@0.8.2`
- Bumped `@arethetypeswrong/core` from `0.18.2` to `0.18.3` (devDependency)
- Regenerated `package-lock.json`

## How was this tested?

Lockfile regenerated via npm install; this is a dev-only tooling dependency change.

## Checklist

- [x] No production code affected (devDependencies only)