### PR TITLE
EMBR-12299 docs(sessions): document 2.21.0 user-session API migration and expose getSessionPartSpan publicly

### DIFF
--- a/packages/web-sdk/UPGRADING.md
+++ b/packages/web-sdk/UPGRADING.md
@@ -28,9 +28,8 @@ session.endSessionSpan();
 session.endUserSession();
 ```
 
-A new user session begins with
-the next session part: immediately if the tab is still foregrounded, otherwise the next time it is foregrounded. The
-call is subject to a 5-second cooldown.
+A new user session begins with the next session part: immediately if the tab is still foregrounded, otherwise
+the next time it is foregrounded. The call is subject to a 5-second cooldown.
 
 `getSessionPartSpan()` is provided for backwards compatibility only: direct access to the span will be removed
 entirely in a future version. The SDK owns the span's lifecycle and can end it at any moment, so do not end it

--- a/packages/web-sdk/UPGRADING.md
+++ b/packages/web-sdk/UPGRADING.md
@@ -1,5 +1,50 @@
 # Upgrading
 
+## 2.x to 2.21.0
+
+The session API now distinguishes between a **user session** (the full period of user engagement, which can span
+multiple foregrounds of the page) and a **session part** (a single foreground period within a user session). Methods
+on `session` were renamed to make this explicit. The old names still work as deprecated forwarders and will be
+removed in a future version.
+
+### Renamed methods
+
+| Deprecated                      | Replacement                         |
+| ------------------------------- | ----------------------------------- |
+| `session.getSessionId()`        | `session.getUserSessionId()`        |
+| `session.getSessionStartTime()` | `session.getUserSessionStartTime()` |
+| `session.endSessionSpan()`      | `session.endUserSession()`          |
+| `session.getSessionSpan()`      | `session.getSessionPartSpan()`      |
+
+For example:
+
+```typescript
+import { session } from '@embrace-io/web-sdk';
+
+// Before
+session.endSessionSpan();
+
+// After
+session.endUserSession();
+```
+
+Note that `endUserSession()` ends the entire user session, not just the current span. A new user session begins with
+the next session part: immediately if the tab is still foregrounded, otherwise the next time it is foregrounded. The
+call is subject to a 5-second cooldown.
+
+`getSessionPartSpan()` is provided for backwards compatibility only: direct access to the span will be removed
+entirely in a future version. The SDK owns the span's lifecycle and can end it at any moment, so do not end it
+yourself or hold long-lived references to it.
+
+### Deprecated methods with changed behavior
+
+- `session.getPreviousSessionId()` always returns `null`. Use `session.getPreviousUserSessionId()` instead.
+- `session.startSessionSpan()` is a no-op. A session part starts automatically when the page is foregrounded, this
+  is no longer exposed as an API.
+- `session.currentSessionAsReadableSpan()` always returns `null`.
+- `session.addSessionStartedListener()` and `session.addSessionEndedListener()` are no-ops, the listeners are never
+  invoked and the returned unsubscribe functions do nothing.
+
 ## 1.x to 2.x
 
 See the breaking changes outlined in the [2.0.0 Release notes](https://github.com/embrace-io/embrace-web-sdk/releases/tag/2.0.0).
@@ -89,7 +134,7 @@ log.message('Loading not finished in time.', 'error', {
   keYB: 'valueB'
 }, true);
 
-// ... 
+// ...
 
 log.logException(err, true, { keyA: 'valueA' }, ts);
 ```
@@ -107,7 +152,7 @@ log.message('Loading not finished in time.', 'error', {
   includeStacktrace: true
 });
 
-// ... 
+// ...
 
 log.logException(err, {
   handled: true,

--- a/packages/web-sdk/UPGRADING.md
+++ b/packages/web-sdk/UPGRADING.md
@@ -28,7 +28,7 @@ session.endSessionSpan();
 session.endUserSession();
 ```
 
-Note that `endUserSession()` ends the entire user session, not just the current span. A new user session begins with
+A new user session begins with
 the next session part: immediately if the tab is still foregrounded, otherwise the next time it is foregrounded. The
 call is subject to a 5-second cooldown.
 

--- a/packages/web-sdk/src/api-sessions/manager/types.ts
+++ b/packages/web-sdk/src/api-sessions/manager/types.ts
@@ -76,6 +76,18 @@ export interface UserSessionManager {
   getUserSessionStartTime: () => number | null;
 
   /**
+   * Returns the active session part span, or `null` when no part is active.
+   *
+   * The SDK owns this span's lifecycle and can end it at any moment
+   * (backgrounding, inactivity, max duration, user session end). Do not end
+   * it yourself and do not hold long-lived references to it.
+   *
+   * Direct access to the span exists for backwards compatibility only and
+   * will be removed entirely in a future version.
+   */
+  getSessionPartSpan: () => ExtendedSpan | null;
+
+  /**
    * Ends the current user session. The next foreground session part will
    * begin a new user session; there is no companion public start API,
    * starting is an internal consequence of the next foreground part.

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
@@ -6,7 +6,6 @@ import type {
   UserSessionManager,
 } from '../../api-sessions/manager/types.ts';
 import type { VisibilityStateDocument } from '../../common/index.ts';
-import type { ExtendedSpan } from '../../index.ts';
 import type { DynamicConfigManager } from '../../sdk/index.ts';
 import type {
   NamespacedStorage,
@@ -103,7 +102,6 @@ export interface UserSessionManagerInternal extends UserSessionManager {
   getSessionPartProperties: () => Record<string, string>;
 
   getSessionPartId: () => string | null;
-  getSessionPartSpan: () => ExtendedSpan | null;
 
   startSessionPartInternal: (reason: SessionPartStartReason) => void;
   /**


### PR DESCRIPTION
## What problem is this solving?

The 2.21.0 user-session API renames (user session vs session part) had no migration documentation, and `getSessionPartSpan()` was only available on the internal manager interface even though the deprecated `getSessionSpan()` forwarder points users to it.

## Short description of changes

- Add a "2.x to 2.21.0" section to `UPGRADING.md` covering the renamed methods, the semantics of `endUserSession()`, and the deprecated methods whose behavior changed (no-ops / always-null returns)
- Move `getSessionPartSpan()` from `UserSessionManagerInternal` to the public `UserSessionManager` interface with TSDoc warning that the SDK owns the span lifecycle and direct access is for backwards compatibility only

## How has this been tested?

`npm run check` and `npm run lint` pass; docs-and-interface-only change with no runtime behavior modified.

## Checklist

- [x] Documentation added
- [ ] Tests added