### PR TITLE
build(npm): set ignore-scripts to prevent install lifecycle scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 lockfile-version=3
 prefer-dedupe=true
 workspaces-update=true
+ignore-scripts=true

--- a/tests/performance/.npmrc
+++ b/tests/performance/.npmrc
@@ -1,0 +1,4 @@
+lockfile-version=3
+prefer-dedupe=true
+workspaces-update=true
+ignore-scripts=true

--- a/tests/performance/package-lock.json
+++ b/tests/performance/package-lock.json
@@ -11,7 +11,6 @@
       },
       "devDependencies": {
         "@playwright/test": "1.60.0",
-        "get-port": "7.2.0",
         "lighthouse": "13.3.0"
       }
     },
@@ -774,19 +773,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-port": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
-      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {

--- a/tests/performance/package.json
+++ b/tests/performance/package.json
@@ -3,8 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "pretest": "npm run build --prefix ../.. && npm install && npx playwright install",
-    "test": "npx playwright test"
+    "test": "npm run build --prefix ../.. && npm install && npx playwright install && npx playwright test"
   },
   "dependencies": {
     "@embrace-io/web-cli": "file:../../packages/web-cli",
@@ -12,7 +11,6 @@
   },
   "devDependencies": {
     "@playwright/test": "1.60.0",
-    "get-port": "7.2.0",
     "lighthouse": "13.3.0"
   },
   "overrides": {

--- a/tests/performance/tests/cdp-performance-tests.spec.ts
+++ b/tests/performance/tests/cdp-performance-tests.spec.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import zlib from 'node:zlib';
 import type { Page } from '@playwright/test';
 import { test } from '@playwright/test';
-import getPort from 'get-port';
 import type { CDPSession } from 'playwright';
 import { chromium } from 'playwright';
 import { resultsToMarkdownTable } from '../../utils/jsonToMarkdownTable.ts';
@@ -119,11 +118,11 @@ const getPerformanceSnapshot = async (
   // No need to change the rest of the test
   return {
     // Transform s to ms
-    scriptDuration: metrics.ScriptDuration * 1000 || 0,
+    scriptDuration: metrics['ScriptDuration'] * 1000 || 0,
     // Transform s to ms
-    taskDuration: metrics.TaskDuration * 1000 || 0,
+    taskDuration: metrics['TaskDuration'] * 1000 || 0,
     // Transform bytes to MB
-    heapUsedSize: (metrics.JSHeapUsedSize || 0) / 1024 / 1024,
+    heapUsedSize: (metrics['JSHeapUsedSize'] || 0) / 1024 / 1024,
   };
 };
 
@@ -177,7 +176,7 @@ test.describe('CDP Performance Tests', () => {
   for (const testPage of Object.values(PAGES)) {
     test(`Tests Performance for ${testPage.name}`, async () => {
       // Start a new context on each test to make sure we have a clean slate
-      const port = await getPort();
+      const port = 60061;
       const chromeBrowser = await chromium.launch({
         args: [`--remote-debugging-port=${port.toString()}`],
         headless: true,

--- a/tests/performance/tests/lighthouse-startup-performance-tests.spec.ts
+++ b/tests/performance/tests/lighthouse-startup-performance-tests.spec.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { test } from '@playwright/test';
-import getPort from 'get-port';
 import lighthouse from 'lighthouse';
 import { chromium } from 'playwright';
 import { resultsToMarkdownTable } from '../../utils/jsonToMarkdownTable.ts';
@@ -91,7 +90,7 @@ test.describe('Lighthouse Performance Tests', () => {
   for (const page of Object.values(PAGES)) {
     test(`Run lighthouse for ${page.name}`, async () => {
       // Launch a new context for each test to ensure a clean slate
-      const port = await getPort();
+      const port = 60062;
       const userDataDir = path.join(os.tmpdir(), 'pw', String(Math.random()));
       const context = await chromium.launchPersistentContext(userDataDir, {
         args: [`--remote-debugging-port=${port.toString()}`],
@@ -111,7 +110,6 @@ test.describe('Lighthouse Performance Tests', () => {
         output: ['json', 'html'],
         onlyCategories: ['performance'],
         pauseAfterLoadMs: 5000,
-        enableErrorReporting: false,
       });
 
       test.expect(result).toBeDefined();


### PR DESCRIPTION
## What problem is this solving?

Pinning npm to 11.16.0 alone does not prevent dependency install lifecycle scripts from running: it only emits a warning. To actually block arbitrary `preinstall`/`install`/`postinstall` scripts during `npm install` (supply-chain hardening), `ignore-scripts` must be set explicitly.

While enabling `ignore-scripts` in the performance-tests workspace, the `get-port` dependency had to go: with scripts ignored it is no longer reliable, and its only use was picking an ephemeral debug port, which can be a fixed value here.

## Short description of changes

- Add `ignore-scripts=true` to the root `.npmrc` and to `tests/performance/.npmrc`.
- Drop the `get-port` dependency in the performance tests; hardcode the remote debugging ports (`60061` for CDP, `60062` for Lighthouse).
- Fold the perf-tests `pretest` step into `test` (so the build/install/playwright-install run as one script).
- Remove the deprecated `enableErrorReporting` flag from the Lighthouse config.

## How has this been tested?

- `npm install` no longer runs dependency lifecycle scripts.
- Pre-commit hooks (lint, typecheck, build) pass on the change.

## Checklist

- [ ] Documentation added
- [ ] Tests added