### PR TITLE
build(deps): replace rimraf with native node remove script

### DIFF
--- a/demo/frontend-cdn/package.json
+++ b/demo/frontend-cdn/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "demo:cdn:frontend:full:preview": "bash ./scripts/runDemo.sh",
     "demo:cdn:frontend:full:preview:async": "bash ./scripts/runDemo.sh --async",
-    "demo:cdn:frontend:build:clean": "npx rimraf dist",
-    "demo:cdn:frontend:install:clean": "npx rimraf node_modules",
+    "demo:cdn:frontend:build:clean": "emb-rm dist",
+    "demo:cdn:frontend:install:clean": "emb-rm node_modules",
     "demo:cdn:sync:web:sdk": "ln -f ../../packages/web-sdk/dist/embrace-web-sdk.js ./public/embrace-web-sdk.js",
     "demo:cdn:frontend:dev": "vite",
     "demo:cdn:frontend:dev:async": "VITE_ASYNC_MODE=true vite",

--- a/demo/frontend/package.json
+++ b/demo/frontend/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "check": "tsc --build",
-    "clean": "npx -y rimraf .sonda dist",
+    "clean": "emb-rm .sonda dist",
     "dev": "vite --port 4847 --open",
     "build": "vite build",
     "preview": "vite preview --port 4847 --open",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "workspaces": [
         "packages/*",
         "demo/*",
+        "scripts",
         "server",
         "tests/integration"
       ],
@@ -44,7 +45,6 @@
         "publint": "0.3.21",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "rimraf": "6.1.3",
         "sinon": "22.0.0",
         "sinon-chai": "4.0.1",
         "sonda": "0.11.1",
@@ -5065,6 +5065,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/embrace-web-monorepo-scripts": {
+      "resolved": "scripts",
+      "link": true
+    },
     "node_modules/embrace-web-sdk-react-demo": {
       "resolved": "demo/frontend",
       "link": true
@@ -5998,24 +6002,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -7605,16 +7591,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -7942,13 +7918,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
@@ -8041,23 +8010,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
@@ -8782,26 +8734,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
-      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "glob": "^13.0.3",
-        "package-json-from-dist": "^1.0.1"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rolldown": {
@@ -10419,6 +10351,13 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "scripts": {
+      "name": "embrace-web-monorepo-scripts",
+      "version": "0.0.0",
+      "bin": {
+        "emb-rm": "emb-rm.js"
       }
     },
     "server": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "prepare": "npx -y lefthook install -f",
-    "clean": "node scripts/emb-rm.js \"**/.turbo\" \"**/.next\" \"**/dist\" \"**/node_modules\"",
+    "clean": "node scripts/emb-rm.js '**/.turbo' '**/.next' '**/dist' '**/node_modules'",
     "build": "turbo run build",
     "test": "turbo run test",
     "lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "prepare": "npx -y lefthook install -f",
-    "clean": "npx -y rimraf -g \"**/.turbo\" \"**/.next\" \"**/dist\" \"**/node_modules\"",
+    "clean": "node scripts/emb-rm.js \"**/.turbo\" \"**/.next\" \"**/dist\" \"**/node_modules\"",
     "build": "turbo run build",
     "test": "turbo run test",
     "lint": "biome check .",
@@ -30,6 +30,7 @@
   "workspaces": [
     "packages/*",
     "demo/*",
+    "scripts",
     "server",
     "tests/integration"
   ],
@@ -66,7 +67,6 @@
     "publint": "0.3.21",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "rimraf": "6.1.3",
     "sinon": "22.0.0",
     "sinon-chai": "4.0.1",
     "sonda": "0.11.1",

--- a/packages/web-cli/package.json
+++ b/packages/web-cli/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "npx -y rimraf dist",
+    "clean": "emb-rm dist",
     "build": "tsdown",
     "dev": "tsdown --watch --no-clean",
     "check": "tsc",

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -17,7 +17,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "clean": "npx -y rimraf dist .sonda",
+    "clean": "emb-rm dist .sonda",
     "build": "npm run build --prefix packages/otlp-transformer && tsdown",
     "dev": "tsdown --watch --no-clean",
     "test": "web-test-runner",

--- a/packages/web-sdk/packages/otlp-transformer/package.json
+++ b/packages/web-sdk/packages/otlp-transformer/package.json
@@ -15,6 +15,6 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsdown",
-    "clean": "npx -y rimraf dist"
+    "clean": "emb-rm dist"
   }
 }

--- a/scripts/emb-rm.js
+++ b/scripts/emb-rm.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+// Recursively removes the given paths. Arguments may be literal paths or glob
+// patterns (e.g. "**/dist"), resolved against the working directory.
+
+import { globSync, rmSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
+
+const packageRoot = process.cwd();
+const targets = globSync(process.argv.slice(2)).map((path) => resolve(path));
+
+// Refuse to delete anything at or outside the working directory, so a
+// mistyped relative path cannot remove the package itself or its siblings.
+// Validated before any removal so a bad argument deletes nothing at all.
+const escaped = targets.filter(
+  (target) => !target.startsWith(packageRoot + sep),
+);
+if (escaped.length > 0) {
+  for (const target of escaped) {
+    console.error(`Refusing to remove ${target}: outside ${packageRoot}`);
+  }
+  process.exit(1);
+}
+
+for (const target of targets) {
+  rmSync(target, { recursive: true, force: true });
+}

--- a/scripts/emb-rm.js
+++ b/scripts/emb-rm.js
@@ -5,18 +5,26 @@
 import { globSync, rmSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
 
-const packageRoot = process.cwd();
-const targets = globSync(process.argv.slice(2)).map((path) => resolve(path));
+const patterns = process.argv.slice(2);
+if (patterns.length === 0) {
+  console.error('Usage: emb-rm <path-or-glob>...');
+  process.exit(1);
+}
+
+const workingDirectory = process.cwd();
+const targets = globSync(patterns).map((path) => resolve(path));
 
 // Refuse to delete anything at or outside the working directory, so a
 // mistyped relative path cannot remove the package itself or its siblings.
 // Validated before any removal so a bad argument deletes nothing at all.
 const escaped = targets.filter(
-  (target) => !target.startsWith(packageRoot + sep),
+  (target) => !target.startsWith(workingDirectory + sep),
 );
 if (escaped.length > 0) {
   for (const target of escaped) {
-    console.error(`Refusing to remove ${target}: outside ${packageRoot}`);
+    console.error(
+      `Refusing to remove ${target}: at or outside ${workingDirectory}`,
+    );
   }
   process.exit(1);
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "embrace-web-monorepo-scripts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "emb-rm": "./emb-rm.js"
+  }
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -140,7 +140,7 @@ Create a new platform directory under `platforms/<platform-name>/` with a `packa
 {
   "scripts": {
     "build": "npm run build:clean && npm run build:es2015",
-    "build:clean": "npx rimraf dist .sonda",
+    "build:clean": "emb-rm dist .sonda",
     "build:es2015": "your-build-command && npm run process-sourcemaps",
     "process-sourcemaps": "embrace-web-cli upload -a NOEMB -p ./dist/es2015 --no-upload"
   }

--- a/tests/integration/platforms/next-15-turbopack-app/package.json
+++ b/tests/integration/platforms/next-15-turbopack-app/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
-    "build:clean": "npx rimraf .next",
+    "build:clean": "emb-rm .next",
     "build:es2020": "next build --turbopack",
     "process-sourcemaps": "embrace-web-cli upload -a NOEMB -p ./.next/static/chunks --no-upload",
     "start": "next start"

--- a/tests/integration/platforms/next-15-turbopack-pages/package.json
+++ b/tests/integration/platforms/next-15-turbopack-pages/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
-    "build:clean": "npx rimraf .next",
+    "build:clean": "emb-rm .next",
     "build:es2020": "next build --turbopack",
     "process-sourcemaps": "embrace-web-cli upload -a NOEMB -p ./.next/static/chunks --no-upload",
     "start": "next start"

--- a/tests/integration/platforms/next-15-webpack-app/package.json
+++ b/tests/integration/platforms/next-15-webpack-app/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
-    "build:clean": "npx rimraf .next",
+    "build:clean": "emb-rm .next",
     "build:es2020": "next build",
     "process-sourcemaps": "embrace-web-cli upload -a NOEMB -p ./.next/static/chunks --no-upload",
     "start": "next start"

--- a/tests/integration/platforms/next-15-webpack-pages/package.json
+++ b/tests/integration/platforms/next-15-webpack-pages/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
-    "build:clean": "npx rimraf .next",
+    "build:clean": "emb-rm .next",
     "build:es2020": "next build",
     "process-sourcemaps": "embrace-web-cli upload -a NOEMB -p ./.next/static/chunks --no-upload",
     "start": "next start"

--- a/tests/integration/platforms/next-16-app/package.json
+++ b/tests/integration/platforms/next-16-app/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
-    "build:clean": "npx rimraf .next",
+    "build:clean": "emb-rm .next",
     "build:es2020": "next build",
     "process-sourcemaps": "embrace-web-cli upload -a NOEMB -p ./.next/static/chunks --no-upload",
     "start": "next start"

--- a/tests/integration/platforms/next-16-pages/package.json
+++ b/tests/integration/platforms/next-16-pages/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
-    "build:clean": "npx rimraf .next",
+    "build:clean": "emb-rm .next",
     "build:es2020": "next build",
     "process-sourcemaps": "embrace-web-cli upload -a NOEMB -p ./.next/static/chunks --no-upload",
     "start": "next start"

--- a/tests/integration/platforms/vite-6/package.json
+++ b/tests/integration/platforms/vite-6/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "npm run build:clean && npm run build:es2015",
-    "build:clean": "npx rimraf dist .sonda",
+    "build:clean": "emb-rm dist .sonda",
     "build:es2015": "vite build && npm run process-sourcemaps",
     "process-sourcemaps": "embrace-web-cli upload -a NOEMB -p ./dist/es2015 --no-upload"
   },

--- a/tests/integration/platforms/vite-7/package.json
+++ b/tests/integration/platforms/vite-7/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "npm run build:clean && npm run build:es2015",
-    "build:clean": "npx rimraf dist .sonda",
+    "build:clean": "emb-rm dist .sonda",
     "build:es2015": "vite build && npm run process-sourcemaps",
     "process-sourcemaps": "embrace-web-cli upload -a NOEMB -p ./dist/es2015 --no-upload"
   },

--- a/tests/integration/platforms/webpack-5/package.json
+++ b/tests/integration/platforms/webpack-5/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "webpack serve --config webpack.config.es2015.mjs --mode development",
     "build": "npm run build:clean && npm run build:es2015",
-    "build:clean": "npx rimraf dist .sonda",
+    "build:clean": "emb-rm dist .sonda",
     "build:es2015": "webpack --config webpack.config.es2015.mjs --mode production && npm run process-sourcemaps",
     "process-sourcemaps": "embrace-web-cli upload -a NOEMB -p ./dist/es2015 --no-upload"
   },


### PR DESCRIPTION
## What problem is this PR solving?

`rimraf` is only used for deleting directories in `clean` scripts, but it requires Node 20+ and pulls in several transitive dependencies (`glob`, `minipass`, `path-scurry`, `package-json-from-dist`) for that one job. Since the repo already pins Node >= 26, native `fs.globSync` and `fs.rmSync` cover everything rimraf did here, with no dependency at all.

## Short description of the changes

- Add `scripts/emb-rm.js`, a small helper that expands its arguments with `fs.globSync` (literal paths and glob patterns alike) and removes each match with `fs.rmSync(path, {recursive: true, force: true})`.
- The helper refuses to remove anything at or outside the working directory (exit 1, nothing deleted), so a mistyped path in a clean script cannot remove the package itself or its siblings.
- Register `scripts/` as a workspace exposing the helper as an `emb-rm` bin, so package-level `clean` / `build:clean` scripts are just `emb-rm <targets>` with no relative paths. Glob arguments stay quoted so the pattern reaches the helper instead of being half-expanded by `sh`.
- The root `clean` invokes `node scripts/emb-rm.js` directly instead of the bin, so it also works when `node_modules` is already gone (e.g. running clean twice in a row).
- Drop `rimraf` from devDependencies and regenerate the lockfile.

## How was this tested?

- Full cycle matrix in a clean room: root clean with nothing installed, `npm ci` (verifies the bin links from the lockfile), `npm run build`, per-workspace cleans against real build output, root clean after build, then `npm i` and build again.
- All 14 converted clean scripts run in place via `npm run`, including the non-workspace integration platform directories (bin resolves via ancestor `node_modules/.bin` on PATH).
- Reproduced the Next.js 16 case where `.next/node_modules/` contains symlinks to directories: `build:clean` removes `.next` cleanly and the symlink targets are left untouched (`fs.rmSync` removes the link itself, matching rimraf behavior).
- Verified the containment guard refuses parent traversal, absolute paths outside the package, and `/`, and that a mixed valid/invalid invocation deletes nothing.
- `npm run lint` and `npm run check` pass (via pre-commit hooks).

Also adds a zero-argument usage guard to emb-rm (prints usage and exits 1 instead of silently succeeding) and clarifies the escape-guard refusal message to say "at or outside" the working directory.