### PR TITLE
refactor(sessions): take part start/end options as a single object

### DIFF
--- a/packages/web-sdk/src/api-sessions/manager/NoOpUserSessionManager/NoOpUserSessionManager.ts
+++ b/packages/web-sdk/src/api-sessions/manager/NoOpUserSessionManager/NoOpUserSessionManager.ts
@@ -1,14 +1,11 @@
 import type { ExtendedSpan } from '../../../index.ts';
 import type {
+  EndSessionPartOptions,
+  StartSessionPartOptions,
   UserSessionAttributes,
   UserSessionManagerInternal,
 } from '../../../managers/EmbraceUserSessionManager/types.ts';
-import type {
-  PropertyOptions,
-  SessionPartEndReason,
-  SessionPartStartReason,
-  UserSessionEndReason,
-} from '../index.ts';
+import type { PropertyOptions } from '../index.ts';
 
 export class NoOpUserSessionManager implements UserSessionManagerInternal {
   public addBreadcrumb(_name: string): void {
@@ -89,12 +86,9 @@ export class NoOpUserSessionManager implements UserSessionManagerInternal {
     return null;
   }
 
-  public startSessionPartInternal(_reason: SessionPartStartReason): void {}
+  public startSessionPartInternal(_options: StartSessionPartOptions): void {}
 
-  public endSessionPartInternal(
-    _reason: SessionPartEndReason,
-    _userSessionEndReason?: UserSessionEndReason | null,
-  ): void {}
+  public endSessionPartInternal(_options: EndSessionPartOptions): void {}
 
   public incrSessionPartCountForKey(_key: string): void {}
 

--- a/packages/web-sdk/src/api-sessions/manager/ProxyUserSessionManager/ProxyUserSessionManager.ts
+++ b/packages/web-sdk/src/api-sessions/manager/ProxyUserSessionManager/ProxyUserSessionManager.ts
@@ -1,16 +1,15 @@
 import type { TracerProvider } from '@opentelemetry/api';
 import type { ExtendedSpan } from '../../../index.ts';
 import type {
+  EndSessionPartOptions,
+  StartSessionPartOptions,
   UserSessionAttributes,
   UserSessionManagerInternal,
 } from '../../../managers/EmbraceUserSessionManager/types.ts';
 import type {
   PropertyOptions,
   ReasonSessionEnded,
-  SessionPartEndReason,
-  SessionPartStartReason,
   StartSessionOptions,
-  UserSessionEndReason,
 } from '../index.ts';
 import { NoOpUserSessionManager } from '../NoOpUserSessionManager/index.ts';
 
@@ -117,15 +116,12 @@ export class ProxyUserSessionManager implements UserSessionManagerInternal {
     return this.getDelegate().getSessionPartSpan();
   }
 
-  public startSessionPartInternal(reason: SessionPartStartReason): void {
-    this.getDelegate().startSessionPartInternal(reason);
+  public startSessionPartInternal(options: StartSessionPartOptions): void {
+    this.getDelegate().startSessionPartInternal(options);
   }
 
-  public endSessionPartInternal(
-    reason: SessionPartEndReason,
-    userSessionEndReason?: UserSessionEndReason,
-  ): void {
-    this.getDelegate().endSessionPartInternal(reason, userSessionEndReason);
+  public endSessionPartInternal(options: EndSessionPartOptions): void {
+    this.getDelegate().endSessionPartInternal(options);
   }
 
   public incrSessionPartCountForKey(key: string): void {

--- a/packages/web-sdk/src/api-sessions/sessionAPI.test.ts
+++ b/packages/web-sdk/src/api-sessions/sessionAPI.test.ts
@@ -57,7 +57,7 @@ describe('sessionAPI', () => {
         storage: setupTestStorage(),
         visibilityDoc: window.document,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       session.setGlobalUserSessionManager(manager);
     });
 

--- a/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
@@ -41,7 +41,7 @@ describe('ClicksInstrumentation', () => {
       visibilityDoc: window.document,
     });
     session.setGlobalUserSessionManager(userSessionManager);
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
     testContainer = document.createElement('div');
     document.body.append(testContainer);
   });
@@ -60,7 +60,9 @@ describe('ClicksInstrumentation', () => {
     testContainer.append(target);
 
     target.click();
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -86,7 +88,9 @@ describe('ClicksInstrumentation', () => {
     target.disabled = true;
     testContainer.append(target);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -104,7 +108,9 @@ describe('ClicksInstrumentation', () => {
     testContainer.append(target);
 
     target.click();
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -131,7 +137,9 @@ describe('ClicksInstrumentation', () => {
     testContainer.append(target);
 
     target.click();
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -165,7 +173,9 @@ describe('ClicksInstrumentation', () => {
     t2.click();
     t1.click();
     t2.click();
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -221,7 +231,9 @@ describe('ClicksInstrumentation', () => {
     t2.click();
     instrumentation.disable();
     t1.click();
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -252,7 +264,9 @@ describe('ClicksInstrumentation', () => {
     testContainer.append(t2);
 
     t2.click();
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     t1.click();
 
     const finishedSpans = memoryExporter.getFinishedSpans();
@@ -286,7 +300,9 @@ describe('ClicksInstrumentation', () => {
 
     target1.click();
     target2.click();
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -323,7 +339,9 @@ describe('ClicksInstrumentation', () => {
 
     target1.click();
     target2.click();
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);

--- a/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
@@ -39,7 +39,7 @@ describe('EmptyInstrumentation', () => {
       visibilityDoc: window.document,
     });
     session.setGlobalUserSessionManager(userSessionManager);
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
   });
 
   afterEach(() => {
@@ -67,7 +67,9 @@ describe('EmptyInstrumentation', () => {
     await new Promise((r) => setTimeout(r, 1));
 
     // The instrumentation shouldn't immediately emit the event
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     let finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -75,12 +77,14 @@ describe('EmptyInstrumentation', () => {
     expect(sessionSpan.events).to.have.lengthOf(0);
     memoryExporter.reset();
 
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     await new Promise((r) => setTimeout(r, 20));
 
     // Should now emit if the node is still empty after the timeout
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     sessionSpan = finishedSpans[0];
@@ -115,7 +119,9 @@ describe('EmptyInstrumentation', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     // Should not emit the event
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -147,7 +153,9 @@ describe('EmptyInstrumentation', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     // Should not emit the event
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -175,7 +183,9 @@ describe('EmptyInstrumentation', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     // Should not emit the event
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -200,7 +210,9 @@ describe('EmptyInstrumentation', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     // Should not emit the event
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];

--- a/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.test.ts
@@ -225,7 +225,7 @@ describe('FirstInteractionInstrumentation', () => {
       'first_interaction.interaction_type': 'click',
     });
 
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     const target2 = document.createElement('a');
     target2.id = 'b';
@@ -273,7 +273,7 @@ describe('FirstInteractionInstrumentation', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
     instrumentation.disable();
 
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     const target = document.createElement('button');
     testContainer.append(target);

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
@@ -110,7 +110,7 @@ describe('LoafInstrumentation', () => {
       storage,
       visibilityDoc: window.document,
     });
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
     const logManager = new EmbraceLogManager({
       userSessionManager,
       limitManager,
@@ -170,7 +170,9 @@ describe('LoafInstrumentation', () => {
       }),
     ]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const logs = memoryExporter.getFinishedLogRecords();
     const report = logs.find((l) => l.eventName === 'emb-loaf-report');
@@ -206,7 +208,9 @@ describe('LoafInstrumentation', () => {
       makeEntry({ startTime: 200, duration: 80, renderStart: 0 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -229,7 +233,9 @@ describe('LoafInstrumentation', () => {
       makeEntry({ startTime: 200, duration: 80, styleAndLayoutStart: 0 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -253,7 +259,9 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 30, firstUIEventTimestamp: 0 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -276,7 +284,9 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 30, firstUIEventTimestamp: 12345 }), // interaction-driven
     ]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -293,7 +303,9 @@ describe('LoafInstrumentation', () => {
     });
     instrumentation.setUserSessionManager(userSessionManager);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const logs = memoryExporter.getFinishedLogRecords();
     const reports = logs.filter((l) => l.eventName === 'emb-loaf-report');
@@ -333,8 +345,10 @@ describe('LoafInstrumentation', () => {
     triggerEntries([makeEntry()]);
 
     // Re-create a session to trigger end
-    userSessionManager.startSessionPartInternal('init');
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const reports = memoryExporter
       .getFinishedLogRecords()
@@ -359,7 +373,9 @@ describe('LoafInstrumentation', () => {
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([makeEntry({ duration: 100 })]);
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -383,7 +399,9 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 200 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -405,7 +423,9 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 201 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -429,7 +449,9 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 600 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -453,7 +475,9 @@ describe('LoafInstrumentation', () => {
       makeEntry({ blockingDuration: 601 }),
     ]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -474,7 +498,9 @@ describe('LoafInstrumentation', () => {
     instrumentation.enable();
 
     triggerEntries([makeEntry({ duration: 60 })]);
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const reports = memoryExporter
       .getFinishedLogRecords()
@@ -502,7 +528,7 @@ describe('LoafInstrumentation', () => {
       storage: storage2,
       visibilityDoc: window.document,
     });
-    userSessionManager2.startSessionPartInternal('init');
+    userSessionManager2.startSessionPartInternal({ reason: 'init' });
     const logManager2 = new EmbraceLogManager({
       userSessionManager: userSessionManager2,
       limitManager: limitManager2,
@@ -514,7 +540,9 @@ describe('LoafInstrumentation', () => {
     instrumentation.setUserSessionManager(userSessionManager2);
 
     triggerEntries([makeEntry({ duration: 90 })]);
-    userSessionManager2.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager2.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const reports = memoryExporter
       .getFinishedLogRecords()
@@ -546,7 +574,9 @@ describe('LoafInstrumentation', () => {
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([makeEntry({ duration: 100 })]);
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const firstReport = memoryExporter
       .getFinishedLogRecords()
@@ -555,10 +585,12 @@ describe('LoafInstrumentation', () => {
     expect(firstId).to.be.a('string').and.to.have.length.greaterThan(0);
 
     memoryExporter.reset();
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     triggerEntries([makeEntry({ duration: 80 })]);
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const secondReport = memoryExporter
       .getFinishedLogRecords()
@@ -578,7 +610,9 @@ describe('LoafInstrumentation', () => {
 
     triggerEntries([makeEntry({ duration: 100 }), makeEntry({ duration: 80 })]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const firstReport = memoryExporter
       .getFinishedLogRecords()
@@ -591,11 +625,13 @@ describe('LoafInstrumentation', () => {
 
     memoryExporter.reset();
 
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     triggerEntries([makeEntry({ duration: 60 }), makeEntry({ duration: 40 })]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const secondReport = memoryExporter
       .getFinishedLogRecords()
@@ -627,7 +663,9 @@ describe('LoafInstrumentation', () => {
       }),
     ]);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const report = memoryExporter
       .getFinishedLogRecords()
@@ -677,7 +715,9 @@ describe('LoafInstrumentation', () => {
       throw new Error('emit failed');
     };
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     expect(diagLogger.getErrorLogs().length).to.be.greaterThan(0);
 
@@ -730,7 +770,9 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
 
       const logs = memoryExporter.getFinishedLogRecords();
       const summary = logs.find((l) => l.eventName === 'emb-loaf-scripts');
@@ -778,7 +820,9 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
 
       const summary = memoryExporter
         .getFinishedLogRecords()
@@ -807,7 +851,9 @@ describe('LoafInstrumentation', () => {
       ) as unknown as PerformanceLongAnimationFrameTiming['scripts'];
 
       triggerEntries([makeEntry({ scripts })]);
-      userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
 
       const summary = memoryExporter
         .getFinishedLogRecords()
@@ -826,7 +872,9 @@ describe('LoafInstrumentation', () => {
 
       triggerEntries([makeEntry({ scripts: [] })]);
 
-      userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
 
       const summaries = memoryExporter
         .getFinishedLogRecords()
@@ -852,10 +900,12 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
       memoryExporter.reset();
 
-      userSessionManager.startSessionPartInternal('init');
+      userSessionManager.startSessionPartInternal({ reason: 'init' });
 
       triggerEntries([
         makeEntry({
@@ -869,7 +919,9 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
 
       const summary = memoryExporter
         .getFinishedLogRecords()
@@ -905,7 +957,9 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
 
       const summary = memoryExporter
         .getFinishedLogRecords()
@@ -939,7 +993,9 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
 
       const logs = memoryExporter.getFinishedLogRecords();
       const report = logs.find((l) => l.eventName === 'emb-loaf-report');
@@ -976,7 +1032,9 @@ describe('LoafInstrumentation', () => {
         }),
       ]);
 
-      userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
 
       const summary = memoryExporter
         .getFinishedLogRecords()

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
@@ -203,8 +203,10 @@ describe('NavigationInstrumentation', () => {
 
     expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(0);
     // Start and end session to test that listeners are cleaned up
-    userSessionManager.startSessionPartInternal('init');
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     navigationInstrumentation.setCurrentRoute({
       path: '/test/:id',
@@ -221,7 +223,7 @@ describe('NavigationInstrumentation', () => {
   });
 
   it('should start and end route span when session part ends', () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     navigationInstrumentation = new NavigationInstrumentation({ diag });
     navigationInstrumentation.setCurrentRoute({
@@ -231,7 +233,9 @@ describe('NavigationInstrumentation', () => {
 
     expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(0);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     // Session part span and route span
@@ -256,7 +260,7 @@ describe('NavigationInstrumentation', () => {
   });
 
   it('should start the route span when the session part starts if it was previously ended', () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     navigationInstrumentation = new NavigationInstrumentation({ diag });
     navigationInstrumentation.setCurrentRoute({
@@ -266,14 +270,18 @@ describe('NavigationInstrumentation', () => {
 
     expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(0);
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     // At this point we should have two spans: one for the session and one for the route
     expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(2);
 
     // Start and finish another session without changing the route
-    userSessionManager.startSessionPartInternal('init');
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     // 2 sessions and 2 route spans
@@ -313,7 +321,7 @@ describe('NavigationInstrumentation', () => {
 
   it('should work correctly after disable() then enable()', () => {
     navigationInstrumentation = new NavigationInstrumentation({ diag });
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     navigationInstrumentation.setCurrentRoute({
       path: '/first',
@@ -328,7 +336,9 @@ describe('NavigationInstrumentation', () => {
       url: '/second',
     });
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     const navigationSpans = finishedSpans.filter(

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV5/ReactRouterV5.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV5/ReactRouterV5.test.tsx
@@ -95,7 +95,7 @@ describe('ReactRouterV5Legacy', () => {
   });
 
   it('create route spans', async () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     expect(pageManager.getCurrentPageId()).to.be.null;
     expect(pageManager.getCurrentRoute()).to.be.null;
@@ -107,7 +107,10 @@ describe('ReactRouterV5Legacy', () => {
       rootElement: container,
     });
 
-    userSessionManager.endSessionPartInternal('user_session_ended', 'manual');
+    userSessionManager.endSessionPartInternal({
+      reason: 'user_session_ended',
+      userSessionEndReason: 'manual',
+    });
     tearDown();
 
     const routeSpans = memoryExporter

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Data/ReactRouterV6Data.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Data/ReactRouterV6Data.test.tsx
@@ -132,7 +132,7 @@ describe('ReactRouterV6Data', () => {
   });
 
   it('create route spans', async () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     expect(pageManager.getCurrentPageId()).to.be.null;
     expect(pageManager.getCurrentRoute()).to.be.null;
@@ -144,7 +144,10 @@ describe('ReactRouterV6Data', () => {
       rootElement: container,
     });
 
-    userSessionManager.endSessionPartInternal('user_session_ended', 'manual');
+    userSessionManager.endSessionPartInternal({
+      reason: 'user_session_ended',
+      userSessionEndReason: 'manual',
+    });
     tearDown();
 
     const routeSpans = memoryExporter

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Declarative/ReactRouterV6Declarative.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Declarative/ReactRouterV6Declarative.test.tsx
@@ -107,7 +107,7 @@ describe('ReactRouterV6Declarative', () => {
   });
 
   it('create route spans', async () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     expect(pageManager.getCurrentPageId()).to.be.null;
     expect(pageManager.getCurrentRoute()).to.be.null;
@@ -119,7 +119,10 @@ describe('ReactRouterV6Declarative', () => {
       rootElement: container,
     });
 
-    userSessionManager.endSessionPartInternal('user_session_ended', 'manual');
+    userSessionManager.endSessionPartInternal({
+      reason: 'user_session_ended',
+      userSessionEndReason: 'manual',
+    });
     tearDown();
 
     const routeSpans = memoryExporter

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
@@ -60,7 +60,7 @@ describe('ServerTimingInstrumentation', () => {
       storage,
       visibilityDoc: window.document,
     });
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
     const logManager = new EmbraceLogManager({
       userSessionManager,
       limitManager,

--- a/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
@@ -125,7 +125,7 @@ describe('UserTimingInstrumentation', () => {
       storage,
       visibilityDoc: window.document,
     });
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
     const logManager = new EmbraceLogManager({
       userSessionManager,
       limitManager,

--- a/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
@@ -520,7 +520,7 @@ describe('EmbraceLogManager', () => {
   });
 
   it('should report counts of logging on the active session part span', () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     // Error logs should be counted
     manager.message('this is an error log', 'error');
@@ -544,7 +544,9 @@ describe('EmbraceLogManager', () => {
       handled: true,
     });
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -562,8 +564,10 @@ describe('EmbraceLogManager', () => {
       });
     }).to.not.throw();
 
-    userSessionManager.startSessionPartInternal('init');
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
 
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -577,7 +581,7 @@ describe('EmbraceLogManager', () => {
   });
 
   it('should limit the amount of logs per severity per session', () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     for (let i = 0; i < 10; i++) {
       manager.message('this is a warning log', 'warning');
@@ -600,7 +604,9 @@ describe('EmbraceLogManager', () => {
       expect(finishedLogs[i].body).to.equal('this is an error log');
     }
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -621,7 +627,7 @@ describe('EmbraceLogManager', () => {
 
     // A new session should reset the limit
     memoryExporter.reset();
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
     manager.message('this is a warning log', 'warning');
     const nextSessionFinishedLogs = memoryExporter.getFinishedLogRecords();
     expect(nextSessionFinishedLogs).to.have.lengthOf(1);
@@ -629,7 +635,7 @@ describe('EmbraceLogManager', () => {
   });
 
   it('should truncate log messages', () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     manager.message('this is an info log', 'info');
     manager.message(
@@ -644,7 +650,9 @@ describe('EmbraceLogManager', () => {
       'this is an info log which has a message longer than the allo',
     );
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -661,7 +669,7 @@ describe('EmbraceLogManager', () => {
   });
 
   it('should truncate the number of log attributes', () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     manager.message('this is an error log', 'error', {
       attributes: {
@@ -693,7 +701,9 @@ describe('EmbraceLogManager', () => {
     // Seems to be deterministic that this is always the one to be removed, adding sorting if the test becomes flaky
     expect(finishedLogs[1].attributes).not.to.have.property('key3');
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -710,7 +720,7 @@ describe('EmbraceLogManager', () => {
   });
 
   it('should truncate the key and value of a log attribute', () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     manager.message('this is an error log', 'error', {
       attributes: {
@@ -726,7 +736,9 @@ describe('EmbraceLogManager', () => {
       'a-very-long-',
     );
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -751,7 +763,7 @@ describe('EmbraceLogManager', () => {
   });
 
   it('should limit the amount of exceptions per session', () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     for (let i = 0; i < 10; i++) {
       manager.logException(new Error('this is an exception'));
@@ -764,7 +776,9 @@ describe('EmbraceLogManager', () => {
       expect(finishedLogs[i].body).to.equal('this is an exception');
     }
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -782,7 +796,7 @@ describe('EmbraceLogManager', () => {
 
     // A new session should reset the limit
     memoryExporter.reset();
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
     manager.logException(new Error('this is an exception'));
     const nextSessionFinishedLogs = memoryExporter.getFinishedLogRecords();
     expect(nextSessionFinishedLogs).to.have.lengthOf(1);
@@ -790,7 +804,7 @@ describe('EmbraceLogManager', () => {
   });
 
   it('should truncate exception messages', () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     manager.logException(
       new Error(
@@ -804,7 +818,9 @@ describe('EmbraceLogManager', () => {
       'this is an exception which has a message longer th',
     );
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -821,7 +837,7 @@ describe('EmbraceLogManager', () => {
   });
 
   it('should truncate the number of exception attributes', () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     manager.logException('this is an exception', {
       attributes: {
@@ -856,7 +872,9 @@ describe('EmbraceLogManager', () => {
     expect(finishedLogs[1].attributes['key3']).to.be.equal('3');
     expect(finishedLogs[1].attributes).not.to.have.property('key4');
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];
@@ -873,7 +891,7 @@ describe('EmbraceLogManager', () => {
   });
 
   it('should truncate the key and value of an exception attribute', () => {
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     manager.logException('this is an exception', {
       attributes: {
@@ -890,7 +908,9 @@ describe('EmbraceLogManager', () => {
       'a-very-long-',
     );
 
-    userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
     const finishedSpans = spanExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionSpan = finishedSpans[0];

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -17,6 +17,10 @@ import {
   EmbraceLimitManager,
 } from '../EmbraceLimitManager/index.ts';
 import { EmbraceUserSessionManager } from './EmbraceUserSessionManager.ts';
+import type {
+  EndSessionPartOptions,
+  StartSessionPartOptions,
+} from './types.ts';
 
 chai.use(sinonChai);
 const { expect } = chai;
@@ -61,16 +65,16 @@ describe('EmbraceUserSessionManager browser activity', () => {
   let clock: sinon.SinonFakeTimers;
   let target: FakeTarget;
   let manager: EmbraceUserSessionManager;
-  let startSpy: sinon.SinonSpy<[reason: SessionPartStartReason], void>;
+  let startSpy: sinon.SinonSpy<[options: StartSessionPartOptions], void>;
   let endSpy: sinon.SinonSpy;
   let visibilityDoc: FakeVisibilityDoc;
 
   // Pulls reasons from the spies in the same order startSessionPartInternal /
   // endSessionPartInternal were invoked.
   const startReasons = (): SessionPartStartReason[] =>
-    startSpy.getCalls().map((c) => c.args[0]);
+    startSpy.getCalls().map((c) => c.args[0].reason);
   const endReasons = (): SessionPartEndReason[] =>
-    endSpy.getCalls().map((c) => c.args[0] as SessionPartEndReason);
+    endSpy.getCalls().map((c) => (c.args[0] as EndSessionPartOptions).reason);
 
   beforeEach(() => {
     clock = sinon.useFakeTimers({ now: 0 });
@@ -150,7 +154,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   };
 
   it('arms the part-inactivity timer when a part starts', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     clock.tick(FOREGROUND_INACTIVITY_MS - 1);
     expect(endReasons()).to.deep.equal([]);
@@ -160,7 +164,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('resets the part-inactivity timer on activity', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     clock.tick(FOREGROUND_INACTIVITY_MS - 1);
     fireActivity();
@@ -173,7 +177,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('throttles activity events within the throttle window', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     fireActivity();
     clock.tick(THROTTLE_MS - 1);
@@ -186,19 +190,21 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('ends the part with reason web_foreground_inactivity when the part-inactivity window elapses', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     clock.tick(FOREGROUND_INACTIVITY_MS);
 
     expect(endReasons()).to.deep.equal(['web_foreground_inactivity']);
     // The part end reason is web-prefixed, but the enclosing user session's
     // termination reason stays unprefixed for cross-platform correlation.
-    expect(endSpy.lastCall.args[1]).to.equal('inactivity');
+    expect(
+      (endSpy.lastCall.args[0] as EndSessionPartOptions).userSessionEndReason,
+    ).to.equal('inactivity');
     void expect(manager.getSessionPartId()).to.be.null;
   });
 
   it('starts a new part with reason activity after an inactivity-killed part', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     clock.tick(FOREGROUND_INACTIVITY_MS);
     void expect(manager.getSessionPartId()).to.be.null;
@@ -222,17 +228,20 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('clears the part-inactivity timer when a part ends through another path', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     clock.tick(FOREGROUND_INACTIVITY_MS / 2);
-    manager.endSessionPartInternal('user_session_ended', 'manual');
+    manager.endSessionPartInternal({
+      reason: 'user_session_ended',
+      userSessionEndReason: 'manual',
+    });
 
     clock.tick(FOREGROUND_INACTIVITY_MS);
     expect(endReasons()).to.deep.equal(['user_session_ended']);
   });
 
   it('ends the active part with reason background when the tab hides', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     fireVisibilityChange('hidden');
 
@@ -248,7 +257,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('starts a new part with reason foreground when the tab returns to visible', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     fireVisibilityChange('hidden');
     void expect(manager.getSessionPartId()).to.be.null;
@@ -260,7 +269,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('ignores pagehide and pageshow events (no listeners registered)', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     target.dispatchEvent(
       new PageTransitionEvent('pagehide', { persisted: false }),
@@ -281,7 +290,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('ends the active part with reason background when the window loses focus', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     fireBlur();
 
@@ -290,7 +299,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('starts a new part with reason foreground when focus returns to a visible tab', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     fireBlur();
     void expect(manager.getSessionPartId()).to.be.null;
@@ -302,7 +311,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('ignores activity events on a visible-but-unfocused tab', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     fireBlur();
 
     fireActivity();
@@ -319,7 +328,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   // in production.
 
   it('ends the active part exactly once as web_background on a real active-tab unload sequence', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     fireFocusShiftingUnload();
 
@@ -329,7 +338,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('ends on visibilitychange-to-hidden for an already-backgrounded tab unload', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     fireTabHidden();
 
@@ -339,7 +348,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('starts the new part exactly once as web_foreground on a real BFCache restore sequence', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     fireTabHidden();
     startSpy.resetHistory();
     endSpy.resetHistory();
@@ -352,7 +361,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('nets to one end and one start across a full active-tab unload then BFCache restore round-trip', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     fireFocusShiftingUnload();
     fireBfcacheRestore();
@@ -365,7 +374,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('re-arms the part-inactivity timer when an engagement event fires while already engaged and active', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     clock.tick(FOREGROUND_INACTIVITY_MS - 1);
     // Redundant focus event while the tab is still engaged and the part is
@@ -385,7 +394,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   it('starts a fresh part when an activity event arrives just after the prior part finalized', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     // Inactivity expires; the part finalizes. Then user activity resumes;
     // the next event must start a new part with reason 'web_activity'.
@@ -415,21 +424,22 @@ describe('EmbraceUserSessionManager browser activity', () => {
     splitManager.setTracerProvider(new WebTracerProvider());
     const endSpy2 = sinon.spy(splitManager, 'endSessionPartInternal');
 
-    splitManager.startSessionPartInternal('init');
+    splitManager.startSessionPartInternal({ reason: 'init' });
 
     // Live timer fires on the 60s foreground value, not the 1800s inactivity value.
     clock.tick(60 * 1000 - 1);
     expect(endSpy2.called).to.equal(false);
     clock.tick(1);
     expect(endSpy2.callCount).to.equal(1);
-    expect(endSpy2.lastCall.args[0]).to.equal('web_foreground_inactivity');
-    expect(endSpy2.lastCall.args[1]).to.equal('inactivity');
+    const endOptions2 = endSpy2.lastCall.args[0] as EndSessionPartOptions;
+    expect(endOptions2.reason).to.equal('web_foreground_inactivity');
+    expect(endOptions2.userSessionEndReason).to.equal('inactivity');
 
     splitManager._shutdown();
   });
 
   it('removes listeners and clears the timer on shutdown', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     expect(target.listenerCount('keydown')).to.equal(1);
     expect(target.listenerCount('focus')).to.equal(1);
@@ -451,7 +461,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
     expect(endSpy.callCount).to.equal(endCallsBeforeVisibility);
 
     // The internal part-inactivity timer was cleared on shutdown, so no
-    // further endSessionPartInternal('web_foreground_inactivity') calls fire.
+    // further endSessionPartInternal({ reason: 'web_foreground_inactivity' }) calls fire.
     const endCallsBefore = endSpy.callCount;
     clock.tick(FOREGROUND_INACTIVITY_MS * 2);
     expect(endSpy.callCount).to.equal(endCallsBefore);

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
@@ -91,7 +91,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   it('should start a session part', () => {
     void expect(manager.getSessionPartSpan()).to.be.null;
     void expect(manager.getSessionPartId()).to.be.null;
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     void expect(manager.getSessionPartSpan()).to.not.be.null;
     void expect(manager.getSessionPartId()).to.not.be.null;
   });
@@ -99,11 +99,11 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   it('should end the session part', () => {
     void expect(manager.getSessionPartSpan()).to.be.null;
     void expect(manager.getSessionPartId()).to.be.null;
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     void expect(manager.getSessionPartSpan()).to.not.be.null;
     const sessionPartId = manager.getSessionPartId();
     void expect(sessionPartId).to.not.be.null;
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
     void expect(manager.getSessionPartSpan()).to.be.null;
     void expect(manager.getSessionPartId()).to.be.null;
     const finishedSpans = memoryExporter.getFinishedSpans();
@@ -120,11 +120,11 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   });
 
   it('should ignore startSessionPartInternal calls when a part is already active', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const sessionPartId = manager.getSessionPartId();
     void expect(sessionPartId).to.not.be.null;
 
-    manager.startSessionPartInternal('web_activity');
+    manager.startSessionPartInternal({ reason: 'web_activity' });
 
     // Active part is unchanged, no part spans were finalized.
     expect(manager.getSessionPartId()).to.equal(sessionPartId);
@@ -136,7 +136,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   });
 
   it('should not end a session if there is no active session', () => {
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(0);
     expect(diag.getDebugLogs()).to.have.lengthOf(1);
@@ -155,12 +155,12 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   });
 
   it('should add breadcrumb to session part span', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     void expect(manager.getSessionPartSpan()).to.not.be.null;
     void expect(manager.getSessionPartId()).to.not.be.null;
 
     manager.addBreadcrumb('some breadcrumb');
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -180,8 +180,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     // made before the first part lands in the state row and gets stamped
     // on the part span when it starts.
     manager.addProperty('queued-property', 'queued-value');
-    manager.startSessionPartInternal('init');
-    manager.endSessionPartInternal('web_background');
+    manager.startSessionPartInternal({ reason: 'init' });
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -192,11 +192,11 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   });
 
   it('should add properties to session part span', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     manager.addProperty('custom-property-1', 'custom value1');
     manager.addProperty('custom-property-2', 'custom value2');
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -232,8 +232,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       storage,
       dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
-    localManager.startSessionPartInternal('init');
-    localManager.endSessionPartInternal('web_background');
+    localManager.startSessionPartInternal({ reason: 'init' });
+    localManager.endSessionPartInternal({ reason: 'web_background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -273,7 +273,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         storage,
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
-      localManager.startSessionPartInternal('init');
+      localManager.startSessionPartInternal({ reason: 'init' });
       void expect(localManager.getSessionPartId()).to.be.null;
       void expect(localManager.getSessionPartSpan()).to.be.null;
 
@@ -295,12 +295,12 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
     void expect(listener.calledOnce).to.be.false;
 
-    localManager.startSessionPartInternal('init');
+    localManager.startSessionPartInternal({ reason: 'init' });
 
     void expect(listener.calledOnce).to.be.true;
 
     removeListener();
-    localManager.startSessionPartInternal('init');
+    localManager.startSessionPartInternal({ reason: 'init' });
 
     void expect(listener.calledOnce).to.be.true;
   });
@@ -322,28 +322,28 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
     void expect(listenerSessionPartId).to.be.null;
 
-    localManager.startSessionPartInternal('init');
+    localManager.startSessionPartInternal({ reason: 'init' });
     let sessionPartId = localManager.getSessionPartId();
-    localManager.endSessionPartInternal('web_background');
+    localManager.endSessionPartInternal({ reason: 'web_background' });
 
     void expect(listenerSessionPartId).to.be.eq(sessionPartId);
 
     removeListener();
-    localManager.startSessionPartInternal('init');
+    localManager.startSessionPartInternal({ reason: 'init' });
     sessionPartId = localManager.getSessionPartId();
-    localManager.endSessionPartInternal('web_background');
+    localManager.endSessionPartInternal({ reason: 'web_background' });
 
     void expect(listenerSessionPartId).not.to.be.eq(sessionPartId);
   });
 
   it('should limit the amount of breadcrumbs per session', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     for (let i = 0; i < 10; i++) {
       manager.addBreadcrumb('this is a breadcrumb');
     }
 
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionPartSpan = finishedSpans[0];
@@ -371,9 +371,9 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
     // A new session should reset the limit
     memoryExporter.reset();
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.addBreadcrumb('this is a breadcrumb');
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
     const nextSessionFinishedSpans = memoryExporter.getFinishedSpans();
     expect(nextSessionFinishedSpans).to.have.lengthOf(1);
     const nextSessionPartSpan = nextSessionFinishedSpans[0];
@@ -386,14 +386,14 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   });
 
   it('should truncate breadcrumb names', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     manager.addBreadcrumb('this is a breadcrumb');
     manager.addBreadcrumb(
       'this is a breadcrumb which has a name longer than the allowed maximum length',
     );
 
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionPartSpan = finishedSpans[0];
@@ -422,13 +422,13 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   });
 
   it('should limit the amount of session properties per session', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     for (let i = 0; i < 10; i++) {
       manager.addProperty(`property${i.toString()}`, i.toString());
     }
 
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionPartSpan = finishedSpans[0];
@@ -461,9 +461,9 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
     // A new session should reset the limit
     memoryExporter.reset();
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.addProperty('my-new-prop', 'new');
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
     const nextSessionFinishedSpans = memoryExporter.getFinishedSpans();
     expect(nextSessionFinishedSpans).to.have.lengthOf(1);
     const nextSessionPartSpan = nextSessionFinishedSpans[0];
@@ -474,7 +474,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   });
 
   it('should truncate session property keys and values', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     manager.addProperty('key1', '1');
     manager.addProperty(
@@ -482,7 +482,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       'session property long value with extra information',
     );
 
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionPartSpan = finishedSpans[0];
@@ -517,7 +517,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     const propertyKey = 'permanent-key';
     const value = 'permanent-value';
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.addProperty(propertyKey, value, {
       lifespan: 'permanent',
     });
@@ -536,7 +536,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       value,
     );
 
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     // Survives across user-session boundaries.
     expect(blob('embrace_permanent_properties')).to.have.property(
@@ -548,7 +548,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   it('should persist user-session-scoped properties inside the user-session state blob with bare keys', () => {
     const propertyKey = 'session-only-key';
     const value = 'session-only-value';
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.addProperty(propertyKey, value);
 
     // Not a top-level entry: that path is reserved for permanent properties,
@@ -574,9 +574,9 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     const attributeKey = `emb.properties.${propertyKey}`;
     const value = '3';
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.addProperty(propertyKey, value);
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     const secondManager = new EmbraceUserSessionManager({
       diag,
@@ -586,8 +586,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       visibilityDoc: window.document,
       dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
-    secondManager.startSessionPartInternal('init');
-    secondManager.endSessionPartInternal('web_background');
+    secondManager.startSessionPartInternal({ reason: 'init' });
+    secondManager.endSessionPartInternal({ reason: 'web_background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(2);
@@ -627,7 +627,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       visibilityDoc: window.document,
       dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
-    flipManager.startSessionPartInternal('init');
+    flipManager.startSessionPartInternal({ reason: 'init' });
     flipManager.addProperty('cart', '3');
 
     permanentWriteShouldFail = true;
@@ -657,7 +657,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       visibilityDoc: window.document,
       dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
-    failingManager.startSessionPartInternal('init');
+    failingManager.startSessionPartInternal({ reason: 'init' });
 
     expect(() => failingManager.addProperty('flag', 'on')).to.not.throw();
 
@@ -683,17 +683,17 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       return raw ? (JSON.parse(raw) as Record<string, string>) : {};
     };
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.addProperty(propertyKey, value, {
       lifespan: 'permanent',
     });
     expect(blob()).to.have.property(propertyKey, value);
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.removeProperty(propertyKey);
     void expect(blob()[propertyKey]).to.be.undefined;
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     void expect(blob()[propertyKey]).to.be.undefined;
   });
@@ -709,14 +709,14 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     const permanentPropertyKey = 'permanent-key';
     const permanentValue = 'permanent-value';
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.addProperty(sessionOnlyPropertyKey, sessionOnlyValue);
     manager.addProperty(permanentPropertyKey, permanentValue, {
       lifespan: 'permanent',
     });
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     expect(manager.getSessionPartProperties()).to.have.property(
       sessionOnlyPropertyKey,
       sessionOnlyValue,
@@ -737,7 +737,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     const sessionOnlyPropertyKey = 'session-only-key';
     const permanentPropertyKey = 'permanent-key';
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.addProperty(sessionOnlyPropertyKey, 'session-only-value');
     manager.addProperty(permanentPropertyKey, 'permanent-value', {
       lifespan: 'permanent',
@@ -757,17 +757,17 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     const propertyKey = 'permanent-key';
     const value = 'permanent-value';
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.addProperty(propertyKey, value, {
       lifespan: 'permanent',
     });
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.removeProperty(propertyKey);
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     expect(manager.getSessionPartProperties()).to.not.have.property(
       propertyKey,
       value,
@@ -779,13 +779,13 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     const truncatedKey = 'permanent-key-that-i';
     const value = 'permanent-value';
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.addProperty(propertyKey, value, {
       lifespan: 'permanent',
     });
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     expect(manager.getSessionPartProperties()).to.have.property(
       truncatedKey,
       value,
@@ -795,9 +795,9 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       value,
     );
     manager.removeProperty(propertyKey);
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     expect(manager.getSessionPartProperties()).to.not.have.property(
       truncatedKey,
       value,
@@ -821,8 +821,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
 
-    failingManager.startSessionPartInternal('init');
-    failingManager.endSessionPartInternal('web_background');
+    failingManager.startSessionPartInternal({ reason: 'init' });
+    failingManager.endSessionPartInternal({ reason: 'web_background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -845,7 +845,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       visibilityDoc: window.document,
       dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
-    failingManager.startSessionPartInternal('init');
+    failingManager.startSessionPartInternal({ reason: 'init' });
 
     expect(() =>
       failingManager.addProperty('flag', 'on', { lifespan: 'permanent' }),
@@ -893,7 +893,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       visibilityDoc: window.document,
       dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
-    flakyManager.startSessionPartInternal('init');
+    flakyManager.startSessionPartInternal({ reason: 'init' });
 
     expect(() => flakyManager.removeProperty('flag')).to.not.throw();
     expect(
@@ -902,7 +902,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   });
 
   it('should be a silent no-op when removeProperty is called for a key that was never set', () => {
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     expect(() => manager.removeProperty('never-set')).to.not.throw();
     // No storage write happens, no warning is logged.
     expect(
@@ -917,8 +917,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     });
 
     manager.setTracerProvider(tracerProvider);
-    manager.startSessionPartInternal('init');
-    manager.endSessionPartInternal('web_background');
+    manager.startSessionPartInternal({ reason: 'init' });
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(0);
     expect(secondMemoryExporter.getFinishedSpans()).to.have.lengthOf(1);
@@ -932,8 +932,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       });
       manager.setTracerProvider(tracerProvider);
 
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = exporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(1);
@@ -963,7 +963,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         visibilityDoc: window.document,
       });
 
-      localManager.startSessionPartInternal('init');
+      localManager.startSessionPartInternal({ reason: 'init' });
       const firstPartId = localManager.getSessionPartId();
 
       localManager.endUserSession();
@@ -973,7 +973,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     });
 
     it('should mark the session part as final when user session terminates', () => {
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       manager.endUserSession();
 
       const finishedSpans = memoryExporter.getFinishedSpans();
@@ -1023,7 +1023,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
 
-      localManager.startSessionPartInternal('init');
+      localManager.startSessionPartInternal({ reason: 'init' });
       stateOps.length = 0;
 
       localManager.endUserSession();
@@ -1048,7 +1048,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         visibilityDoc: window.document,
       });
 
-      localManager.startSessionPartInternal('init');
+      localManager.startSessionPartInternal({ reason: 'init' });
 
       clock.tick(3601 * 1000);
 
@@ -1100,7 +1100,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         }),
       });
 
-      localManager.startSessionPartInternal('init');
+      localManager.startSessionPartInternal({ reason: 'init' });
       const firstUserSessionId = localManager.getUserSessionId();
       const firstPartId = localManager.getSessionPartId();
       void expect(firstPartId).to.not.be.null;
@@ -1127,11 +1127,11 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       );
 
       // Tab becomes engaged again. The manager's _onEngagementChange would
-      // call startSessionPartInternal('web_foreground') in production;
+      // call startSessionPartInternal({ reason: 'web_foreground' }) in production;
       // simulate that here. A new user session is created.
       visibilityState.current = 'visible';
       visibilityState.focused = true;
-      localManager.startSessionPartInternal('web_foreground');
+      localManager.startSessionPartInternal({ reason: 'web_foreground' });
 
       void expect(localManager.getSessionPartId()).to.not.be.null;
       expect(localManager.getSessionPartId()).to.not.equal(firstPartId);
@@ -1153,24 +1153,24 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         visibilityDoc: window.document,
       });
 
-      localManager.startSessionPartInternal('init');
+      localManager.startSessionPartInternal({ reason: 'init' });
       const firstUserSessionId = localManager.getUserSessionId();
-      localManager.endSessionPartInternal('web_background');
+      localManager.endSessionPartInternal({ reason: 'web_background' });
 
       clock.tick(61 * 1000);
 
-      localManager.startSessionPartInternal('init');
+      localManager.startSessionPartInternal({ reason: 'init' });
       const secondUserSessionId = localManager.getUserSessionId();
 
       expect(secondUserSessionId).to.not.equal(firstUserSessionId);
     });
 
     it('should keep the same user session id across consecutive parts within inactivity timeout', () => {
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const firstUserSessionId = manager.getUserSessionId();
-      manager.endSessionPartInternal('web_background');
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const secondUserSessionId = manager.getUserSessionId();
 
       expect(secondUserSessionId).to.equal(firstUserSessionId);
@@ -1191,7 +1191,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       });
       localManager.setTracerProvider(tracerProvider);
 
-      localManager.startSessionPartInternal('init');
+      localManager.startSessionPartInternal({ reason: 'init' });
       const firstUserSessionId = localManager.getUserSessionId();
       void expect(firstUserSessionId).to.not.be.null;
 
@@ -1199,7 +1199,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       // brand new part span. The new part span must carry the previous user
       // session's id on emb.user_session_previous_id.
       localManager.endUserSession();
-      localManager.endSessionPartInternal('web_background');
+      localManager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = exporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1213,8 +1213,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
   describe('emb.session_part_start_reason', () => {
     it('should default to "init" on the part span when no reason is passed', () => {
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(1);
@@ -1225,8 +1225,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     });
 
     it('should stamp "activity" on the part span when started with that reason', () => {
-      manager.startSessionPartInternal('web_activity');
-      manager.endSessionPartInternal('web_background');
+      manager.startSessionPartInternal({ reason: 'web_activity' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(1);
@@ -1237,11 +1237,11 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     });
 
     it('should stamp "user_session_rollover" on the part span started by user-session rollover', () => {
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       // Triggers the rollover path inside endUserSession, which restarts a
       // part with reason 'user_session_rollover'.
       manager.endUserSession();
-      manager.endSessionPartInternal('web_background');
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1269,11 +1269,11 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         visibilityDoc: window.document,
       });
 
-      localManager.startSessionPartInternal('init');
+      localManager.startSessionPartInternal({ reason: 'init' });
 
       clock.tick(3601 * 1000);
 
-      localManager.endSessionPartInternal('web_background');
+      localManager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1290,8 +1290,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
   describe('emb.session_part_end_reason', () => {
     it('should stamp "background" when the part ends on visibility hidden', () => {
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(1);
@@ -1302,8 +1302,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     });
 
     it('should stamp "web_foreground_inactivity" when the inactivity timer ends the part', () => {
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_foreground_inactivity');
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(1);
@@ -1314,9 +1314,9 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     });
 
     it('should stamp "user_session_ended" when the user-session manager ends the part on rollover', () => {
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       manager.endUserSession();
-      manager.endSessionPartInternal('web_background');
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1333,10 +1333,10 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
   describe('emb.session_part_number', () => {
     it('emits a 1-indexed monotonic counter on the part span, persisted across visits', () => {
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1371,8 +1371,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
           .inactivityDeadlineTs;
       };
 
-      localManager.startSessionPartInternal('init');
-      localManager.endSessionPartInternal('web_background');
+      localManager.startSessionPartInternal({ reason: 'init' });
+      localManager.endSessionPartInternal({ reason: 'web_background' });
 
       // End-of-part writes an inactivity deadline onto the state row.
       const deadlineAfterEnd = readDeadline();
@@ -1383,7 +1383,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
       // A continuing part (still within the inactivity window) must clear
       // the deadline so a future part-start doesn't read a stale value.
-      localManager.startSessionPartInternal('init');
+      localManager.startSessionPartInternal({ reason: 'init' });
 
       void expect(readDeadline()).to.be.null;
     });
@@ -1407,8 +1407,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         .stub(EmbraceExtendedSpan.prototype, 'setAttributes')
         .throws(new Error('poisoned attribute value'));
 
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
       // The span must still be ended and exported, despite the throw.
       expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(1);
@@ -1437,11 +1437,11 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         .stub(EmbraceExtendedSpan.prototype, 'end')
         .throws(new Error('span-end exploded'));
 
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       void expect(manager.getSessionPartSpan()).to.not.be.null;
 
       expect(() =>
-        manager.endSessionPartInternal('web_background'),
+        manager.endSessionPartInternal({ reason: 'web_background' }),
       ).to.not.throw();
 
       void expect(manager.getSessionPartSpan()).to.be.null;
@@ -1456,12 +1456,12 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
   describe('emb.cold_start', () => {
     it('should stamp true on the first part and false on subsequent parts from the same manager', () => {
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(3);
@@ -1480,8 +1480,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     });
 
     it('should stamp true again on the first part from a new manager instance sharing storage', () => {
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
       const secondManager = new EmbraceUserSessionManager({
         diag,
@@ -1491,8 +1491,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         visibilityDoc: window.document,
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
-      secondManager.startSessionPartInternal('init');
-      secondManager.endSessionPartInternal('web_background');
+      secondManager.startSessionPartInternal({ reason: 'init' });
+      secondManager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1525,8 +1525,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         visibilityDoc: makeDoc('complete'),
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
-      localManager.startSessionPartInternal('init');
-      localManager.endSessionPartInternal('web_background');
+      localManager.startSessionPartInternal({ reason: 'init' });
+      localManager.endSessionPartInternal({ reason: 'web_background' });
 
       const [span] = memoryExporter.getFinishedSpans();
       expect(span.attributes).to.have.property(KEY_EMB_PAGE_LOAD, true);
@@ -1541,8 +1541,8 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         visibilityDoc: makeDoc('loading'),
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
-      localManager.startSessionPartInternal('init');
-      localManager.endSessionPartInternal('web_background');
+      localManager.startSessionPartInternal({ reason: 'init' });
+      localManager.endSessionPartInternal({ reason: 'web_background' });
 
       const [span] = memoryExporter.getFinishedSpans();
       expect(span.attributes).to.have.property(KEY_EMB_PAGE_LOAD, false);
@@ -1557,10 +1557,10 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         visibilityDoc: makeDoc('loading'),
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
-      localManager.startSessionPartInternal('init');
-      localManager.endSessionPartInternal('web_background');
-      localManager.startSessionPartInternal('web_foreground');
-      localManager.endSessionPartInternal('web_background');
+      localManager.startSessionPartInternal({ reason: 'init' });
+      localManager.endSessionPartInternal({ reason: 'web_background' });
+      localManager.startSessionPartInternal({ reason: 'web_foreground' });
+      localManager.endSessionPartInternal({ reason: 'web_background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -9,10 +9,6 @@ import {
   MockPerformanceManager,
   TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../tests/utils/index.ts';
-import type {
-  SessionPartEndReason,
-  UserSessionEndReason,
-} from '../../api-sessions/index.ts';
 import type { DynamicSDKConfig } from '../../sdk/index.ts';
 import { NamespacedStorage } from '../../utils/NamespacedStorage/NamespacedStorage.ts';
 import {
@@ -20,24 +16,22 @@ import {
   EmbraceLimitManager,
 } from '../EmbraceLimitManager/index.ts';
 import { EmbraceUserSessionManager } from './EmbraceUserSessionManager.ts';
+import type { EndSessionPartOptions } from './types.ts';
 
 chai.use(sinonChai);
 const { expect } = chai;
 
-type EndCall = [
-  reason: SessionPartEndReason,
-  userSessionEndReason?: UserSessionEndReason | null,
-];
-
 /**
- * Returns the args passed to the most recent `endSessionPartInternal`
+ * Returns the options passed to the most recent `endSessionPartInternal`
  * invocation, or `undefined` if the spy was never called.
  */
-const lastEndCall = (spy: sinon.SinonSpy): EndCall | undefined => {
+const lastEndCall = (
+  spy: sinon.SinonSpy,
+): EndSessionPartOptions | undefined => {
   if (spy.callCount === 0) {
     return undefined;
   }
-  return spy.lastCall.args as EndCall;
+  return spy.lastCall.args[0] as EndSessionPartOptions;
 };
 
 describe('EmbraceUserSessionManager', () => {
@@ -95,7 +89,7 @@ describe('EmbraceUserSessionManager', () => {
 
   it('should create a session on first part start', () => {
     const manager = createManager();
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs = manager.getUserSessionAttributes();
 
     void expect(attrs).to.not.be.null;
@@ -113,7 +107,7 @@ describe('EmbraceUserSessionManager', () => {
     const manager = createManager({
       userSessionForegroundInactivityTimeoutSeconds: 90,
     });
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs = manager.getUserSessionAttributes();
     void expect(attrs).to.not.be.null;
     expect(
@@ -124,16 +118,16 @@ describe('EmbraceUserSessionManager', () => {
   it('should continue session across parts within timeout', () => {
     const manager = createManager();
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs1 = manager.getUserSessionAttributes();
     // web_background ends the part but keeps the user session alive
     // (inactivity now ends both the part and the user session in one step).
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     // Advance time within inactivity timeout (29 min)
     clock.tick(29 * 60 * 1000);
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs2 = manager.getUserSessionAttributes();
 
     expect(attrs2?.['emb.user_session_id']).to.equal(
@@ -146,14 +140,14 @@ describe('EmbraceUserSessionManager', () => {
   it('should start a session when inactivity timeout expires', () => {
     const manager = createManager();
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs1 = manager.getUserSessionAttributes();
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     // Advance past inactivity timeout (31 min)
     clock.tick(31 * 60 * 1000);
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs2 = manager.getUserSessionAttributes();
 
     expect(attrs2?.['emb.user_session_id']).to.not.equal(
@@ -166,14 +160,14 @@ describe('EmbraceUserSessionManager', () => {
   it('should start a session when max duration expires', () => {
     const manager = createManager({ userSessionMaxDurationSeconds: 3600 });
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs1 = manager.getUserSessionAttributes();
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     // Advance past max duration (3601 seconds)
     clock.tick(3601 * 1000);
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs2 = manager.getUserSessionAttributes();
 
     expect(attrs2?.['emb.user_session_id']).to.not.equal(
@@ -195,7 +189,7 @@ describe('EmbraceUserSessionManager', () => {
     const endSpy = sinon.spy(manager, 'endSessionPartInternal');
     const startSpy = sinon.spy(manager, 'startSessionPartInternal');
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     // Fast forward past max duration
     clock.tick(3601 * 1000);
@@ -215,13 +209,13 @@ describe('EmbraceUserSessionManager', () => {
 
     const endSpy = sinon.spy(manager, 'endSessionPartInternal');
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     clock.tick(3601 * 1000);
 
-    expect(lastEndCall(endSpy)).to.deep.equal([
-      'user_session_ended',
-      'max_duration_reached',
-    ]);
+    expect(lastEndCall(endSpy)).to.deep.include({
+      reason: 'user_session_ended',
+      userSessionEndReason: 'max_duration_reached',
+    });
   });
 
   it('should handle manual termination via endUserSession', () => {
@@ -230,7 +224,7 @@ describe('EmbraceUserSessionManager', () => {
     const endSpy = sinon.spy(manager, 'endSessionPartInternal');
     const startSpy = sinon.spy(manager, 'startSessionPartInternal');
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.endUserSession();
 
     void expect(endSpy.called).to.be.true;
@@ -242,10 +236,13 @@ describe('EmbraceUserSessionManager', () => {
 
     const endSpy = sinon.spy(manager, 'endSessionPartInternal');
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     manager.endUserSession();
 
-    expect(lastEndCall(endSpy)).to.deep.equal(['user_session_ended', 'manual']);
+    expect(lastEndCall(endSpy)).to.deep.include({
+      reason: 'user_session_ended',
+      userSessionEndReason: 'manual',
+    });
   });
 
   it('should be a no-op when ending session with no active session', () => {
@@ -256,15 +253,15 @@ describe('EmbraceUserSessionManager', () => {
 
   it('should share state across manager instances via storage', () => {
     const manager1 = createManager();
-    manager1.startSessionPartInternal('init');
+    manager1.startSessionPartInternal({ reason: 'init' });
     const attrs1 = manager1.getUserSessionAttributes();
     // web_background keeps the user session alive; another tab joining
     // should adopt it. (inactivity now ends both part and user session.)
-    manager1.endSessionPartInternal('web_background');
+    manager1.endSessionPartInternal({ reason: 'web_background' });
 
     // Simulate another tab creating a manager with the same storage
     const manager2 = createManager();
-    manager2.startSessionPartInternal('init');
+    manager2.startSessionPartInternal({ reason: 'init' });
     const attrs2 = manager2.getUserSessionAttributes();
 
     expect(attrs2?.['emb.user_session_id']).to.equal(
@@ -304,7 +301,7 @@ describe('EmbraceUserSessionManager', () => {
       dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs = manager.getUserSessionAttributes();
     expect(attrs?.['emb.user_session_id']).to.have.lengthOf(32);
     // Storage unavailable: getIncrementedCount falls back to 1, which is
@@ -321,7 +318,7 @@ describe('EmbraceUserSessionManager', () => {
     const manager = createManager({
       userSessionMaxDurationSeconds: 25 * 60 * 60,
     });
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs = manager.getUserSessionAttributes();
     expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(43200);
   });
@@ -331,7 +328,7 @@ describe('EmbraceUserSessionManager', () => {
     const manager = createManager({
       userSessionInactivityTimeoutSeconds: 25 * 60 * 60,
     });
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs = manager.getUserSessionAttributes();
     expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
       1800,
@@ -341,17 +338,17 @@ describe('EmbraceUserSessionManager', () => {
   it('should increment user session number monotonically', () => {
     const manager = createManager();
 
-    manager.startSessionPartInternal('init');
-    manager.endSessionPartInternal('web_background');
+    manager.startSessionPartInternal({ reason: 'init' });
+    manager.endSessionPartInternal({ reason: 'web_background' });
     // Expire the session
     clock.tick(31 * 60 * 1000);
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs2 = manager.getUserSessionAttributes();
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
     clock.tick(31 * 60 * 1000);
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs3 = manager.getUserSessionAttributes();
 
     expect(attrs2?.['emb.user_session_number']).to.equal(2);
@@ -369,11 +366,11 @@ describe('EmbraceUserSessionManager', () => {
     // directly so the next part start lazily creates a fresh user session.
     const manager = createManager({ userSessionMaxDurationSeconds: 3600 });
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const firstSessionId = manager.getUserSessionId();
     expect(firstSessionId).to.not.be.null;
 
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     clock.tick(3601 * 1000);
 
@@ -381,13 +378,13 @@ describe('EmbraceUserSessionManager', () => {
     // user-session id resets. The next part start rolls a fresh session.
     expect(manager.getUserSessionId()).to.be.null;
 
-    manager.startSessionPartInternal('web_foreground');
+    manager.startSessionPartInternal({ reason: 'web_foreground' });
     expect(manager.getUserSessionId()).to.not.equal(firstSessionId);
   });
 
   it('should persist session state to storage', () => {
     const manager = createManager();
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     const raw = inMemoryStorage.getItem('embrace_user_session_state');
     expect(raw).to.not.be.null;
@@ -411,7 +408,7 @@ describe('EmbraceUserSessionManager', () => {
   it('should create a different user session after endUserSession', () => {
     const manager = createManager();
 
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs1 = manager.getUserSessionAttributes();
     manager.endUserSession();
 
@@ -431,7 +428,7 @@ describe('EmbraceUserSessionManager', () => {
     // is active, an end-driven persist could re-write the in-memory
     // state and silently restore everything. Honor the clear instead.
     const manager = createManager();
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     expect(inMemoryStorage.getItem('embrace_user_session_state')).to.not.be
       .null;
 
@@ -440,7 +437,7 @@ describe('EmbraceUserSessionManager', () => {
     // web_background is the non-final part end that triggers the
     // continuation persist; this is the path that previously rewrote
     // the cleared row.
-    manager.endSessionPartInternal('web_background');
+    manager.endSessionPartInternal({ reason: 'web_background' });
 
     void expect(inMemoryStorage.getItem('embrace_user_session_state')).to.be
       .null;
@@ -448,7 +445,7 @@ describe('EmbraceUserSessionManager', () => {
 
     // Next engagement starts a brand-new user session rather than
     // continuing the cleared one.
-    manager.startSessionPartInternal('web_activity');
+    manager.startSessionPartInternal({ reason: 'web_activity' });
     expect(
       manager.getUserSessionAttributes()?.['emb.user_session_part_index'],
     ).to.equal(1);
@@ -456,7 +453,7 @@ describe('EmbraceUserSessionManager', () => {
 
   it('should clear storage after endUserSession-driven termination', () => {
     const manager = createManager();
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
 
     expect(inMemoryStorage.getItem('embrace_user_session_state')).to.not.be
       .null;
@@ -466,21 +463,16 @@ describe('EmbraceUserSessionManager', () => {
     // endSessionPartInternal and reading storage at that moment.
     let storageDuringEnd: string | null = '';
     const original = manager.endSessionPartInternal.bind(manager);
-    type EndFn = (
-      reason: SessionPartEndReason,
-      userSessionEndReason?: UserSessionEndReason | null,
-    ) => void;
-    sinon.stub(manager, 'endSessionPartInternal').callsFake(((
-      reason,
-      userSessionEndReason,
-    ) => {
-      if (reason === 'user_session_ended') {
-        storageDuringEnd = inMemoryStorage.getItem(
-          'embrace_user_session_state',
-        );
-      }
-      (original as EndFn)(reason, userSessionEndReason);
-    }) as EndFn);
+    sinon
+      .stub(manager, 'endSessionPartInternal')
+      .callsFake((options: EndSessionPartOptions) => {
+        if (options.reason === 'user_session_ended') {
+          storageDuringEnd = inMemoryStorage.getItem(
+            'embrace_user_session_state',
+          );
+        }
+        original(options);
+      });
 
     manager.endUserSession();
 
@@ -493,7 +485,7 @@ describe('EmbraceUserSessionManager', () => {
 
   it('should expose the dying user session id via getPreviousUserSessionId on manual end', () => {
     const manager = createManager();
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs = manager.getUserSessionAttributes();
     const dyingId = attrs?.['emb.user_session_id'];
 
@@ -504,7 +496,7 @@ describe('EmbraceUserSessionManager', () => {
 
   it('should expose the dying user session id via getPreviousUserSessionId on max-duration rollover', () => {
     const manager = createManager({ userSessionMaxDurationSeconds: 3600 });
-    manager.startSessionPartInternal('init');
+    manager.startSessionPartInternal({ reason: 'init' });
     const attrs = manager.getUserSessionAttributes();
     const dyingId = attrs?.['emb.user_session_id'];
 
@@ -516,7 +508,7 @@ describe('EmbraceUserSessionManager', () => {
   describe('endUserSession cooldown', () => {
     it('should accept the first endUserSession with no prior end on record', () => {
       const manager = createManager();
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
 
       const idBefore = manager.getUserSessionId();
       manager.endUserSession();
@@ -529,7 +521,7 @@ describe('EmbraceUserSessionManager', () => {
 
     it('should reject a second endUserSession within 5s of a successful end', () => {
       const manager = createManager();
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       manager.endUserSession();
 
       clock.tick(2 * 1000);
@@ -547,13 +539,13 @@ describe('EmbraceUserSessionManager', () => {
       // new page load) reads the persisted last-end timestamp and still
       // rejects calls within the 5s window.
       const first = createManager();
-      first.startSessionPartInternal('init');
+      first.startSessionPartInternal({ reason: 'init' });
       first.endUserSession();
 
       clock.tick(1 * 1000);
 
       const afterRefresh = createManager();
-      afterRefresh.startSessionPartInternal('init');
+      afterRefresh.startSessionPartInternal({ reason: 'init' });
       const idBefore = afterRefresh.getUserSessionId();
       afterRefresh.endUserSession();
 
@@ -565,7 +557,7 @@ describe('EmbraceUserSessionManager', () => {
 
     it('should accept endUserSession exactly at the 5s boundary (strict less-than)', () => {
       const manager = createManager();
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       manager.endUserSession();
 
       clock.tick(5 * 1000);
@@ -580,7 +572,7 @@ describe('EmbraceUserSessionManager', () => {
 
     it('should accept endUserSession after the cooldown window has elapsed', () => {
       const manager = createManager();
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       manager.endUserSession();
 
       clock.tick(6 * 1000);
@@ -598,21 +590,21 @@ describe('EmbraceUserSessionManager', () => {
     it('should fall back to default when userSessionMaxDurationSeconds is below minimum', () => {
       // MIN is 1 hour (3600s); 60s is below minimum
       const manager = createManager({ userSessionMaxDurationSeconds: 60 });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(43200);
     });
 
     it('should fall back to default when userSessionMaxDurationSeconds is zero', () => {
       const manager = createManager({ userSessionMaxDurationSeconds: 0 });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(43200);
     });
 
     it('should fall back to default when userSessionMaxDurationSeconds is negative', () => {
       const manager = createManager({ userSessionMaxDurationSeconds: -60 });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(43200);
     });
@@ -622,7 +614,7 @@ describe('EmbraceUserSessionManager', () => {
       const manager = createManager({
         userSessionInactivityTimeoutSeconds: 10,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
         1800,
@@ -631,7 +623,7 @@ describe('EmbraceUserSessionManager', () => {
 
     it('should fall back to default when userSessionInactivityTimeoutSeconds is zero', () => {
       const manager = createManager({ userSessionInactivityTimeoutSeconds: 0 });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
         1800,
@@ -642,7 +634,7 @@ describe('EmbraceUserSessionManager', () => {
       const manager = createManager({
         userSessionInactivityTimeoutSeconds: -60,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
         1800,
@@ -656,7 +648,7 @@ describe('EmbraceUserSessionManager', () => {
       const manager = createManager({
         userSessionMaxDurationSeconds: Number.NaN,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(43200);
     });
@@ -665,7 +657,7 @@ describe('EmbraceUserSessionManager', () => {
       const manager = createManager({
         userSessionMaxDurationSeconds: Number.POSITIVE_INFINITY,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(43200);
     });
@@ -674,7 +666,7 @@ describe('EmbraceUserSessionManager', () => {
       const manager = createManager({
         userSessionInactivityTimeoutSeconds: Number.NaN,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
         1800,
@@ -688,7 +680,7 @@ describe('EmbraceUserSessionManager', () => {
       });
       // Durations are resolved lazily at user-session creation, so the
       // clamp warnings only fire once a part starts.
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
 
       const warnLogs = diag.getWarnLogs();
       expect(
@@ -709,7 +701,7 @@ describe('EmbraceUserSessionManager', () => {
         userSessionMaxDurationSeconds: 3600,
         userSessionInactivityTimeoutSeconds: 7200,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
       expect(attrs?.['emb.user_session_max_duration_seconds']).to.equal(3600);
       expect(attrs?.['emb.user_session_inactivity_timeout_seconds']).to.equal(
@@ -722,7 +714,7 @@ describe('EmbraceUserSessionManager', () => {
         userSessionMaxDurationSeconds: 3600,
         userSessionInactivityTimeoutSeconds: 7200,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
 
       expect(
         diag
@@ -737,7 +729,7 @@ describe('EmbraceUserSessionManager', () => {
         userSessionMaxDurationSeconds: 3600,
         userSessionForegroundInactivityTimeoutSeconds: 7200,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
 
       expect(
         diag
@@ -754,7 +746,7 @@ describe('EmbraceUserSessionManager', () => {
 
       // The cold-start user session relies on initSDK's startup refresh, so
       // the manager must not issue its own redundant fetch here.
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       expect(refreshRemoteConfig.callCount).to.equal(0);
 
       // Ending the user session rolls over into a fresh one, which should
@@ -771,10 +763,10 @@ describe('EmbraceUserSessionManager', () => {
     it('does not refresh on a continuing part within the same user session', () => {
       const { manager, refreshRemoteConfig } = createManagerWithLiveConfig();
 
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
       clock.tick(60 * 1000); // within the default inactivity timeout
-      manager.startSessionPartInternal('init'); // same session continues
+      manager.startSessionPartInternal({ reason: 'init' }); // same session continues
 
       expect(refreshRemoteConfig.callCount).to.equal(0);
     });
@@ -782,10 +774,10 @@ describe('EmbraceUserSessionManager', () => {
     it('refreshes when the inactivity timeout expires into a new user session', () => {
       const { manager, refreshRemoteConfig } = createManagerWithLiveConfig();
 
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
       clock.tick(31 * 60 * 1000); // past the default 30 min inactivity timeout
-      manager.startSessionPartInternal('init'); // fresh session
+      manager.startSessionPartInternal({ reason: 'init' }); // fresh session
 
       expect(refreshRemoteConfig.callCount).to.equal(1);
     });
@@ -799,7 +791,7 @@ describe('EmbraceUserSessionManager', () => {
         userSessionForegroundInactivityTimeoutSeconds: 3600,
       });
 
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       clock.tick(3601 * 1000); // fire max-duration timer -> rollover
 
       expect(refreshRemoteConfig.callCount).to.equal(1);
@@ -820,11 +812,11 @@ describe('EmbraceUserSessionManager', () => {
   describe('clock anomaly handling', () => {
     it('should start a fresh session when device time is before stored session start', () => {
       const manager1 = createManager();
-      manager1.startSessionPartInternal('init');
+      manager1.startSessionPartInternal({ reason: 'init' });
       const attrs1 = manager1.getUserSessionAttributes();
       // web_background keeps state on disk for the second manager to
       // read back; the test then mutates the persisted row.
-      manager1.endSessionPartInternal('web_background');
+      manager1.endSessionPartInternal({ reason: 'web_background' });
 
       // Simulate device clock jumping backward (before userSessionStartTs).
       const rawBefore = inMemoryStorage.getItem('embrace_user_session_state');
@@ -843,7 +835,7 @@ describe('EmbraceUserSessionManager', () => {
 
       // clock.now is 0, which is before userSessionStartTs=3600000.
       const manager2 = createManager();
-      manager2.startSessionPartInternal('init');
+      manager2.startSessionPartInternal({ reason: 'init' });
       const attrs2 = manager2.getUserSessionAttributes();
 
       expect(attrs2?.['emb.user_session_id']).to.not.equal(
@@ -863,7 +855,7 @@ describe('EmbraceUserSessionManager', () => {
   describe('inactivity timeout invalidation', () => {
     it('should not write an inactivity deadline while the first foreground part is active', () => {
       const manager = createManager();
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
 
       void expect(readStoredDeadline()).to.be.null;
     });
@@ -872,24 +864,24 @@ describe('EmbraceUserSessionManager', () => {
       const manager = createManager({
         userSessionInactivityTimeoutSeconds: 120,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       clock.tick(10 * 1000);
       // web_background keeps the user session alive and writes the
       // deadline; inactivity would terminate the session in one step.
-      manager.endSessionPartInternal('web_background');
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
       expect(readStoredDeadline()).to.equal(10 * 1000 + 120 * 1000);
     });
 
     it('should clear the inactivity deadline when a continuing part starts', () => {
       const manager = createManager();
-      manager.startSessionPartInternal('init');
-      manager.endSessionPartInternal('web_background');
+      manager.startSessionPartInternal({ reason: 'init' });
+      manager.endSessionPartInternal({ reason: 'web_background' });
       void expect(readStoredDeadline()).to.not.be.null;
 
       // A continuing part (within timeout) should clear the persisted value.
       clock.tick(60 * 1000);
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
 
       void expect(readStoredDeadline()).to.be.null;
     });
@@ -898,7 +890,7 @@ describe('EmbraceUserSessionManager', () => {
       const manager1 = createManager({
         userSessionMaxDurationSeconds: 12 * 60 * 60,
       });
-      manager1.startSessionPartInternal('init');
+      manager1.startSessionPartInternal({ reason: 'init' });
       const attrs1 = manager1.getUserSessionAttributes();
       // Simulate a crash: no endSessionPartInternal call, no deadline written.
       // shutdown clears manager1's part-inactivity and max-duration timers
@@ -912,7 +904,7 @@ describe('EmbraceUserSessionManager', () => {
       const manager2 = createManager({
         userSessionMaxDurationSeconds: 12 * 60 * 60,
       });
-      manager2.startSessionPartInternal('init');
+      manager2.startSessionPartInternal({ reason: 'init' });
       const attrs2 = manager2.getUserSessionAttributes();
 
       expect(attrs2?.['emb.user_session_id']).to.equal(
@@ -927,7 +919,7 @@ describe('EmbraceUserSessionManager', () => {
         userSessionInactivityTimeoutSeconds: 120,
       });
 
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       expect(
         manager.getUserSessionAttributes()?.[
           'emb.user_session_inactivity_timeout_seconds'
@@ -937,13 +929,13 @@ describe('EmbraceUserSessionManager', () => {
       // A mid-session remote-config change must not shift the active session.
       config.userSessionInactivityTimeoutSeconds = 600;
       clock.tick(10 * 1000);
-      manager.endSessionPartInternal('web_background');
+      manager.endSessionPartInternal({ reason: 'web_background' });
       // The persisted deadline uses the frozen 120s, not the live 600s.
       expect(readStoredDeadline()).to.equal(10 * 1000 + 120 * 1000);
 
       // Rolling into a fresh session resolves durations again, picking up 600s.
       clock.tick(3 * 60 * 1000); // past the frozen 120s deadline -> expired
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       expect(
         manager.getUserSessionAttributes()?.[
           'emb.user_session_inactivity_timeout_seconds'
@@ -959,7 +951,7 @@ describe('EmbraceUserSessionManager', () => {
         userSessionMaxDurationSeconds: 3600,
       });
 
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       expect(
         manager.getUserSessionAttributes()?.[
           'emb.user_session_max_duration_seconds'
@@ -976,9 +968,9 @@ describe('EmbraceUserSessionManager', () => {
 
       // Inactivity expiry rolls into a fresh session, which resolves durations
       // again and picks up the changed 7200s max.
-      manager.endSessionPartInternal('web_background');
+      manager.endSessionPartInternal({ reason: 'web_background' });
       clock.tick(31 * 60 * 1000); // past the default 30 min inactivity timeout
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       expect(
         manager.getUserSessionAttributes()?.[
           'emb.user_session_max_duration_seconds'
@@ -998,7 +990,7 @@ describe('EmbraceUserSessionManager', () => {
       );
 
       const manager = createManager();
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
 
       expect(attrs?.['emb.user_session_id']).to.have.lengthOf(32);
@@ -1018,9 +1010,9 @@ describe('EmbraceUserSessionManager', () => {
       const manager1 = createManager({
         userSessionMaxDurationSeconds: 60 * 60,
       });
-      manager1.startSessionPartInternal('init');
+      manager1.startSessionPartInternal({ reason: 'init' });
       const attrs1 = manager1.getUserSessionAttributes();
-      manager1.endSessionPartInternal('web_background');
+      manager1.endSessionPartInternal({ reason: 'web_background' });
       // Cancel manager1's max-duration timer so it doesn't auto-rollover during
       // the tick. We're simulating a page reload: the prior page is gone,
       // storage carries the dying state forward, and a fresh manager loads.
@@ -1032,7 +1024,7 @@ describe('EmbraceUserSessionManager', () => {
       const manager2 = createManager({
         userSessionMaxDurationSeconds: 60 * 60,
       });
-      manager2.startSessionPartInternal('init');
+      manager2.startSessionPartInternal({ reason: 'init' });
       const attrs2 = manager2.getUserSessionAttributes();
 
       expect(attrs2?.['emb.user_session_id']).to.not.equal(
@@ -1070,7 +1062,7 @@ describe('EmbraceUserSessionManager', () => {
       const manager = createManager({
         userSessionForegroundInactivityTimeoutSeconds: 90,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       expect(readStoredForegroundTimeout()).to.equal(90);
     });
 
@@ -1078,7 +1070,7 @@ describe('EmbraceUserSessionManager', () => {
       const manager = createManager({
         userSessionForegroundInactivityTimeoutSeconds: 5,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       expect(readStoredForegroundTimeout()).to.equal(1800);
     });
 
@@ -1087,7 +1079,7 @@ describe('EmbraceUserSessionManager', () => {
         userSessionMaxDurationSeconds: 3600,
         userSessionForegroundInactivityTimeoutSeconds: 7200,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
       expect(readStoredForegroundTimeout()).to.equal(1800);
     });
 
@@ -1097,7 +1089,7 @@ describe('EmbraceUserSessionManager', () => {
         userSessionInactivityTimeoutSeconds: 120,
         userSessionForegroundInactivityTimeoutSeconds: 7200,
       });
-      manager.startSessionPartInternal('init');
+      manager.startSessionPartInternal({ reason: 'init' });
 
       const raw = inMemoryStorage.getItem('embrace_user_session_state');
       void expect(raw).to.not.be.null;

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -11,8 +11,6 @@ import {
 } from '@opentelemetry/semantic-conventions/incubating';
 import type {
   PropertyOptions,
-  SessionPartEndReason,
-  SessionPartStartReason,
   UserSessionEndReason,
 } from '../../api-sessions/manager/types.ts';
 import type { VisibilityStateDocument } from '../../common/index.ts';
@@ -78,6 +76,8 @@ import {
 } from './constants.ts';
 import type {
   EmbraceUserSessionManagerArgs,
+  EndSessionPartOptions,
+  StartSessionPartOptions,
   UserSessionAttributes,
   UserSessionManagerInternal,
   UserSessionState,
@@ -340,7 +340,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     return this._sessionPartSpan;
   }
 
-  public startSessionPartInternal(reason: SessionPartStartReason): void {
+  public startSessionPartInternal({ reason }: StartSessionPartOptions): void {
     if (this._sessionPartSpan) {
       this._diag.warn(
         `startSessionPartInternal called while a part is active (reason: ${reason}); ignoring`,
@@ -396,10 +396,10 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     this._fireListeners(this._sessionPartStartedListeners, 'started');
   }
 
-  public endSessionPartInternal(
-    reason: SessionPartEndReason,
-    userSessionEndReason?: UserSessionEndReason | null,
-  ): void {
+  public endSessionPartInternal({
+    reason,
+    userSessionEndReason,
+  }: EndSessionPartOptions): void {
     if (!this._sessionPartSpan) {
       this._diag.debug(
         'trying to end a session part, but there is no session part in progress. This is a no-op.',
@@ -769,8 +769,11 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     userSessionEndReason: UserSessionEndReason,
   ): void {
     if (this._sessionPartSpan) {
-      this.endSessionPartInternal('user_session_ended', userSessionEndReason);
-      this.startSessionPartInternal('user_session_rollover');
+      this.endSessionPartInternal({
+        reason: 'user_session_ended',
+        userSessionEndReason,
+      });
+      this.startSessionPartInternal({ reason: 'user_session_rollover' });
       return;
     }
 
@@ -829,7 +832,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
         return;
       }
       if (this._activeSessionPartId === null) {
-        this.startSessionPartInternal('web_activity');
+        this.startSessionPartInternal({ reason: 'web_activity' });
         return;
       }
       this._startSessionPartInactivityTimer();
@@ -867,12 +870,12 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
       const active = this._activeSessionPartId !== null;
       if (!engaged && active) {
         this._diag.debug(`tab disengaged via ${source}; ending current part`);
-        this.endSessionPartInternal('web_background');
+        this.endSessionPartInternal({ reason: 'web_background' });
         return;
       }
       if (engaged && !active) {
         this._diag.debug(`tab engaged via ${source}; starting new part`);
-        this.startSessionPartInternal('web_foreground');
+        this.startSessionPartInternal({ reason: 'web_foreground' });
         return;
       }
       if (engaged && active) {
@@ -895,7 +898,10 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
       this._diag.debug(
         'inactivity timer fired; ending current part and user session',
       );
-      this.endSessionPartInternal('web_foreground_inactivity', 'inactivity');
+      this.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+        userSessionEndReason: 'inactivity',
+      });
     } catch (e) {
       this._diag.warn('Error handling inactivity timer', e);
     }

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -60,7 +60,7 @@ new equivalents; others are inert (return `null` or no-op).
 `UserSessionManagerInternal` extends the public interface with members used by
 instrumentations and processors only:
 
-- `startSessionPartInternal(reason)`, `endSessionPartInternal(reason, userSessionEndReason?)`
+- `startSessionPartInternal({ reason })`, `endSessionPartInternal({ reason, userSessionEndReason? })`
 - `getSessionPartId()`, `getSessionPartSpan()`
 - `incrSessionPartCountForKey(key)` and `incrNextSessionPartCountForKey(key)`
 - `addSessionPartStartedListener(listener)`, `addSessionPartEndedListener(listener)`
@@ -75,7 +75,7 @@ is stamped as `emb.sdk_startup_duration` on every session-part end span.
 
 ### Start
 
-`startSessionPartInternal(reason)` is a no-op unless **both** of the following
+`startSessionPartInternal({ reason })` is a no-op unless **both** of the following
 are true at call time:
 
 - `document.visibilityState === 'visible'`
@@ -178,9 +178,10 @@ is called from:
 | `inactivity` | Part-inactivity timer fires while a part is active. | Yes, stamped as the user-session termination reason on the final part span, paired with that part's `web_foreground_inactivity` end reason. When inactivity is instead detected lazily at the next part start (no part was active to run the timer), the prior part span has already been exported, so no reason is stamped. |
 
 On termination the manager calls
-`endSessionPartInternal('user_session_ended', reason)`, saves
-`_previousUserSessionId`, sets `_state` to `null`, removes the storage row, and
-immediately calls `startSessionPartInternal('user_session_rollover')`. That
+`endSessionPartInternal({ reason: 'user_session_ended', userSessionEndReason })`,
+saves `_previousUserSessionId`, sets `_state` to `null`, removes the storage
+row, and immediately calls
+`startSessionPartInternal({ reason: 'user_session_rollover' })`. That
 follow-up call mints a fresh user session if the tab is still engaged, or
 silently no-ops if not (the next engagement event will create it).
 
@@ -190,7 +191,7 @@ silently no-ops if not (the next engagement event will create it).
 | --- | --- | --- | --- | --- |
 | Max duration | `DEFAULT_USER_SESSION_MAX_DURATION_SECONDS` | 12 hours | `MIN_USER_SESSION_MAX_DURATION_SECONDS` (1h) to `MAX_USER_SESSION_MAX_DURATION_SECONDS` (24h) | `_terminateUserSession('max_duration_reached')` |
 | User-session inactivity (lazy) | `DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` | 30 minutes | `MIN_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (30s) to `MAX_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (24h) | Not a live timer. Written into the state blob as `userSessionInactivityTimeoutSeconds`; `_continueUserSessionAfterPartEnd` records `partEndTs + userSessionInactivityTimeoutSeconds * 1000` into `inactivityDeadlineTs`, checked on the next part start by `isUserSessionExpired`. |
-| Part (foreground) inactivity | `DEFAULT_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` | 30 minutes | `MIN_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` (30s) to `MAX_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` (24h) | Live `setTimeout` armed from `userSessionForegroundInactivityTimeoutSeconds` while a part is active; on fire, `endSessionPartInternal('web_foreground_inactivity', 'inactivity')` ends the part and the enclosing user session. |
+| Part (foreground) inactivity | `DEFAULT_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` | 30 minutes | `MIN_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` (30s) to `MAX_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` (24h) | Live `setTimeout` armed from `userSessionForegroundInactivityTimeoutSeconds` while a part is active; on fire, `endSessionPartInternal({ reason: 'web_foreground_inactivity', userSessionEndReason: 'inactivity' })` ends the part and the enclosing user session. |
 | Activity throttle | `ACTIVITY_THROTTLE_MS` | 30 seconds | n/a | At most one inactivity-timer reset per 30 seconds of input. |
 | `endUserSession` cooldown | `END_USER_SESSION_COOLDOWN_MS` | 5 seconds | n/a | Calls within 5 seconds of the last call are silently ignored. |
 
@@ -403,7 +404,7 @@ Why it happens:
 1. `setTracerProvider` materializes the user-session state via
    `_loadOrCreateUserSessionState`, so `getUserSessionId()` returns a real
    id immediately.
-2. `initSDK` calls `startSessionPartInternal('init')` next, but the call
+2. `initSDK` calls `startSessionPartInternal({ reason: 'init' })` next, but the call
    no-ops when `!document.hasFocus()` or `visibilityState === 'background'`
    (parts are foreground-only by design).
 3. Until the next engagement event fires (`focus`/`visibilitychange`),

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
@@ -85,6 +85,21 @@ export interface UserSessionAttributes {
   readonly 'emb.user_session_foreground_inactivity_timeout_seconds': number;
 }
 
+export interface StartSessionPartOptions {
+  readonly reason: SessionPartStartReason;
+}
+
+export interface EndSessionPartOptions {
+  readonly reason: SessionPartEndReason;
+  /**
+   * Termination reason for the enclosing user session; only meaningful
+   * when the part-end reason also ends the user session
+   * (`user_session_ended` or `web_foreground_inactivity`). Ignored
+   * otherwise.
+   */
+  readonly userSessionEndReason?: UserSessionEndReason;
+}
+
 /**
  * SDK-internal handle on the user-session manager. Extends the public
  * `UserSessionManager` with the part-side surface (span lifecycle, listeners,
@@ -103,17 +118,8 @@ export interface UserSessionManagerInternal extends UserSessionManager {
 
   getSessionPartId: () => string | null;
 
-  startSessionPartInternal: (reason: SessionPartStartReason) => void;
-  /**
-   * Ends the active part. `reason` is the part-end reason.
-   * `userSessionEndReason` is only meaningful when the reason ends the
-   * user session (`user_session_ended` or `inactivity`); the implementation
-   * ignores it otherwise.
-   */
-  endSessionPartInternal: (
-    reason: SessionPartEndReason,
-    userSessionEndReason?: UserSessionEndReason,
-  ) => void;
+  startSessionPartInternal: (options: StartSessionPartOptions) => void;
+  endSessionPartInternal: (options: EndSessionPartOptions) => void;
 
   incrSessionPartCountForKey: (key: string) => void;
   /** Same as `incrSessionPartCountForKey` but for the next part. */

--- a/packages/web-sdk/src/processors/EmbraceSessionPartBatchedSpanProcessor/EmbraceSessionPartBatchedSpanProcessor.test.ts
+++ b/packages/web-sdk/src/processors/EmbraceSessionPartBatchedSpanProcessor/EmbraceSessionPartBatchedSpanProcessor.test.ts
@@ -163,7 +163,7 @@ describe('EmbraceSessionPartBatchedSpanProcessor', () => {
 
   exportFailedTests.forEach((test) => {
     it(test.name, async () => {
-      userSessionManager.startSessionPartInternal('init');
+      userSessionManager.startSessionPartInternal({ reason: 'init' });
       const diagLogger = new InMemoryDiagLogger();
       processor = new EmbraceSessionPartBatchedSpanProcessor({
         exporter: new FailingSpanExporter(
@@ -178,10 +178,14 @@ describe('EmbraceSessionPartBatchedSpanProcessor', () => {
 
       await Promise.resolve();
 
-      userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
 
-      userSessionManager.startSessionPartInternal('init');
-      userSessionManager.endSessionPartInternal('web_foreground_inactivity');
+      userSessionManager.startSessionPartInternal({ reason: 'init' });
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);

--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -890,7 +890,7 @@ describe('initSDK', () => {
 
       session
         .getUserSessionManager()
-        .endSessionPartInternal('web_foreground_inactivity');
+        .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
       const exportedSpans = await getLastSessionExportedSpans(0);
 
@@ -923,7 +923,7 @@ describe('initSDK', () => {
 
       session
         .getUserSessionManager()
-        .endSessionPartInternal('web_foreground_inactivity');
+        .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
       const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1000);
@@ -933,7 +933,9 @@ describe('initSDK', () => {
 
       fakeFetchResetHistory();
 
-      session.getUserSessionManager().startSessionPartInternal('init');
+      session
+        .getUserSessionManager()
+        .startSessionPartInternal({ reason: 'init' });
 
       // Limit should be reset for the next session
       for (let i = 0; i < 100; i++) {
@@ -942,7 +944,7 @@ describe('initSDK', () => {
 
       session
         .getUserSessionManager()
-        .endSessionPartInternal('web_foreground_inactivity');
+        .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
       const nextSessionExportedSpans = await getLastSessionExportedSpans(0);
       expect(nextSessionExportedSpans).to.have.lengthOf(100);
@@ -982,7 +984,7 @@ describe('initSDK', () => {
       span.end();
       session
         .getUserSessionManager()
-        .endSessionPartInternal('web_foreground_inactivity');
+        .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
       const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
@@ -1030,7 +1032,7 @@ describe('initSDK', () => {
       span.end();
       session
         .getUserSessionManager()
-        .endSessionPartInternal('web_foreground_inactivity');
+        .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
       const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
@@ -1099,7 +1101,7 @@ describe('initSDK', () => {
       span.end();
       session
         .getUserSessionManager()
-        .endSessionPartInternal('web_foreground_inactivity');
+        .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
       const exportedSpans = await getLastSessionExportedSpans(0);
       expect(exportedSpans).to.have.lengthOf(1);
@@ -1153,7 +1155,7 @@ describe('initSDK', () => {
 
       session
         .getUserSessionManager()
-        .endSessionPartInternal('web_foreground_inactivity');
+        .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
       if (result) {
         await result.flush();
@@ -1232,7 +1234,7 @@ describe('initSDK', () => {
 
       session
         .getUserSessionManager()
-        .endSessionPartInternal('web_foreground_inactivity');
+        .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
       if (result) {
         await result.flush();
@@ -1314,7 +1316,7 @@ describe('initSDK', () => {
 
       session
         .getUserSessionManager()
-        .endSessionPartInternal('web_foreground_inactivity');
+        .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
       if (result) {
         await result.flush();
@@ -1820,7 +1822,7 @@ describe('initSDK', () => {
 
         session
           .getUserSessionManager()
-          .endSessionPartInternal('web_foreground_inactivity');
+          .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
         // Need to restore the clock here so that the setTimeout in `getLastSessionExportedSpans` works
         clock.restore();
@@ -1950,11 +1952,13 @@ describe('isolated instances', () => {
     // New internal path through the proxy's underlying manager — also a no-op.
     session
       .getUserSessionManager()
-      .endSessionPartInternal('web_foreground_inactivity');
-    session.getUserSessionManager().startSessionPartInternal('web_activity');
+      .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
     session
       .getUserSessionManager()
-      .endSessionPartInternal('web_foreground_inactivity');
+      .startSessionPartInternal({ reason: 'web_activity' });
+    session
+      .getUserSessionManager()
+      .endSessionPartInternal({ reason: 'web_foreground_inactivity' });
 
     await result.flush();
 
@@ -2008,13 +2012,15 @@ describe('isolated instances', () => {
 
       sdkInstance.log.message('some log', 'info');
       sdkInstance.trace.startSpan('some span').end();
-      internalSessionManager.endSessionPartInternal(
-        'web_foreground_inactivity',
-      );
-      internalSessionManager.startSessionPartInternal('web_activity');
-      internalSessionManager.endSessionPartInternal(
-        'web_foreground_inactivity',
-      );
+      internalSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
+      internalSessionManager.startSessionPartInternal({
+        reason: 'web_activity',
+      });
+      internalSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
       instrumentation.emit();
 
       await sdkInstance.flush();

--- a/packages/web-sdk/src/sdk/initSDK.ts
+++ b/packages/web-sdk/src/sdk/initSDK.ts
@@ -279,7 +279,7 @@ export const initSDK = (
     userSessionManager.setTracerProvider(tracerProvider);
     // No-op if the tab is hidden/unfocused at init; the first part starts
     // on the next engagement via the manager's browser-activity listeners.
-    userSessionManager.startSessionPartInternal('init');
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     const { loggerProvider, embraceLogManager } = setupLogs({
       resource: resourceWithWebSDKAttributes,


### PR DESCRIPTION
## What problem is this solving?

`startSessionPartInternal`/`endSessionPartInternal` took positional string parameters, so call sites like `endSessionPartInternal('user_session_ended', 'manual')` were easy to misread and invited argument-order mistakes as the surface grows.

## Short description of changes

- `startSessionPartInternal` and `endSessionPartInternal` now take a single options object (`StartSessionPartOptions` / `EndSessionPartOptions`), defined once in the manager's `types.ts` and shared by the concrete, no-op, and proxy managers
- `userSessionEndReason` is now plain optional (the `| null` widening is gone) and the option fields are `readonly`, matching the sibling interfaces
- Corrected the field TSDoc to name the actual final part-end reasons (`user_session_ended` / `web_foreground_inactivity`)
- Updated the manager README call shapes to the options-object form
- Migrated all call sites and tests to the new shape (the bulk of the diff; assertions unchanged in strength)

## How has this been tested?

- `npm run lint`, `npm run check`, and the full unit test suite pass
- Test updates are mechanical call-shape migrations; reason sequences and termination-reason assertions are preserved

## Checklist

- [x] Documentation added
- [x] Tests added