### PR TITLE
docs(sessions): correct visibility state value in manager README

### DIFF
--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -404,7 +404,7 @@ Why it happens:
    `_loadOrCreateUserSessionState`, so `getUserSessionId()` returns a real
    id immediately.
 2. `initSDK` calls `startSessionPartInternal('init')` next, but the call
-   no-ops when `!document.hasFocus()` or `visibilityState === 'background'`
+   no-ops when `!document.hasFocus()` or `visibilityState === 'hidden'`
    (parts are foreground-only by design).
 3. Until the next engagement event fires (`focus`/`visibilitychange`),
    `_activeSessionPartId === null`. Logs that pass


### PR DESCRIPTION
## What problem is this solving?

The manager README's empty-part-id troubleshooting section said the init part start no-ops when `visibilityState === 'background'`, but the DOM `document.visibilityState` property only has the values `'visible'` and `'hidden'`. `'background'` is the `emb.state` attribute vocabulary, not a DOM value.

## Short description of changes

- Changed `visibilityState === 'background'` to `visibilityState === 'hidden'` in the README

## How has this been tested?

Docs-only change; no code affected.