### PR TITLE
docs(sessions): align manager README with the rollover method naming

### DIFF
--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -93,7 +93,7 @@ engagement condition holds, the call is a debug-level no-op.
 | `init` | SDK init flow on page load. |
 | `web_foreground` | `visibilitychange` to visible or `focus` while no part is active and the tab is engaged. Also covers the BFCache restore path. |
 | `web_activity` | `keydown`, `mousedown`, `mousemove`, or `scroll` while no part is active and the tab is engaged. Subject to the 30 second activity throttle. |
-| `user_session_rollover` | Called synchronously by `_terminateUserSession` immediately after a user session ends. |
+| `user_session_rollover` | Called synchronously by `_rolloverUserSession` immediately after a user session ends. |
 
 ### End triggers
 
@@ -103,7 +103,7 @@ engagement condition holds, the call is a debug-level no-op.
 | --- | --- |
 | `web_background` | `visibilitychange` to hidden or `blur`. Also covers hard-nav unload and BFCache freeze, since blur or an earlier `visibilitychange` to hidden ends the part before `pagehide` fires. |
 | `web_foreground_inactivity` | The foreground part-inactivity timer (`userSessionForegroundInactivityTimeoutSeconds`, default 30 minutes) fires without any user input event resetting it. |
-| `user_session_ended` | `_terminateUserSession` ending the active part, fired on manual `endUserSession()` or max-duration expiry. |
+| `user_session_ended` | `_rolloverUserSession` ending the active part, fired on manual `endUserSession()` or max-duration expiry. |
 
 The part-level `web_foreground_inactivity` is distinct from the user-session-level `inactivity` reason in the [`UserSessionEndReason`](#termination) table below: when the part-inactivity timer fires it stamps `web_foreground_inactivity` as the part end reason and `inactivity` as the enclosing user session's termination reason on the same final part span.
 
@@ -163,11 +163,15 @@ receive `emb.is_final_session_part`.
 
 ### Termination
 
-`_terminateUserSession(reason)` is the only path that ends a user session. It
-is called from:
+`_rolloverUserSession(reason)` ends the active user session and immediately
+attempts to start a part for the next one. It is called from:
 
 - `endUserSession()` with reason `manual`.
 - The max-duration `setTimeout` callback with reason `max_duration_reached`.
+
+The part-inactivity timer ends a user session without going through
+`_rolloverUserSession`: it calls `endSessionPartInternal` directly with the
+`inactivity` termination reason (see the table below).
 
 `UserSessionEndReason` defines all possible values:
 
@@ -190,7 +194,7 @@ silently no-ops if not (the next engagement event will create it).
 
 | Timer | Constant | Default | Range | Effect on fire |
 | --- | --- | --- | --- | --- |
-| Max duration | `DEFAULT_USER_SESSION_MAX_DURATION_SECONDS` | 12 hours | `MIN_USER_SESSION_MAX_DURATION_SECONDS` (1h) to `MAX_USER_SESSION_MAX_DURATION_SECONDS` (24h) | `_terminateUserSession('max_duration_reached')` |
+| Max duration | `DEFAULT_USER_SESSION_MAX_DURATION_SECONDS` | 12 hours | `MIN_USER_SESSION_MAX_DURATION_SECONDS` (1h) to `MAX_USER_SESSION_MAX_DURATION_SECONDS` (24h) | `_rolloverUserSession('max_duration_reached')` |
 | User-session inactivity (lazy) | `DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` | 30 minutes | `MIN_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (30s) to `MAX_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (24h) | Not a live timer. Written into the state blob as `userSessionInactivityTimeoutSeconds`; `_continueUserSessionAfterPartEnd` records `partEndTs + userSessionInactivityTimeoutSeconds * 1000` into `inactivityDeadlineTs`, checked on the next part start by `isUserSessionExpired`. |
 | Part (foreground) inactivity | `DEFAULT_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` | 30 minutes | `MIN_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` (30s) to `MAX_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` (24h) | Live `setTimeout` armed from `userSessionForegroundInactivityTimeoutSeconds` while a part is active; on fire, `endSessionPartInternal({ reason: 'web_foreground_inactivity', userSessionEndReason: 'inactivity' })` ends the part and the enclosing user session. |
 | Activity throttle | `ACTIVITY_THROTTLE_MS` | 30 seconds | n/a | At most one inactivity-timer reset per 30 seconds of input. |
@@ -222,7 +226,7 @@ The part-inactivity timer is restarted on every activity event, subject to the
 
 | Key | Contents | Lifetime |
 | --- | --- | --- |
-| `embrace_user_session_state` | JSON-serialized `UserSessionState` (id, previous id, start ts, max-end ts, numbers, durations, deadline, properties) | Cleared on `_terminateUserSession`. Written on every part start, every part end (to update `inactivityDeadlineTs`), and on every user-session-scoped `addProperty` / `removeProperty` call while a user session exists. |
+| `embrace_user_session_state` | JSON-serialized `UserSessionState` (id, previous id, start ts, max-end ts, numbers, durations, deadline, properties) | Cleared when the user session ends (final part end, or `_rolloverUserSession` with no active part). Written on every part start, every part end (to update `inactivityDeadlineTs`), and on every user-session-scoped `addProperty` / `removeProperty` call while a user session exists. |
 | `embrace_user_session_number` | Monotonic integer string. | Persisted across visits. Only ever incremented. |
 | `embrace_session_part_number` | Monotonic integer string. | Persisted across visits. Bumped at every session-part start. |
 | `emb.properties.<key>` | String value. | Persisted across visits. Survives user-session boundaries. |
@@ -303,7 +307,7 @@ Several specific edge cases are handled:
   has no active part at the moment of rollover, so no `_continueUserSessionAfterPartEnd`
   call can race with the wipe. The peer's stale max-duration timer is cleared
   lazily, on its next `_setupMaxDurationTimer` call (the next part start). If
-  the stale timer fires first, `_terminateUserSession('max_duration_reached')`
+  the stale timer fires first, `_rolloverUserSession('max_duration_reached')`
   runs benignly against the already-cleared storage row.
 
 ## Unload and BFCache handling

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -120,9 +120,11 @@ On end, the manager:
    `_activeSessionPartId`, and `_activeSessionPartCounts`.
 4. If the end reason is not final (anything other than `user_session_ended` or
    `web_foreground_inactivity`, in practice `web_background`), calls
-   `_continueUserSessionAfterPartEnd(partEndTs)` which writes
-   `partEndTs + userSessionInactivityTimeoutSeconds * 1000` into the state blob's
-   `inactivityDeadlineTs`. The max-duration timer keeps running on its existing
+   `_continueUserSessionAfterPartEnd(now)` which writes
+   `now + userSessionInactivityTimeoutSeconds * 1000` into the state blob's
+   `inactivityDeadlineTs`. `now` is the actual call time, not the (possibly
+   anchored) span end timestamp, so an anchored part end cannot shorten the
+   inactivity window. The max-duration timer keeps running on its existing
    deadline (`userSessionMaxEndTs` is fixed at creation), so it is not re-armed.
 
 When the end reason is final (`user_session_ended` or `web_foreground_inactivity`) the
@@ -195,7 +197,7 @@ silently no-ops if not (the next engagement event will create it).
 | Timer | Constant | Default | Range | Effect on fire |
 | --- | --- | --- | --- | --- |
 | Max duration | `DEFAULT_USER_SESSION_MAX_DURATION_SECONDS` | 12 hours | `MIN_USER_SESSION_MAX_DURATION_SECONDS` (1h) to `MAX_USER_SESSION_MAX_DURATION_SECONDS` (24h) | `_rolloverUserSession('max_duration_reached')` |
-| User-session inactivity (lazy) | `DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` | 30 minutes | `MIN_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (30s) to `MAX_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (24h) | Not a live timer. Written into the state blob as `userSessionInactivityTimeoutSeconds`; `_continueUserSessionAfterPartEnd` records `partEndTs + userSessionInactivityTimeoutSeconds * 1000` into `inactivityDeadlineTs`, checked on the next part start by `isUserSessionExpired`. |
+| User-session inactivity (lazy) | `DEFAULT_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` | 30 minutes | `MIN_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (30s) to `MAX_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS` (24h) | Not a live timer. Written into the state blob as `userSessionInactivityTimeoutSeconds`; `_continueUserSessionAfterPartEnd` records `now + userSessionInactivityTimeoutSeconds * 1000` into `inactivityDeadlineTs` (from the actual call time, not the anchored span end), checked on the next part start by `isUserSessionExpired`. |
 | Part (foreground) inactivity | `DEFAULT_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` | 30 minutes | `MIN_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` (30s) to `MAX_USER_SESSION_FOREGROUND_INACTIVITY_TIMEOUT_SECONDS` (24h) | Live `setTimeout` armed from `userSessionForegroundInactivityTimeoutSeconds` while a part is active; on fire, `endSessionPartInternal({ reason: 'web_foreground_inactivity', userSessionEndReason: 'inactivity' })` ends the part and the enclosing user session. |
 | Activity throttle | `ACTIVITY_THROTTLE_MS` | 30 seconds | n/a | At most one inactivity-timer reset per 30 seconds of input. |
 | `endUserSession` cooldown | `END_USER_SESSION_COOLDOWN_MS` | 5 seconds | n/a | Calls within 5 seconds of the last call are silently ignored. |


### PR DESCRIPTION
## What problem is this solving?

The user-session manager README referred to `_terminateUserSession` in six places, but the method is named `_rolloverUserSession`. It also claimed that method is the only path that ends a user session, contradicting its own tables: the part-inactivity timer ends one directly through `endSessionPartInternal`. Separately, the README still described `inactivityDeadlineTs` as computed from `partEndTs`, but `_continueUserSessionAfterPartEnd` now derives it from the actual call time so an anchored part end cannot shorten the inactivity window.

## Short description of changes

- Renamed all `_terminateUserSession` references to `_rolloverUserSession`.
- Replaced the "only path" claim with an accurate description and noted the part-inactivity path.
- Clarified when the user-session state storage row is cleared.
- Described the inactivity deadline as computed from the actual call time, not the anchored span end timestamp.

## How has this been tested?

Docs-only change. Verified each statement against EmbraceUserSessionManager.ts and ran lint.

## Checklist

- [x] Documentation added
- [ ] Tests added