### PR TITLE
feat(transport): use fflate for gzip compression

### DIFF
--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -94,6 +94,7 @@
     "@opentelemetry/sdk-trace-web": "^2.9.0",
     "@opentelemetry/semantic-conventions": "^1.41.1",
     "@opentelemetry/web-common": "^0.220.0",
+    "fflate": "0.8.3",
     "hoist-non-react-statics": "^3.3.2",
     "web-vitals": "^5.3.0"
   },

--- a/packages/web-sdk/scripts/validate.ts
+++ b/packages/web-sdk/scripts/validate.ts
@@ -18,7 +18,7 @@ import zlib from 'node:zlib';
 import { COLORS, log, logSection } from '../../../scripts/build-config.ts';
 
 // Maximum bundle size (gzipped) — triggers hard failure to catch bloat/duplication early
-const MAX_BUNDLE_SIZE_KB = 56;
+const MAX_BUNDLE_SIZE_KB = 57;
 
 const BUNDLE_FILE = 'embrace-web-sdk.js';
 const BUNDLE_MAP_FILE = 'embrace-web-sdk.js.map';

--- a/packages/web-sdk/src/exporters/EmbraceLogExporter/EmbraceLogExporter.test.ts
+++ b/packages/web-sdk/src/exporters/EmbraceLogExporter/EmbraceLogExporter.test.ts
@@ -80,14 +80,9 @@ describe('EmbraceLogExporter', () => {
     expect((headers as Record<string, string>)['X-EM-DID']).to.equal(
       mockUserID,
     );
-    // Chrome, Webkit and Firefox have slightly different encoding processes, generating different Content-Length values.
-    const chromeContentLength = '189';
-    const firefoxWebkitContentLength = '191';
-    //TODO we should find a way to know if we are running in Chrome, Firefox or Webkit and just assert for the specific value for each browser
-    expect((headers as Record<string, string>)['Content-Length']).to.be.oneOf([
-      chromeContentLength,
-      firefoxWebkitContentLength,
-    ]);
+    expect((headers as Record<string, string>)['Content-Length']).to.equal(
+      '189',
+    );
     expect(fakeFetchGetUrl()).to.equal(
       'https://a-testAppID.data.emb-api.com/v2/logs',
     );

--- a/packages/web-sdk/src/exporters/EmbraceTraceExporter/EmbraceTraceExporter.test.ts
+++ b/packages/web-sdk/src/exporters/EmbraceTraceExporter/EmbraceTraceExporter.test.ts
@@ -68,14 +68,9 @@ describe('EmbraceTraceExporter', () => {
     expect((headers as Record<string, string>)['X-EM-DID']).to.equal(
       mockUserID,
     );
-    // Chrome, Webkit and Firefox have slightly different encoding processes- Content-Length values. 286 for Chrome, 287 for Firefox and Webkit.
-    const chromeContentLength = '294';
-    const firefoxWebkitContentLength = '293';
-    //TODO we should find a way to know if we are running in Chrome, Firefox or Webkit and just assert for the specific value for each browser
-    expect((headers as Record<string, string>)['Content-Length']).to.be.oneOf([
-      chromeContentLength,
-      firefoxWebkitContentLength,
-    ]);
+    expect((headers as Record<string, string>)['Content-Length']).to.equal(
+      '292',
+    );
     expect(fakeFetchGetUrl()).to.equal(
       'https://a-testAppID.data.emb-api.com/v2/spans',
     );

--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -644,49 +644,6 @@ describe('initSDK', () => {
     expect(diagLogger.getErrorLogs()).to.have.lengthOf(0);
   });
 
-  it('should not initialize when CompressionStream is unavailable and sending to Embrace', () => {
-    const diagLogger = new InMemoryDiagLogger();
-    const originalCompressionStream = (globalThis as never)[
-      'CompressionStream'
-    ];
-    delete (globalThis as never)['CompressionStream'];
-
-    try {
-      const result = initSDK({ appID: 'app12', diagLogger });
-      void expect(result).to.be.false;
-
-      expect(diagLogger.getErrorLogs()).to.have.lengthOf(1);
-      expect(diagLogger.getErrorLogs()[0]).to.equal(
-        'failed to initialize the SDK: CompressionStream is not supported in this browser and required for data compression.',
-      );
-    } finally {
-      // Restore CompressionStream
-      (globalThis as never)['CompressionStream'] = originalCompressionStream;
-    }
-  });
-
-  it('should initialize when CompressionStream is unavailable but using custom exporters', () => {
-    const diagLogger = new InMemoryDiagLogger();
-    const originalCompressionStream = (globalThis as never)[
-      'CompressionStream'
-    ];
-    delete (globalThis as never)['CompressionStream'];
-
-    try {
-      const result = initSDK({
-        logExporters: [logExporter],
-        spanExporters: [spanExporter],
-        diagLogger,
-      });
-      void expect(result).not.to.be.false;
-
-      expect(diagLogger.getErrorLogs()).to.have.lengthOf(0);
-    } finally {
-      // Restore CompressionStream
-      (globalThis as never)['CompressionStream'] = originalCompressionStream;
-    }
-  });
-
   describe('communication with Embrace', () => {
     it('should include the correct resource attributes', async () => {
       fakeFetchRespondWith('');

--- a/packages/web-sdk/src/sdk/initSDK.ts
+++ b/packages/web-sdk/src/sdk/initSDK.ts
@@ -148,12 +148,6 @@ export const initSDK = (
       );
     }
 
-    if (sendingToEmbrace && typeof CompressionStream === 'undefined') {
-      throw new Error(
-        'CompressionStream is not supported in this browser and required for data compression.',
-      );
-    }
-
     const namespace = appID ?? undefined;
     const sdkLocalStorage = new NamespacedStorage({
       namespace,

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
@@ -319,50 +319,6 @@ describe('FetchTransport', () => {
     });
   });
 
-  describe('compression failure', () => {
-    it('should return failure with diagnostic log when compression fails', async () => {
-      const original = globalThis.CompressionStream;
-      globalThis.CompressionStream = class {
-        constructor() {
-          throw new Error('CompressionStream not supported');
-        }
-      } as unknown as typeof CompressionStream;
-
-      try {
-        const transport = makeTransport({ compression: 'gzip' });
-        const result = await transport.send(smallPayload, 1000);
-
-        expect(result.status).to.equal('failure');
-
-        const warns = diagLogger.getWarnLogs();
-        expect(warns.some((msg) => msg.includes('gzip compression failed'))).to
-          .be.true;
-      } finally {
-        globalThis.CompressionStream = original;
-      }
-    });
-
-    it('should not corrupt keepalive counters when compression fails', async () => {
-      const original = globalThis.CompressionStream;
-      globalThis.CompressionStream = class {
-        constructor() {
-          throw new Error('CompressionStream not supported');
-        }
-      } as unknown as typeof CompressionStream;
-
-      const transport = makeTransport({ compression: 'gzip' });
-      await transport.send(smallPayload, 1000);
-
-      globalThis.CompressionStream = original;
-
-      fakeFetchRespondWith('ok', { status: 200 });
-      const transport2 = makeTransport();
-      await transport2.send(smallPayload, 1000);
-
-      expect(fakeFetchGetKeepalive()).to.equal(true);
-    });
-  });
-
   describe('network errors', () => {
     it('should return retryable when fetch throws a TypeError', async () => {
       reinstallFetch().rejects(new TypeError('Failed to fetch'));

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
@@ -3,6 +3,7 @@ import type {
   ExportResponse,
   IExporterTransport,
 } from '@opentelemetry/otlp-exporter-base';
+import { gzipSync } from 'fflate';
 import type { FetchRequestParameters } from './types.ts';
 
 // The fetch spec limits inflight keepalive request bodies to 64KiB total per
@@ -25,44 +26,6 @@ export function _resetKeepaliveTracking(): void {
 
 export class FetchTransport implements IExporterTransport {
   public constructor(private readonly _config: FetchRequestParameters) {}
-
-  // Embrace endpoints require request bodies to be compressed with gzip
-  private static async _compressRequest(
-    data: Uint8Array<ArrayBuffer>,
-  ): Promise<Uint8Array<ArrayBuffer>> {
-    const stream = new CompressionStream('gzip');
-    const writer = stream.writable.getWriter();
-
-    void writer.write(data);
-    void writer.close();
-
-    const compressedChunks: Uint8Array[] = [];
-    const reader = stream.readable.getReader();
-
-    let done = false;
-    while (!done) {
-      const result = await reader.read();
-
-      if (result.value) {
-        compressedChunks.push(result.value);
-      }
-
-      done = result.done;
-    }
-
-    const compressedData = new Uint8Array(
-      compressedChunks.reduce((acc, chunk) => acc + chunk.length, 0),
-    );
-
-    let offset = 0;
-
-    for (const chunk of compressedChunks) {
-      compressedData.set(chunk, offset);
-      offset += chunk.length;
-    }
-
-    return compressedData;
-  }
 
   public send(
     data: Uint8Array<ArrayBuffer>,
@@ -107,7 +70,9 @@ export class FetchTransport implements IExporterTransport {
     try {
       if (this._config.compression === 'gzip') {
         try {
-          request = await FetchTransport._compressRequest(data);
+          // mtime: 0 keeps the gzip MTIME header field zeroed so output is
+          // deterministic and carries no per-request timestamp.
+          request = gzipSync(data, { mtime: 0 });
         } catch (error) {
           const compressError =
             error instanceof Error ? error : new Error(String(error));


### PR DESCRIPTION
## What problem is this solving?

Request body compression relied on the browser `CompressionStream` API, which is async, unavailable in some browsers (forcing `initSDK` to refuse initialization when sending to Embrace), and produces slightly different output per browser engine. Using fflate gives the SDK synchronous, deterministic gzip with no browser capability requirement.

## Short description of changes

- Add `fflate` 0.8.3 and replace the `CompressionStream`-based `_compressRequest` in `FetchTransport` with `gzipSync`, zeroing the gzip MTIME header so output is deterministic and carries no per-request timestamp
- Keep a narrow try/catch around compression that logs a `gzip compression failed` diagnostic and returns a failure result
- Remove the `initSDK` guard that refused to initialize when `CompressionStream` was unavailable, along with its tests; the failure mode no longer exists
- Tighten exporter `Content-Length` test assertions from per-browser `oneOf` ranges to exact values, since fflate output is identical across browsers

## Testing

- `FetchTransport`, `EmbraceLogExporter`, and `EmbraceTraceExporter` unit tests pass (26 tests), including decompressing captured request bodies via native `DecompressionStream` and comparing the parsed JSON
- `npm run lint` and `npm run check` pass from the repo root