### PR TITLE
build: remove dts generation from tsdown configs

### DIFF
--- a/packages/web-sdk/packages/otlp-transformer/tsdown.config.ts
+++ b/packages/web-sdk/packages/otlp-transformer/tsdown.config.ts
@@ -18,7 +18,6 @@ export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
   target: false,
-  dts: true,
   outDir: 'dist',
   sourcemap: true,
   platform: 'browser',

--- a/packages/web-sdk/tsdown.config.ts
+++ b/packages/web-sdk/tsdown.config.ts
@@ -43,7 +43,6 @@ export default defineConfig([
     entry: ['src/**/*.ts', '!src/**/*.test.*'],
     format: ['cjs', 'esm'],
     target: 'es2022',
-    dts: true,
     outDir: 'dist',
     sourcemap: true,
     platform: 'browser',


### PR DESCRIPTION
## What problem is this PR solving?

The tsdown build configs for `web-sdk` and the `otlp-transformer` sub-package generate `.d.ts` declarations via `dts: true`. This PR removes that key from the config to let tsdown use the default: true.

## Short description of the changes

- Drop `dts: true` from `packages/web-sdk/tsdown.config.ts`
- Drop `dts: true` from `packages/web-sdk/packages/otlp-transformer/tsdown.config.ts`

## How was this tested?

Pre-commit lint and typecheck passed.

## Checklist

- [x] Code builds and lints
- [ ] Tests added/updated (n/a)