### PR TITLE
build(deps): update turbo to 2.9.18

### DIFF
--- a/demo/frontend/turbo.json
+++ b/demo/frontend/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "../../node_modules/turbo/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "terser": "5.48.0",
         "tsdown": "0.22.1",
         "tsx": "4.22.4",
-        "turbo": "2.9.16",
+        "turbo": "2.9.18",
         "typescript": "6.0.3",
         "typescript-eslint": "8.60.0",
         "vite": "8.0.16"
@@ -2722,9 +2722,9 @@
       "license": "MIT"
     },
     "node_modules/@turbo/darwin-64": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.16.tgz",
-      "integrity": "sha512-jLjApWTSNd7JZ5JaLYfelW1ytnGQOvB7ivl+2RD1xQvJTbi8I9gBjzcga7tDZVPyaxpl10YTfJt3BrYXR18KDw==",
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.18.tgz",
+      "integrity": "sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==",
       "cpu": [
         "x64"
       ],
@@ -2736,9 +2736,9 @@
       ]
     },
     "node_modules/@turbo/darwin-arm64": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.16.tgz",
-      "integrity": "sha512-YPgrn+5HIGzrx0O2a631SV4MBQUe4W/DafMFUuBVgaU32PW9/OTT0ehviF0QSxTXuRJlHvW2eUTemddF5/spmw==",
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.18.tgz",
+      "integrity": "sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==",
       "cpu": [
         "arm64"
       ],
@@ -2750,9 +2750,9 @@
       ]
     },
     "node_modules/@turbo/linux-64": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.16.tgz",
-      "integrity": "sha512-vAEf1H6l26lTpl9FJ/peQo1NUB8RC0sbEJJz5mPcUhHA2bPDup2x3CZPgo/bH8S4cUcBLm4FN3UHd5iUO2RAew==",
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.18.tgz",
+      "integrity": "sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==",
       "cpu": [
         "x64"
       ],
@@ -2764,9 +2764,9 @@
       ]
     },
     "node_modules/@turbo/linux-arm64": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.16.tgz",
-      "integrity": "sha512-xDBLR2PZg4BrQOchfG6svgpv5FCNJ2TOtT2psLdEJcdKo1BH+pnPs9Xj6pvUjgfkHbuvBOfeE4R6tvxMoQKDHQ==",
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.18.tgz",
+      "integrity": "sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==",
       "cpu": [
         "arm64"
       ],
@@ -2778,9 +2778,9 @@
       ]
     },
     "node_modules/@turbo/windows-64": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.16.tgz",
-      "integrity": "sha512-NBAJnaUiGdgkSzQwUIdOvkCkcpTSu58G/sBGa0mvBtzfvFOOgrQwepKOOQ8cp6sWM6OcKDNFj2p1dsZA1OWjPg==",
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.18.tgz",
+      "integrity": "sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==",
       "cpu": [
         "x64"
       ],
@@ -2792,9 +2792,9 @@
       ]
     },
     "node_modules/@turbo/windows-arm64": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.16.tgz",
-      "integrity": "sha512-Y7SJppD0Z8wjO3Ec0ZGd9KQ4Yv0BMnA8CIowj5Vp+OEVsosXDG2weK6/t1RRLfJmc2Ozrnd6y4DOgQys+mn3WQ==",
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.18.tgz",
+      "integrity": "sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==",
       "cpu": [
         "arm64"
       ],
@@ -9826,21 +9826,21 @@
       }
     },
     "node_modules/turbo": {
-      "version": "2.9.16",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.16.tgz",
-      "integrity": "sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==",
+      "version": "2.9.18",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.18.tgz",
+      "integrity": "sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "@turbo/darwin-64": "2.9.16",
-        "@turbo/darwin-arm64": "2.9.16",
-        "@turbo/linux-64": "2.9.16",
-        "@turbo/linux-arm64": "2.9.16",
-        "@turbo/windows-64": "2.9.16",
-        "@turbo/windows-arm64": "2.9.16"
+        "@turbo/darwin-64": "2.9.18",
+        "@turbo/darwin-arm64": "2.9.18",
+        "@turbo/linux-64": "2.9.18",
+        "@turbo/linux-arm64": "2.9.18",
+        "@turbo/windows-64": "2.9.18",
+        "@turbo/windows-arm64": "2.9.18"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "terser": "5.48.0",
     "tsdown": "0.22.1",
     "tsx": "4.22.4",
-    "turbo": "2.9.16",
+    "turbo": "2.9.18",
     "typescript": "6.0.3",
     "typescript-eslint": "8.60.0",
     "vite": "8.0.16"

--- a/packages/web-cli/turbo.json
+++ b/packages/web-cli/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "../../node_modules/turbo/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/packages/web-sdk/turbo.json
+++ b/packages/web-sdk/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "../../node_modules/turbo/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/tests/integration/turbo.json
+++ b/tests/integration/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "../../node_modules/turbo/schema.json",
   "extends": ["//"],
   "tasks": {
     "install-dependencies": {


### PR DESCRIPTION
## What problem is this solving?

Keeps the `turbo` dev dependency current (2.9.16 -> 2.9.18) and makes editor schema resolution work offline by pointing each `turbo.json` `$schema` at the locally installed `node_modules/turbo/schema.json` instead of the remote `https://turbo.build/schema.json` URL.

## Short description of the changes

- Bump `turbo` to `2.9.18` in `package.json` and `package-lock.json`.
- Repoint `$schema` in every workspace `turbo.json` (demo/frontend, web-cli, web-sdk, tests/integration) to the local package path.

## How was this tested?

`npm run check` runs via the pre-commit hook (lint:fix + turbo run check), both clean.

## Checklist

- [x] Changes are covered by existing tooling (lint/typecheck)