### PR TITLE
feat(sessions): add soft-nav part rollover primitive and web_soft_nav reasons

### DIFF
--- a/packages/web-sdk/src/api-sessions/manager/types.ts
+++ b/packages/web-sdk/src/api-sessions/manager/types.ts
@@ -126,7 +126,8 @@ export type StartSessionOptions = {
 // `UserSessionEndReason`) are emitted unprefixed so the backend can correlate
 // them across platforms. Reasons that describe behaviour specific to the web
 // environment (`web_foreground`, `web_background`, `web_activity`,
-// `web_foreground_inactivity`) are stamped with a `web_` prefix. The part-level
+// `web_foreground_inactivity`, `web_soft_nav`) are stamped with a `web_`
+// prefix. The part-level
 // `web_foreground_inactivity` and the user-session-level `inactivity` are distinct: when
 // the part-inactivity timer fires it stamps `web_foreground_inactivity` as the part end
 // reason and `inactivity` as the enclosing user session's termination reason
@@ -136,11 +137,13 @@ export type SessionPartStartReason =
   | 'init' // first part on SDK init (page load); covers the hard-nav load side
   | 'web_foreground' // tab became engaged via visibilitychange (visible) or focus while no part was active
   | 'web_activity' // user input resumed after an inactivity-killed part
+  | 'web_soft_nav' // soft navigation started the next part in the same user session
   | 'user_session_rollover'; // synchronous user-session rollover forced a new part (endUserSession API / max-duration timer)
 
 export type SessionPartEndReason =
   | 'web_background' // tab disengaged via visibilitychange (hidden) or blur. Also covers hard-nav unload and BFCache freeze (pagehide is not listened to)
   | 'web_foreground_inactivity' // no keyboard/mouse/scroll input during the active part for the configured inactivity window; also ends the enclosing user session, with the part span end timestamp anchored to the last activity
+  | 'web_soft_nav' // rolled the part over on a soft navigation. Not final, the user session continues
   | 'user_session_ended'; // closed because the enclosing user session ended (manual endUserSession, max-duration); stamped on the span by the manager
 
 export type UserSessionEndReason =

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -11,6 +11,8 @@ import {
 } from '@opentelemetry/semantic-conventions/incubating';
 import type {
   PropertyOptions,
+  SessionPartEndReason,
+  SessionPartStartReason,
   UserSessionEndReason,
 } from '../../api-sessions/manager/types.ts';
 import type { VisibilityStateDocument } from '../../common/index.ts';
@@ -802,6 +804,41 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     this._state = null;
     this._storage.removeItem(EMBRACE_USER_SESSION_STATE_KEY);
     this._clearMaxDurationTimer();
+  }
+
+  /**
+   * Ends the active part and starts a new one within the same user session.
+   * The user session is preserved while the part counters advance, so the
+   * caller's `endReason`/`startReason` must both be non-final. Both spans share
+   * one boundary timestamp so they tile without a gap; the caller may supply it
+   * (for example the timestamp of the triggering event), defaulting to now. A
+   * no-op when no part is active: there is nothing to roll over and the next
+   * engagement starts one.
+   */
+
+  // @ts-expect-error suppressed until a caller is wired; remove the directive then
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: no caller is wired yet
+  private _rolloverSessionPart({
+    endReason,
+    startReason,
+    timestamp,
+  }: {
+    endReason: SessionPartEndReason;
+    startReason: SessionPartStartReason;
+    timestamp?: number;
+  }): void {
+    if (!this._sessionPartSpan) {
+      return;
+    }
+    const boundaryTimestamp = timestamp ?? this._perf.getNowMillis();
+    this.endSessionPartInternal({
+      reason: endReason,
+      timestamp: boundaryTimestamp,
+    });
+    this.startSessionPartInternal({
+      reason: startReason,
+      timestamp: boundaryTimestamp,
+    });
   }
 
   private _setupMaxDurationTimer(state: UserSessionState, now: number): void {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -96,6 +96,7 @@ by design.
 | `init` | SDK init flow on page load. |
 | `web_foreground` | `visibilitychange` to visible or `focus` while no part is active and the tab is engaged. Also covers the BFCache restore path. |
 | `web_activity` | `keydown`, `mousedown`, `mousemove`, or `scroll` while no part is active and the tab is engaged. Subject to the 30 second activity throttle. |
+| `web_soft_nav` | A soft navigation rolled the active part over, starting the next part in the same user session. Stamped on the new part. |
 | `user_session_rollover` | Begins the next user session's first part immediately after a user session ends. |
 
 ### End triggers
@@ -106,6 +107,7 @@ by design.
 | --- | --- |
 | `web_background` | `visibilitychange` to hidden or `blur`. Also covers hard-nav unload and BFCache freeze, since blur or an earlier `visibilitychange` to hidden ends the part before `pagehide` fires. |
 | `web_foreground_inactivity` | The foreground part-inactivity timer (`userSessionForegroundInactivityTimeoutSeconds`, default 30 minutes) fires without any user input event resetting it. |
+| `web_soft_nav` | A soft navigation rolled the active part over. Not a final reason: the enclosing user session continues and a new part starts immediately. |
 | `user_session_ended` | The active part is ended as part of a user-session rollover, triggered by manual `endUserSession()` or max-duration expiry. |
 
 The part-level `web_foreground_inactivity` is distinct from the user-session-level `inactivity` reason in the [`UserSessionEndReason`](#termination) table below: when the part-inactivity timer fires it stamps `web_foreground_inactivity` as the part end reason and `inactivity` as the enclosing user session's termination reason on the same final part span.


### PR DESCRIPTION
## What problem is this PR solving?

Soft navigations (SPA route changes) should roll the active session part over so each route maps to its own part. The trigger and its navigation-type filtering are not settled yet, so this lands the reusable building blocks without wiring a trigger.

## Short description of the changes

- Add `_rolloverSessionPart`, a navigation-agnostic primitive that ends the active part and starts a new one within the same user session. Both spans share one boundary timestamp so they tile without a gap; the caller may supply it (e.g. the triggering event's timestamp), defaulting to now. No-op when no part is active. Not yet called: the lint/ts directives are suppressed until a caller is wired.
- Add the `web_soft_nav` `SessionPartStartReason` and `SessionPartEndReason` (non-final, `web_`-prefixed).
- Document soft-nav rollover in the `EmbraceUserSessionManager` README.

## How was this tested?

`npm run check` and `npm run lint`. No runtime path is reachable yet since the primitive has no caller, so no behavioral tests were added.

## Checklist

- [x] Typecheck and lint pass
- [x] README updated to match the code