### PR TITLE
fix(sessions): keep in-memory user session authoritative when storage is unavailable

### DIFF
--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -4,6 +4,7 @@ import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import {
   createTestDynamicConfigManager,
+  FailingStorage,
   InMemoryDiagLogger,
   InMemoryStorage,
   MockPerformanceManager,
@@ -311,6 +312,34 @@ describe('EmbraceUserSessionManager', () => {
     // exactly one error; later failures stay silent.
     expect(diag.getErrorLogs()).to.have.lengthOf(1);
     expect(diag.getErrorLogs()[0]).to.contain('writes disabled');
+  });
+
+  it('continues the same user session across parts when storage is unavailable', () => {
+    const manager = new EmbraceUserSessionManager({
+      diag,
+      perf: new MockPerformanceManager(clock),
+      storage: new NamespacedStorage({ storage: new FailingStorage(), diag }),
+      limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      visibilityDoc: window.document,
+      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
+    });
+
+    manager.startSessionPartInternal({ reason: 'init' });
+    const attrs1 = manager.getUserSessionAttributes();
+    manager.endSessionPartInternal({ reason: 'web_background' });
+
+    // Advance within the inactivity timeout.
+    clock.tick(29 * 60 * 1000);
+
+    manager.startSessionPartInternal({ reason: 'init' });
+    const attrs2 = manager.getUserSessionAttributes();
+
+    // Storage is unavailable, so the in-memory session the manager already
+    // holds stays authoritative; a fresh user session is not minted per part.
+    expect(attrs2?.['emb.user_session_id']).to.equal(
+      attrs1?.['emb.user_session_id'],
+    );
+    expect(attrs2?.['emb.user_session_part_index']).to.equal(2);
   });
 
   it('should clamp max duration to the maximum', () => {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -8,7 +8,6 @@ import {
   InMemoryDiagLogger,
   InMemoryStorage,
   MockPerformanceManager,
-  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../tests/utils/index.ts';
 import type { DynamicSDKConfig } from '../../sdk/index.ts';
 import { NamespacedStorage } from '../../utils/NamespacedStorage/NamespacedStorage.ts';
@@ -290,35 +289,7 @@ describe('EmbraceUserSessionManager', () => {
 
   describe('storage unavailable', () => {
     it('creates an in-memory user session and reports the write failure once', () => {
-      const failingStorage = {
-        getItem: () => {
-          throw new Error('Storage unavailable');
-        },
-        setItem: () => {
-          throw new Error('Storage unavailable');
-        },
-        removeItem: () => {
-          throw new Error('Storage unavailable');
-        },
-        clear: () => {
-          throw new Error('Storage unavailable');
-        },
-        key: () => null,
-        length: 0,
-      } satisfies Storage;
-      const safeFailing = new NamespacedStorage({
-        storage: failingStorage,
-        diag,
-      });
-
-      const manager = new EmbraceUserSessionManager({
-        diag,
-        perf: new MockPerformanceManager(clock),
-        storage: safeFailing,
-        limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
-        visibilityDoc: window.document,
-        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
-      });
+      const manager = createFailingStorageManager();
 
       manager.startSessionPartInternal({ reason: 'init' });
       const attrs = manager.getUserSessionAttributes();
@@ -361,8 +332,8 @@ describe('EmbraceUserSessionManager', () => {
         manager.getUserSessionAttributes()?.['emb.user_session_id'];
 
       // Several engage/disengage cycles, each well within the inactivity
-      // timeout: one journey must stay one user session, never fragmenting into
-      // one-per-part the way it did before the in-memory fallback existed.
+      // timeout: one journey must stay one user session and must not fragment
+      // into one part per user session.
       for (
         let expectedPartIndex = 2;
         expectedPartIndex <= 4;
@@ -380,14 +351,16 @@ describe('EmbraceUserSessionManager', () => {
       }
     });
 
-    it('mints a fresh user session when the inactivity timeout expires', () => {
+    it('mints a fresh user session when the between-parts inactivity deadline passes', () => {
       const manager = createFailingStorageManager();
 
       manager.startSessionPartInternal({ reason: 'init' });
       const attrs1 = manager.getUserSessionAttributes();
       manager.endSessionPartInternal({ reason: 'web_background' });
 
-      // Past the default 30 min inactivity timeout.
+      // Past the default 30 min inactivity timeout. The part ended without a
+      // live timer, so the next start detects lazy expiry from the deadline
+      // recorded on the in-memory row.
       clock.tick(31 * 60 * 1000);
 
       manager.startSessionPartInternal({ reason: 'init' });
@@ -401,6 +374,11 @@ describe('EmbraceUserSessionManager', () => {
         attrs1?.['emb.user_session_id'],
       );
       expect(attrs2?.['emb.user_session_part_index']).to.equal(1);
+      // The fresh user session back-links to the one that just expired, even
+      // though that link was never persisted.
+      expect(attrs2?.['emb.user_session_previous_id']).to.equal(
+        attrs1?.['emb.user_session_id'],
+      );
     });
 
     it('mints a fresh user session when the max duration expires', () => {
@@ -415,6 +393,55 @@ describe('EmbraceUserSessionManager', () => {
       // Past the 1 hour max duration. The max-duration timer lives in memory, so
       // it rolls the user session over even though nothing was ever persisted.
       clock.tick(3601 * 1000);
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const attrs2 = manager.getUserSessionAttributes();
+
+      expect(attrs2?.['emb.user_session_id']).to.not.equal(
+        attrs1?.['emb.user_session_id'],
+      );
+      expect(attrs2?.['emb.user_session_part_index']).to.equal(1);
+    });
+
+    it('mints a fresh user session when the live foreground inactivity timer fires', () => {
+      const manager = createFailingStorageManager({
+        userSessionForegroundInactivityTimeoutSeconds: 60,
+        userSessionInactivityTimeoutSeconds: 1800,
+      });
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const attrs1 = manager.getUserSessionAttributes();
+
+      // Let the live timer fire while the part is still active. It ends the part
+      // with a final reason, which nulls the in-memory row, so the fallback must
+      // not resurrect it on the next start: the expired session is gone for good.
+      clock.tick(60 * 1000);
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const attrs2 = manager.getUserSessionAttributes();
+
+      expect(attrs2?.['emb.user_session_id']).to.not.equal(
+        attrs1?.['emb.user_session_id'],
+      );
+      expect(attrs2?.['emb.user_session_part_index']).to.equal(1);
+      expect(attrs2?.['emb.user_session_previous_id']).to.equal(
+        attrs1?.['emb.user_session_id'],
+      );
+    });
+
+    it('does not resurrect in-memory state once a write has persisted and storage clears', () => {
+      // Storage works at first, so the manager persists and flips _hasStoredState
+      // true. Then the row is wiped (sibling tab, eviction). An empty read after
+      // a successful persist is a genuine clear, not an outage, so the next part
+      // start must create a fresh user session rather than reuse the in-memory one.
+      const manager = createManager();
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const attrs1 = manager.getUserSessionAttributes();
+      manager.endSessionPartInternal({ reason: 'web_background' });
+
+      inMemoryStorage.clear();
+      clock.tick(5 * 60 * 1000);
 
       manager.startSessionPartInternal({ reason: 'init' });
       const attrs2 = manager.getUserSessionAttributes();

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -288,140 +288,142 @@ describe('EmbraceUserSessionManager', () => {
     expect(attrs2?.['emb.user_session_part_index']).to.equal(2);
   });
 
-  it('should handle localStorage unavailable gracefully', () => {
-    const failingStorage = {
-      getItem: () => {
-        throw new Error('Storage unavailable');
-      },
-      setItem: () => {
-        throw new Error('Storage unavailable');
-      },
-      removeItem: () => {
-        throw new Error('Storage unavailable');
-      },
-      clear: () => {
-        throw new Error('Storage unavailable');
-      },
-      key: () => null,
-      length: 0,
-    } satisfies Storage;
-    const safeFailing = new NamespacedStorage({
-      storage: failingStorage,
-      diag,
-    });
+  describe('storage unavailable', () => {
+    it('creates an in-memory user session and reports the write failure once', () => {
+      const failingStorage = {
+        getItem: () => {
+          throw new Error('Storage unavailable');
+        },
+        setItem: () => {
+          throw new Error('Storage unavailable');
+        },
+        removeItem: () => {
+          throw new Error('Storage unavailable');
+        },
+        clear: () => {
+          throw new Error('Storage unavailable');
+        },
+        key: () => null,
+        length: 0,
+      } satisfies Storage;
+      const safeFailing = new NamespacedStorage({
+        storage: failingStorage,
+        diag,
+      });
 
-    const manager = new EmbraceUserSessionManager({
-      diag,
-      perf: new MockPerformanceManager(clock),
-      storage: safeFailing,
-      limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
-      visibilityDoc: window.document,
-      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
-    });
+      const manager = new EmbraceUserSessionManager({
+        diag,
+        perf: new MockPerformanceManager(clock),
+        storage: safeFailing,
+        limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+        visibilityDoc: window.document,
+        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
+      });
 
-    manager.startSessionPartInternal({ reason: 'init' });
-    const attrs = manager.getUserSessionAttributes();
-    expect(attrs?.['emb.user_session_id']).to.have.lengthOf(32);
-    // Storage unavailable: getIncrementedCount falls back to 1, which is
-    // indistinguishable from a genuine first session.
-    expect(attrs?.['emb.user_session_number']).to.equal(1);
-    // NamespacedStorage flips disabled on the first failed write and emits
-    // exactly one error; later failures stay silent.
-    expect(diag.getErrorLogs()).to.have.lengthOf(1);
-    expect(diag.getErrorLogs()[0]).to.contain('writes disabled');
-  });
-
-  it('continues the same user session across parts when storage is unavailable', () => {
-    const manager = createFailingStorageManager();
-
-    manager.startSessionPartInternal({ reason: 'init' });
-    const attrs1 = manager.getUserSessionAttributes();
-    manager.endSessionPartInternal({ reason: 'web_background' });
-
-    // Advance within the inactivity timeout.
-    clock.tick(29 * 60 * 1000);
-
-    manager.startSessionPartInternal({ reason: 'init' });
-    const attrs2 = manager.getUserSessionAttributes();
-
-    // Storage is unavailable, so the in-memory session the manager already
-    // holds stays authoritative; a fresh user session is not minted per part.
-    expect(attrs2?.['emb.user_session_id']).to.equal(
-      attrs1?.['emb.user_session_id'],
-    );
-    expect(attrs2?.['emb.user_session_part_index']).to.equal(2);
-  });
-
-  it('keeps one user session across repeated parts when storage is unavailable', () => {
-    const manager = createFailingStorageManager();
-
-    manager.startSessionPartInternal({ reason: 'init' });
-    const userSessionId =
-      manager.getUserSessionAttributes()?.['emb.user_session_id'];
-
-    // Several engage/disengage cycles, each well within the inactivity
-    // timeout: one journey must stay one user session, never fragmenting into
-    // one-per-part the way it did before the in-memory fallback existed.
-    for (
-      let expectedPartIndex = 2;
-      expectedPartIndex <= 4;
-      expectedPartIndex++
-    ) {
-      manager.endSessionPartInternal({ reason: 'web_background' });
-      clock.tick(5 * 60 * 1000);
       manager.startSessionPartInternal({ reason: 'init' });
-
       const attrs = manager.getUserSessionAttributes();
-      expect(attrs?.['emb.user_session_id']).to.equal(userSessionId);
-      expect(attrs?.['emb.user_session_part_index']).to.equal(
-        expectedPartIndex,
-      );
-    }
-  });
-
-  it('mints a fresh user session when the inactivity timeout expires while storage is unavailable', () => {
-    const manager = createFailingStorageManager();
-
-    manager.startSessionPartInternal({ reason: 'init' });
-    const attrs1 = manager.getUserSessionAttributes();
-    manager.endSessionPartInternal({ reason: 'web_background' });
-
-    // Past the default 30 min inactivity timeout.
-    clock.tick(31 * 60 * 1000);
-
-    manager.startSessionPartInternal({ reason: 'init' });
-    const attrs2 = manager.getUserSessionAttributes();
-
-    // The in-memory session stays authoritative only while it is live: once
-    // its inactivity deadline passes, the next part rolls a fresh user session
-    // instead of resurrecting the expired one. The user-session number cannot
-    // advance because the shared counter also lives in unavailable storage.
-    expect(attrs2?.['emb.user_session_id']).to.not.equal(
-      attrs1?.['emb.user_session_id'],
-    );
-    expect(attrs2?.['emb.user_session_part_index']).to.equal(1);
-  });
-
-  it('mints a fresh user session when the max duration expires while storage is unavailable', () => {
-    const manager = createFailingStorageManager({
-      userSessionMaxDurationSeconds: 3600,
+      expect(attrs?.['emb.user_session_id']).to.have.lengthOf(32);
+      // Storage unavailable: getIncrementedCount falls back to 1, which is
+      // indistinguishable from a genuine first session.
+      expect(attrs?.['emb.user_session_number']).to.equal(1);
+      // NamespacedStorage flips disabled on the first failed write and emits
+      // exactly one error; later failures stay silent.
+      expect(diag.getErrorLogs()).to.have.lengthOf(1);
+      expect(diag.getErrorLogs()[0]).to.contain('writes disabled');
     });
 
-    manager.startSessionPartInternal({ reason: 'init' });
-    const attrs1 = manager.getUserSessionAttributes();
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    it('continues the same user session across parts', () => {
+      const manager = createFailingStorageManager();
 
-    // Past the 1 hour max duration. The max-duration timer lives in memory, so
-    // it rolls the user session over even though nothing was ever persisted.
-    clock.tick(3601 * 1000);
+      manager.startSessionPartInternal({ reason: 'init' });
+      const attrs1 = manager.getUserSessionAttributes();
+      manager.endSessionPartInternal({ reason: 'web_background' });
 
-    manager.startSessionPartInternal({ reason: 'init' });
-    const attrs2 = manager.getUserSessionAttributes();
+      // Advance within the inactivity timeout.
+      clock.tick(29 * 60 * 1000);
 
-    expect(attrs2?.['emb.user_session_id']).to.not.equal(
-      attrs1?.['emb.user_session_id'],
-    );
-    expect(attrs2?.['emb.user_session_part_index']).to.equal(1);
+      manager.startSessionPartInternal({ reason: 'init' });
+      const attrs2 = manager.getUserSessionAttributes();
+
+      // Storage is unavailable, so the in-memory session the manager already
+      // holds stays authoritative; a fresh user session is not minted per part.
+      expect(attrs2?.['emb.user_session_id']).to.equal(
+        attrs1?.['emb.user_session_id'],
+      );
+      expect(attrs2?.['emb.user_session_part_index']).to.equal(2);
+    });
+
+    it('keeps one user session across repeated parts', () => {
+      const manager = createFailingStorageManager();
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const userSessionId =
+        manager.getUserSessionAttributes()?.['emb.user_session_id'];
+
+      // Several engage/disengage cycles, each well within the inactivity
+      // timeout: one journey must stay one user session, never fragmenting into
+      // one-per-part the way it did before the in-memory fallback existed.
+      for (
+        let expectedPartIndex = 2;
+        expectedPartIndex <= 4;
+        expectedPartIndex++
+      ) {
+        manager.endSessionPartInternal({ reason: 'web_background' });
+        clock.tick(5 * 60 * 1000);
+        manager.startSessionPartInternal({ reason: 'init' });
+
+        const attrs = manager.getUserSessionAttributes();
+        expect(attrs?.['emb.user_session_id']).to.equal(userSessionId);
+        expect(attrs?.['emb.user_session_part_index']).to.equal(
+          expectedPartIndex,
+        );
+      }
+    });
+
+    it('mints a fresh user session when the inactivity timeout expires', () => {
+      const manager = createFailingStorageManager();
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const attrs1 = manager.getUserSessionAttributes();
+      manager.endSessionPartInternal({ reason: 'web_background' });
+
+      // Past the default 30 min inactivity timeout.
+      clock.tick(31 * 60 * 1000);
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const attrs2 = manager.getUserSessionAttributes();
+
+      // The in-memory session stays authoritative only while it is live: once
+      // its inactivity deadline passes, the next part rolls a fresh user session
+      // instead of resurrecting the expired one. The user-session number cannot
+      // advance because the shared counter also lives in unavailable storage.
+      expect(attrs2?.['emb.user_session_id']).to.not.equal(
+        attrs1?.['emb.user_session_id'],
+      );
+      expect(attrs2?.['emb.user_session_part_index']).to.equal(1);
+    });
+
+    it('mints a fresh user session when the max duration expires', () => {
+      const manager = createFailingStorageManager({
+        userSessionMaxDurationSeconds: 3600,
+      });
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const attrs1 = manager.getUserSessionAttributes();
+      manager.endSessionPartInternal({ reason: 'web_background' });
+
+      // Past the 1 hour max duration. The max-duration timer lives in memory, so
+      // it rolls the user session over even though nothing was ever persisted.
+      clock.tick(3601 * 1000);
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const attrs2 = manager.getUserSessionAttributes();
+
+      expect(attrs2?.['emb.user_session_id']).to.not.equal(
+        attrs1?.['emb.user_session_id'],
+      );
+      expect(attrs2?.['emb.user_session_part_index']).to.equal(1);
+    });
   });
 
   it('should clamp max duration to the maximum', () => {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -66,6 +66,23 @@ describe('EmbraceUserSessionManager', () => {
       dynamicConfigManager: createTestDynamicConfigManager(config),
     });
 
+  // A manager wired to storage that throws on every operation, so reads
+  // always come back empty and no write ever persists. Exercises the
+  // in-memory-authoritative path in _loadOrCreateUserSessionState.
+  const createFailingStorageManager = (config?: {
+    userSessionMaxDurationSeconds?: number;
+    userSessionInactivityTimeoutSeconds?: number;
+    userSessionForegroundInactivityTimeoutSeconds?: number;
+  }) =>
+    new EmbraceUserSessionManager({
+      diag,
+      perf: new MockPerformanceManager(clock),
+      storage: new NamespacedStorage({ storage: new FailingStorage(), diag }),
+      limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+      visibilityDoc: window.document,
+      dynamicConfigManager: createTestDynamicConfigManager(config),
+    });
+
   // Builds a manager whose getConfig() reads a live, mutable config object so a
   // test can change remote-config values mid-session. getConfig returns a fresh
   // copy each call so mutations are picked up at the next session creation.
@@ -315,14 +332,7 @@ describe('EmbraceUserSessionManager', () => {
   });
 
   it('continues the same user session across parts when storage is unavailable', () => {
-    const manager = new EmbraceUserSessionManager({
-      diag,
-      perf: new MockPerformanceManager(clock),
-      storage: new NamespacedStorage({ storage: new FailingStorage(), diag }),
-      limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
-      visibilityDoc: window.document,
-      dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
-    });
+    const manager = createFailingStorageManager();
 
     manager.startSessionPartInternal({ reason: 'init' });
     const attrs1 = manager.getUserSessionAttributes();
@@ -340,6 +350,78 @@ describe('EmbraceUserSessionManager', () => {
       attrs1?.['emb.user_session_id'],
     );
     expect(attrs2?.['emb.user_session_part_index']).to.equal(2);
+  });
+
+  it('keeps one user session across repeated parts when storage is unavailable', () => {
+    const manager = createFailingStorageManager();
+
+    manager.startSessionPartInternal({ reason: 'init' });
+    const userSessionId =
+      manager.getUserSessionAttributes()?.['emb.user_session_id'];
+
+    // Several engage/disengage cycles, each well within the inactivity
+    // timeout: one journey must stay one user session, never fragmenting into
+    // one-per-part the way it did before the in-memory fallback existed.
+    for (
+      let expectedPartIndex = 2;
+      expectedPartIndex <= 4;
+      expectedPartIndex++
+    ) {
+      manager.endSessionPartInternal({ reason: 'web_background' });
+      clock.tick(5 * 60 * 1000);
+      manager.startSessionPartInternal({ reason: 'init' });
+
+      const attrs = manager.getUserSessionAttributes();
+      expect(attrs?.['emb.user_session_id']).to.equal(userSessionId);
+      expect(attrs?.['emb.user_session_part_index']).to.equal(
+        expectedPartIndex,
+      );
+    }
+  });
+
+  it('mints a fresh user session when the inactivity timeout expires while storage is unavailable', () => {
+    const manager = createFailingStorageManager();
+
+    manager.startSessionPartInternal({ reason: 'init' });
+    const attrs1 = manager.getUserSessionAttributes();
+    manager.endSessionPartInternal({ reason: 'web_background' });
+
+    // Past the default 30 min inactivity timeout.
+    clock.tick(31 * 60 * 1000);
+
+    manager.startSessionPartInternal({ reason: 'init' });
+    const attrs2 = manager.getUserSessionAttributes();
+
+    // The in-memory session stays authoritative only while it is live: once
+    // its inactivity deadline passes, the next part rolls a fresh user session
+    // instead of resurrecting the expired one. The user-session number cannot
+    // advance because the shared counter also lives in unavailable storage.
+    expect(attrs2?.['emb.user_session_id']).to.not.equal(
+      attrs1?.['emb.user_session_id'],
+    );
+    expect(attrs2?.['emb.user_session_part_index']).to.equal(1);
+  });
+
+  it('mints a fresh user session when the max duration expires while storage is unavailable', () => {
+    const manager = createFailingStorageManager({
+      userSessionMaxDurationSeconds: 3600,
+    });
+
+    manager.startSessionPartInternal({ reason: 'init' });
+    const attrs1 = manager.getUserSessionAttributes();
+    manager.endSessionPartInternal({ reason: 'web_background' });
+
+    // Past the 1 hour max duration. The max-duration timer lives in memory, so
+    // it rolls the user session over even though nothing was ever persisted.
+    clock.tick(3601 * 1000);
+
+    manager.startSessionPartInternal({ reason: 'init' });
+    const attrs2 = manager.getUserSessionAttributes();
+
+    expect(attrs2?.['emb.user_session_id']).to.not.equal(
+      attrs1?.['emb.user_session_id'],
+    );
+    expect(attrs2?.['emb.user_session_part_index']).to.equal(1);
   });
 
   it('should clamp max duration to the maximum', () => {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -351,7 +351,7 @@ describe('EmbraceUserSessionManager', () => {
       }
     });
 
-    it('mints a fresh user session when the between-parts inactivity deadline passes', () => {
+    it('mints a fresh user session when the next part starts after the inactivity timeout', () => {
       const manager = createFailingStorageManager();
 
       manager.startSessionPartInternal({ reason: 'init' });

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -666,13 +666,8 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     created: boolean;
   } {
     let state = readUserSessionState(this._storage, this._diag);
-    // Storage read came back empty but we hold an in-memory session we never
-    // managed to persist (writes disabled). It stays authoritative, mirroring
-    // _continueUserSessionAfterPartEnd's _hasStoredState gate. Without this,
-    // every part start under a storage outage mints a fresh user session,
-    // fragmenting one journey into many. Once we have persisted (_hasStoredState),
-    // an empty read is a genuine clear (sibling tab, eviction) and falls through
-    // to creating a new user session.
+    // Never persisted (writes disabled): keep the in-memory session rather than
+    // mint a fresh one per part. After a persist, an empty read is a real clear.
     if (!state && !this._hasStoredState && this._state) {
       state = this._state;
     }

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -666,6 +666,16 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     created: boolean;
   } {
     let state = readUserSessionState(this._storage, this._diag);
+    // Storage read came back empty but we hold an in-memory session we never
+    // managed to persist (writes disabled). It stays authoritative, mirroring
+    // _continueUserSessionAfterPartEnd's _hasStoredState gate. Without this,
+    // every part start under a storage outage mints a fresh user session,
+    // fragmenting one journey into many. Once we have persisted (_hasStoredState),
+    // an empty read is a genuine clear (sibling tab, eviction) and falls through
+    // to creating a new session.
+    if (!state && !this._hasStoredState && this._state) {
+      state = this._state;
+    }
     let created = false;
     if (!state || isUserSessionExpired(state, now)) {
       if (state) {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -672,7 +672,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     // every part start under a storage outage mints a fresh user session,
     // fragmenting one journey into many. Once we have persisted (_hasStoredState),
     // an empty read is a genuine clear (sibling tab, eviction) and falls through
-    // to creating a new session.
+    // to creating a new user session.
     if (!state && !this._hasStoredState && this._state) {
       state = this._state;
     }


### PR DESCRIPTION
## What problem is this solving?

When persistent storage is unavailable (writes disabled after a quota/permission failure), every session-part start minted a fresh user session, fragmenting one user journey into many one-part user sessions.

## Short description of changes

- In `_loadOrCreateUserSessionState`, when the storage read comes back empty but no write has ever persisted (`!_hasStoredState`) and an in-memory user session is held, that in-memory session stays authoritative. This mirrors the existing `_hasStoredState` gate in `_continueUserSessionAfterPartEnd`. Once a write has persisted, an empty read is a genuine clear (sibling tab, eviction) and falls through to creating a fresh user session.
- Expiry is preserved: an expired in-memory session still rolls over (the fallback runs before the `isUserSessionExpired` check).
- New `storage unavailable` tests covering the one-time write-failure report, continuity across parts, repeated parts staying one user session, inactivity-timeout expiry detected on the next part start, the live foreground inactivity timer firing, max-duration expiry, and the post-persist storage-clear path (a genuine clear must not resurrect in-memory state).

## How has this been tested?

`npm run test` (66 pass in the affected file), `npm run lint`, and `npm run check` all green from the repo root. Confirmed the post-persist-clear test fails when the `!_hasStoredState` guard condition is dropped, so it genuinely locks down the gate.

## Checklist

- [ ] Documentation added
- [x] Tests added