### PR TITLE
EMBR-12526 chore: consolidate instrumentations tracking enable called multiple times

### DIFF
--- a/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.test.ts
+++ b/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.test.ts
@@ -1,0 +1,49 @@
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { FakeInstrumentation } from '../../../tests/utils/index.ts';
+
+chai.use(sinonChai);
+const { expect } = chai;
+
+describe('EmbraceInstrumentationBase', () => {
+  let instrumentation: FakeInstrumentation;
+  let onEnableSpy: sinon.SinonSpy;
+  let onDisableSpy: sinon.SinonSpy;
+
+  beforeEach(() => {
+    instrumentation = new FakeInstrumentation();
+    // start Instrumentation in a disabled state so assertions are consistent
+    instrumentation.disable();
+    onEnableSpy = sinon.spy(instrumentation, 'onEnable');
+    onDisableSpy = sinon.spy(instrumentation, 'onDisable');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('fires onEnable once when enabling a disabled instrumentation', () => {
+    instrumentation.enable();
+    instrumentation.enable();
+
+    expect(onEnableSpy).to.have.been.calledOnce;
+  });
+
+  it('fires onDisable once when disabling an enabled instrumentation', () => {
+    instrumentation.enable();
+    instrumentation.disable();
+    instrumentation.disable();
+
+    expect(onDisableSpy).to.have.been.calledOnce;
+  });
+
+  it('fires each hook once per state flip across a full toggle cycle', () => {
+    instrumentation.enable();
+    instrumentation.disable();
+    instrumentation.enable();
+
+    expect(onEnableSpy).to.have.been.calledTwice;
+    expect(onDisableSpy).to.have.been.calledOnce;
+  });
+});

--- a/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.ts
+++ b/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.ts
@@ -25,6 +25,7 @@ export abstract class EmbraceInstrumentationBase<
   private _logManager: LogManager;
   private readonly _perf: PerformanceManager;
   private _limitManager: LimitManagerInternal | undefined;
+  protected _isEnabled = false;
 
   protected constructor({
     instrumentationName,
@@ -89,4 +90,28 @@ export abstract class EmbraceInstrumentationBase<
   ): void {
     this._userSessionManager = userSessionManager;
   }
+
+  public override disable(): void {
+    if (!this._isEnabled) {
+      return;
+    }
+
+    this._isEnabled = false;
+    this.onDisable();
+  }
+
+  public override enable(): void {
+    if (this._isEnabled) {
+      return;
+    }
+
+    this._isEnabled = true;
+    this.onEnable();
+  }
+
+  /* Only triggered when the instrumentation transitions to disabled */
+  protected abstract onDisable(): void;
+
+  /* Only triggered when the instrumentation transitions to enabled */
+  public abstract onEnable(): void;
 }

--- a/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
@@ -77,11 +77,11 @@ export class ClicksInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  public disable(): void {
+  public override onDisable(): void {
     document.removeEventListener('click', this._onClickHandler);
   }
 
-  public enable(): void {
+  public override onEnable(): void {
     document.addEventListener('click', this._onClickHandler);
   }
 }

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -892,11 +892,11 @@ describe('DocumentLoad Instrumentation', () => {
       spyEntries.restore();
     });
 
-    it('should not collect performance twice when enable() is called multiple times', (done) => {
+    it('should not collect performance twice when disabled and re-enabled', (done) => {
       plugin = new DocumentLoadInstrumentation({ enabled: false });
 
       plugin.enable();
-      plugin.enable();
+      plugin.disable();
       plugin.enable();
 
       setTimeout(() => {

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -539,12 +539,12 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
     }
   }
 
-  public enable(): void {
+  public override onEnable(): void {
     window.removeEventListener('load', this._onDocumentLoaded);
     this._waitForPageLoad();
   }
 
-  public disable(): void {
+  public override onDisable(): void {
     window.removeEventListener('load', this._onDocumentLoaded);
   }
 }

--- a/packages/web-sdk/src/instrumentations/element-timing/ElementTimingInstrumentation/ElementTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/element-timing/ElementTimingInstrumentation/ElementTimingInstrumentation.test.ts
@@ -267,4 +267,27 @@ describe('ElementTimingInstrumentation', () => {
 
     instrumentation.disable();
   });
+
+  it('logs an error when the observer fails to construct', () => {
+    const original = globalThis.PerformanceObserver;
+    // @ts-expect-error redefinition is intentional for testing
+    globalThis.PerformanceObserver = class {
+      public static supportedEntryTypes = ['element'];
+      public constructor() {
+        throw new Error('constructor failed');
+      }
+    };
+
+    const diagLogger = new InMemoryDiagLogger();
+    const instrumentation = new ElementTimingInstrumentation({
+      perf,
+      diag: diagLogger,
+      limitManager,
+    });
+
+    expect(diagLogger.getErrorLogs()[0]).to.equal('failed to enable');
+
+    globalThis.PerformanceObserver = original;
+    instrumentation.disable();
+  });
 });

--- a/packages/web-sdk/src/instrumentations/element-timing/ElementTimingInstrumentation/ElementTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/element-timing/ElementTimingInstrumentation/ElementTimingInstrumentation.ts
@@ -21,7 +21,6 @@ import type {
 
 export class ElementTimingInstrumentation extends EmbraceInstrumentationBase {
   private _observer: PerformanceObserver | null = null;
-  private _isEnabled = false;
 
   public constructor({
     diag,
@@ -42,18 +41,15 @@ export class ElementTimingInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  public enable(): void {
-    if (this._isEnabled) {
-      return;
-    }
-
-    if (!isEntryTypeSupported('element')) {
+  public override enable(): void {
+    if (isEntryTypeSupported('element')) {
+      super.enable();
+    } else {
       this._diag.debug('element not supported, skipping');
-      return;
     }
+  }
 
-    this._isEnabled = true;
-
+  public override onEnable(): void {
     if (this._observer) {
       this._observer.disconnect();
     }
@@ -71,9 +67,7 @@ export class ElementTimingInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  public disable(): void {
-    this._isEnabled = false;
-
+  public onDisable(): void {
     if (this._observer) {
       this._observer.disconnect();
       this._observer = null;

--- a/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.ts
@@ -33,20 +33,26 @@ export class EmptyRootInstrumentation extends EmbraceInstrumentationBase {
       },
     );
 
-    if (this._config.enabled && this._rootNode) {
+    if (this._config.enabled) {
       this.enable();
-    } else if (!this._rootNode) {
+    }
+  }
+
+  public override enable(): void {
+    if (this._rootNode) {
+      super.enable();
+    } else {
       this._diag.warn(
         "supplied root node was null, this instrumentation won't be enabled",
       );
     }
   }
 
-  public disable(): void {
+  public override onDisable(): void {
     this._observer.disconnect();
   }
 
-  public enable(): void {
+  public override onEnable(): void {
     if (this._rootNode) {
       this._observer.observe(this._rootNode, { childList: true });
     }

--- a/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
@@ -35,7 +35,7 @@ export class GlobalExceptionInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  public disable(): void {
+  public onDisable(): void {
     window.removeEventListener('error', this._onErrorHandler);
     window.removeEventListener(
       'unhandledrejection',
@@ -43,7 +43,7 @@ export class GlobalExceptionInstrumentation extends EmbraceInstrumentationBase {
     );
   }
 
-  public enable(): void {
+  public onEnable(): void {
     window.addEventListener('error', this._onErrorHandler);
     window.addEventListener(
       'unhandledrejection',

--- a/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.ts
@@ -72,7 +72,7 @@ export class FirstInteractionInstrumentation extends EmbraceInstrumentationBase 
     }
   }
 
-  public enable(): void {
+  public override onEnable(): void {
     this._attachListeners();
 
     if (!this._removeSessionPartStartedFn) {
@@ -83,7 +83,7 @@ export class FirstInteractionInstrumentation extends EmbraceInstrumentationBase 
     }
   }
 
-  public disable(): void {
+  public override onDisable(): void {
     this._detachListeners();
 
     if (this._removeSessionPartStartedFn) {

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
@@ -37,7 +37,6 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
   private _observer: PerformanceObserver | null = null;
   private _isFirstEntry = true;
   private _removeSessionPartEndedListener: (() => void) | null = null;
-  private _isEnabled = false;
 
   private _totalDuration = 0;
   private _workDuration = 0;
@@ -62,18 +61,15 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  public enable(): void {
-    if (this._isEnabled) {
-      return;
-    }
-
-    if (!isEntryTypeSupported('long-animation-frame')) {
+  public override enable(): void {
+    if (isEntryTypeSupported('long-animation-frame')) {
+      super.enable();
+    } else {
       this._diag.debug('long-animation-frame not supported, skipping');
-      return;
     }
+  }
 
-    this._isEnabled = true;
-
+  public onEnable(): void {
     if (this._observer) {
       this._observer.disconnect();
     }
@@ -120,8 +116,7 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
     this._registerSessionPartEndedListener();
   }
 
-  public disable(): void {
-    this._isEnabled = false;
+  public onDisable(): void {
     this._resetAccumulators();
 
     if (this._observer) {

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
@@ -137,7 +137,7 @@ export class NavigationInstrumentation extends EmbraceInstrumentationBase {
     }
   };
 
-  public enable = () => {
+  public override onEnable = () => {
     this.setConfig({
       enabled: true,
     });
@@ -146,7 +146,7 @@ export class NavigationInstrumentation extends EmbraceInstrumentationBase {
     );
   };
 
-  public disable = () => {
+  public override onDisable = () => {
     this._cleanUpSessionPartListeners();
     this.setConfig({
       enabled: false,

--- a/packages/web-sdk/src/instrumentations/rage-click/RageClickInstrumentation/RageClickInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/rage-click/RageClickInstrumentation/RageClickInstrumentation.ts
@@ -61,12 +61,12 @@ export class RageClickInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  public disable(): void {
+  public override onDisable(): void {
     document.removeEventListener('click', this._onClickHandler);
     this._flush();
   }
 
-  public enable(): void {
+  public override onEnable(): void {
     document.addEventListener('click', this._onClickHandler);
   }
 

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
@@ -237,7 +237,7 @@ describe('ServerTimingInstrumentation', () => {
   });
 
   describe('duplicate collection guard', () => {
-    it('does not emit logs a second time when enable() is called again', () => {
+    it('does not emit logs a second time when disabled and re-enabled', () => {
       getEntriesByTypeStub
         .withArgs('navigation')
         .returns([makeNavigationEntry([makeServerTimingEntry()])]);
@@ -249,6 +249,7 @@ describe('ServerTimingInstrumentation', () => {
 
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(1);
 
+      instrumentation.disable();
       instrumentation.enable();
 
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(1);

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
@@ -36,7 +36,7 @@ export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  public enable(): void {
+  public override onEnable(): void {
     window.removeEventListener('load', this._onLoad);
 
     if (window.document.readyState === 'complete') {
@@ -47,7 +47,7 @@ export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
     window.addEventListener('load', this._onLoad);
   }
 
-  public disable(): void {
+  public override onDisable(): void {
     window.removeEventListener('load', this._onLoad);
   }
 

--- a/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.ts
@@ -24,7 +24,6 @@ export class UserTimingInstrumentation extends EmbraceInstrumentationBase {
   private _markObserver: PerformanceObserver | null = null;
   private _measureObserver: PerformanceObserver | null = null;
   private _seenEntries: Set<string> = new Set();
-  private _isEnabled = false;
   private readonly _allowedEntries: UserTimingEntryFilter | undefined;
 
   public constructor({
@@ -48,12 +47,7 @@ export class UserTimingInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  public enable(): void {
-    if (this._isEnabled) {
-      return;
-    }
-
-    this._isEnabled = true;
+  public override onEnable(): void {
     this._seenEntries = new Set();
 
     if (this._markObserver) {
@@ -88,9 +82,7 @@ export class UserTimingInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  public disable(): void {
-    this._isEnabled = false;
-
+  public onDisable(): void {
     if (this._markObserver) {
       this._markObserver.disconnect();
       this._markObserver = null;

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -1297,6 +1297,22 @@ describe('WebVitalsInstrumentation', () => {
     expect(memoryExporter.getFinishedLogRecords()).to.have.lengthOf(1);
   });
 
+  it('logs a debug message when re-enabling already-registered listeners', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    instrumentation.disable();
+    instrumentation.enable();
+
+    expect(diag.getDebugLogs()).to.include(
+      'WebVitalsInstrumentation listeners already registered, resuming emission',
+    );
+  });
+
   it('should log debug message when disable() is called', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -1231,21 +1231,6 @@ describe('WebVitalsInstrumentation', () => {
     expect(clsStub.callCount).to.equal(1);
   });
 
-  it('should log debug message when enable() is called on already registered listeners', () => {
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      listeners: mockWebVitalListeners,
-      urlAttribution: false,
-    });
-
-    instrumentation.enable();
-
-    expect(diag.getDebugLogs()).to.include(
-      'WebVitalsInstrumentation listeners already registered, resuming emission',
-    );
-  });
-
   it('should pause emission when disable() is called', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -1231,6 +1231,22 @@ describe('WebVitalsInstrumentation', () => {
     expect(clsStub.callCount).to.equal(1);
   });
 
+  it('should log debug message when enable() is called on already registered listeners', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    instrumentation.disable();
+    instrumentation.enable();
+
+    expect(diag.getDebugLogs()).to.include(
+      'WebVitalsInstrumentation listeners already registered, resuming emission',
+    );
+  });
+
   it('should pause emission when disable() is called', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,
@@ -1295,22 +1311,6 @@ describe('WebVitalsInstrumentation', () => {
     } as MetricWithAttribution);
 
     expect(memoryExporter.getFinishedLogRecords()).to.have.lengthOf(1);
-  });
-
-  it('logs a debug message when re-enabling already-registered listeners', () => {
-    instrumentation = new WebVitalsInstrumentation({
-      diag,
-      perf,
-      listeners: mockWebVitalListeners,
-      urlAttribution: false,
-    });
-
-    instrumentation.disable();
-    instrumentation.enable();
-
-    expect(diag.getDebugLogs()).to.include(
-      'WebVitalsInstrumentation listeners already registered, resuming emission',
-    );
   });
 
   it('should log debug message when disable() is called', () => {

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -208,7 +208,6 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
   private _largestShiftTargetForCLS: string | undefined | null = null;
   private _applyCustomLogRecordData?: (logRecord: LogRecord) => void;
   private _listenersRegistered = false;
-  private _isEnabled = false;
 
   public constructor({
     diag,
@@ -240,23 +239,23 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  public override disable(): void {
+  public override onDisable(): void {
     // web-vitals library doesn't support removing listeners, so we just pause emission
     // https://github.com/GoogleChrome/web-vitals/issues/357#issuecomment-1593439036
-    this._isEnabled = false;
     this._diag.debug('WebVitalsInstrumentation disabled, pausing emission');
   }
 
   public override enable(): void {
-    if (typeof PerformanceObserver === 'undefined') {
+    if (typeof PerformanceObserver !== 'undefined') {
+      super.enable();
+    } else {
       this._diag.debug(
         'PerformanceObserver not supported, web vitals will not be collected',
       );
-      return;
     }
+  }
 
-    this._isEnabled = true;
-
+  public override onEnable(): void {
     // web-vitals library doesn't support removing listeners, so only register once
     if (this._listenersRegistered) {
       this._diag.debug(

--- a/packages/web-sdk/tests/utils/FakeInstrumentation.ts
+++ b/packages/web-sdk/tests/utils/FakeInstrumentation.ts
@@ -1,8 +1,6 @@
 import { EmbraceInstrumentationBase } from '../../src/instrumentations/index.ts';
 
 export class FakeInstrumentation extends EmbraceInstrumentationBase {
-  private _enabled = false;
-
   public constructor() {
     super({
       instrumentationName: 'FakeInstrumentation',
@@ -15,16 +13,16 @@ export class FakeInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  public disable(): void {
-    this._enabled = false;
+  public override onDisable(): void {
+    // no-op
   }
 
-  public enable(): void {
-    this._enabled = true;
+  public override onEnable(): void {
+    // no-op
   }
 
   public emit(): void {
-    if (this._enabled) {
+    if (this._isEnabled) {
       this.logger.emit({
         body: 'my log',
       });


### PR DESCRIPTION
Pulling out this piece out of the refactor from https://github.com/embrace-io/embrace-web-sdk/commit/bce10973dae68a65eb153f07e52e6deb1b54e4e1

Various instrumentations were tracking whether `enable` had been called more than once, moving this variable to the base class and then splitting out `enable`/`disable` (the public methods that are called directly potentially multiple times) from `onEnable`/`onDisable` (the protected methods that only trigger on the instrumentation actually becoming enabled or disabled)