### PR TITLE
chore: relax codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
 coverage:
   status:
-    project: true
+    project:
+      default:
+        target: auto
+        threshold: 0.5%


### PR DESCRIPTION
This came out of https://github.com/embrace-io/embrace-web-sdk/pull/1390, I found myself re-enabling + adding a test case to satisfy the code cov check which I think ultimately would have been okay to leave off but were needed to avoid dropping the coverage. Curious if anyone else has hit this and if we'd be okay allowing a small fractional coverage drop to avoid noise from these types of refactors