### PR TITLE
EMBR-12558 feat: roll over session part on soft navigation

### DIFF
--- a/packages/web-sdk/scripts/validate.ts
+++ b/packages/web-sdk/scripts/validate.ts
@@ -18,7 +18,7 @@ import zlib from 'node:zlib';
 import { COLORS, log, logSection } from '../../../scripts/build-config.ts';
 
 // Maximum bundle size (gzipped) — triggers hard failure to catch bloat/duplication early
-const MAX_BUNDLE_SIZE_KB = 55;
+const MAX_BUNDLE_SIZE_KB = 56;
 
 const BUNDLE_FILE = 'embrace-web-sdk.js';
 const BUNDLE_MAP_FILE = 'embrace-web-sdk.js.map';

--- a/packages/web-sdk/src/api-sessions/manager/types.ts
+++ b/packages/web-sdk/src/api-sessions/manager/types.ts
@@ -126,7 +126,7 @@ export type StartSessionOptions = {
 // `UserSessionEndReason`) are emitted unprefixed so the backend can correlate
 // them across platforms. Reasons that describe behaviour specific to the web
 // environment (`web_foreground`, `web_background`, `web_activity`,
-// `web_foreground_inactivity`, `web_soft_nav`) are stamped with a `web_`
+// `web_foreground_inactivity`, `web_soft_navigation`) are stamped with a `web_`
 // prefix. The part-level
 // `web_foreground_inactivity` and the user-session-level `inactivity` are distinct: when
 // the part-inactivity timer fires it stamps `web_foreground_inactivity` as the part end
@@ -137,13 +137,13 @@ export type SessionPartStartReason =
   | 'init' // first part on SDK init (page load); covers the hard-nav load side
   | 'web_foreground' // tab became engaged via visibilitychange (visible) or focus while no part was active
   | 'web_activity' // user input resumed after an inactivity-killed part
-  | 'web_soft_nav' // soft navigation started the next part in the same user session
+  | 'web_soft_navigation' // soft navigation started the next part in the same user session
   | 'user_session_rollover'; // synchronous user-session rollover forced a new part (endUserSession API / max-duration timer)
 
 export type SessionPartEndReason =
   | 'web_background' // tab disengaged via visibilitychange (hidden) or blur. Also covers hard-nav unload and BFCache freeze (pagehide is not listened to)
   | 'web_foreground_inactivity' // no keyboard/mouse/scroll input during the active part for the configured inactivity window; also ends the enclosing user session, with the part span end timestamp anchored to the last activity
-  | 'web_soft_nav' // rolled the part over on a soft navigation. Not final, the user session continues
+  | 'web_soft_navigation' // rolled the part over on a soft navigation. Not final, the user session continues
   | 'user_session_ended'; // closed because the enclosing user session ended (manual endUserSession, max-duration); stamped on the span by the manager
 
 export type UserSessionEndReason =

--- a/packages/web-sdk/src/api-sessions/manager/types.ts
+++ b/packages/web-sdk/src/api-sessions/manager/types.ts
@@ -125,7 +125,7 @@ export type StartSessionOptions = {
 // `user_session_ended`, and the user-session-level `inactivity` on
 // `UserSessionEndReason`) are emitted unprefixed so the backend can correlate
 // them across platforms. Reasons that describe behaviour specific to the web
-// environment (`web_foreground`, `web_background`, `web_activity`,
+// environment (`foreground`, `background`, `web_activity`,
 // `web_foreground_inactivity`, `web_soft_navigation`) are stamped with a `web_`
 // prefix. The part-level
 // `web_foreground_inactivity` and the user-session-level `inactivity` are distinct: when
@@ -135,13 +135,13 @@ export type StartSessionOptions = {
 
 export type SessionPartStartReason =
   | 'init' // first part on SDK init (page load); covers the hard-nav load side
-  | 'web_foreground' // tab became engaged via visibilitychange (visible) or focus while no part was active
+  | 'foreground' // tab became engaged via visibilitychange (visible) or focus while no part was active
   | 'web_activity' // user input resumed after an inactivity-killed part
   | 'web_soft_navigation' // soft navigation started the next part in the same user session
   | 'user_session_rollover'; // synchronous user-session rollover forced a new part (endUserSession API / max-duration timer)
 
 export type SessionPartEndReason =
-  | 'web_background' // tab disengaged via visibilitychange (hidden) or blur. Also covers hard-nav unload and BFCache freeze (pagehide is not listened to)
+  | 'background' // tab disengaged via visibilitychange (hidden) or blur. Also covers hard-nav unload and BFCache freeze (pagehide is not listened to)
   | 'web_foreground_inactivity' // no keyboard/mouse/scroll input during the active part for the configured inactivity window; also ends the enclosing user session, with the part span end timestamp anchored to the last activity
   | 'web_soft_navigation' // rolled the part over on a soft navigation. Not final, the user session continues
   | 'user_session_ended'; // closed because the enclosing user session ended (manual endUserSession, max-duration); stamped on the span by the manager

--- a/packages/web-sdk/src/common/index.ts
+++ b/packages/web-sdk/src/common/index.ts
@@ -1,10 +1,8 @@
 export { attributes } from './attributes.ts';
 export type {
   AttributeScrubber,
-  Navigation,
   NavigationHost,
   PathnameDocument,
-  SoftNavigationEvent,
   TitleDocument,
   URLDocument,
   VisibilityStateDocument,

--- a/packages/web-sdk/src/common/index.ts
+++ b/packages/web-sdk/src/common/index.ts
@@ -1,8 +1,10 @@
 export { attributes } from './attributes.ts';
 export type {
   AttributeScrubber,
+  Navigation,
   NavigationHost,
   PathnameDocument,
+  SoftNavigationEvent,
   TitleDocument,
   URLDocument,
   VisibilityStateDocument,

--- a/packages/web-sdk/src/common/index.ts
+++ b/packages/web-sdk/src/common/index.ts
@@ -1,6 +1,7 @@
 export { attributes } from './attributes.ts';
 export type {
   AttributeScrubber,
+  NavigationHost,
   PathnameDocument,
   TitleDocument,
   URLDocument,

--- a/packages/web-sdk/src/common/types.ts
+++ b/packages/web-sdk/src/common/types.ts
@@ -19,9 +19,28 @@ export interface VisibilityStateDocument {
   ) => void;
 }
 
+// Minimal shape of NavigationCurrentEntryChangeEvent (Navigation API, not yet in TypeScript's DOM lib).
+// `from` is optional so test fakes that dispatch a plain Event remain valid.
+export interface SoftNavigationEvent extends Event {
+  readonly from: { url: string };
+}
+
+// Minimal shape of window.navigation (Navigation API, not yet in TypeScript's DOM lib).
+export interface Navigation {
+  addEventListener(
+    type: 'currententrychange',
+    listener: (event: SoftNavigationEvent) => void,
+  ): void;
+  removeEventListener(
+    type: 'currententrychange',
+    listener: (event: SoftNavigationEvent) => void,
+  ): void;
+}
+
 // Useful for testing so that we can pass in a window-like object for soft-navigation detection
 export interface NavigationHost {
-  navigation?: EventTarget;
+  navigation?: Navigation;
+  location: { href: string };
 }
 
 // Useful for testing so that we can pass in a document-like object and change its URL

--- a/packages/web-sdk/src/common/types.ts
+++ b/packages/web-sdk/src/common/types.ts
@@ -19,6 +19,11 @@ export interface VisibilityStateDocument {
   ) => void;
 }
 
+// Useful for testing so that we can pass in a window-like object for soft-navigation detection
+export interface NavigationHost {
+  navigation?: EventTarget;
+}
+
 // Useful for testing so that we can pass in a document-like object and change its URL
 export interface URLDocument {
   URL: string;

--- a/packages/web-sdk/src/common/types.ts
+++ b/packages/web-sdk/src/common/types.ts
@@ -19,24 +19,6 @@ export interface VisibilityStateDocument {
   ) => void;
 }
 
-// Minimal shape of NavigationCurrentEntryChangeEvent (Navigation API, not yet in TypeScript's DOM lib).
-// `from` is optional so test fakes that dispatch a plain Event remain valid.
-export interface SoftNavigationEvent extends Event {
-  readonly from: { url: string };
-}
-
-// Minimal shape of window.navigation (Navigation API, not yet in TypeScript's DOM lib).
-export interface Navigation {
-  addEventListener(
-    type: 'currententrychange',
-    listener: (event: SoftNavigationEvent) => void,
-  ): void;
-  removeEventListener(
-    type: 'currententrychange',
-    listener: (event: SoftNavigationEvent) => void,
-  ): void;
-}
-
 // Useful for testing so that we can pass in a window-like object for soft-navigation detection
 export interface NavigationHost {
   navigation?: Navigation;

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -547,13 +547,16 @@ describe('EmbraceUserSessionManager browser activity', () => {
       softNavManager._shutdown();
     });
 
-    it('rolls over the part with web_soft_nav reasons when a navigation fires while a part is active', () => {
+    it('rolls over the part with web_soft_navigation reasons when a navigation fires while a part is active', () => {
       softNavManager.startSessionPartInternal({ reason: 'init' });
 
       fireCurrentEntryChange();
 
-      expect(softNavEndReasons()).to.deep.equal(['web_soft_nav']);
-      expect(softNavStartReasons()).to.deep.equal(['init', 'web_soft_nav']);
+      expect(softNavEndReasons()).to.deep.equal(['web_soft_navigation']);
+      expect(softNavStartReasons()).to.deep.equal([
+        'init',
+        'web_soft_navigation',
+      ]);
       void expect(softNavManager.getSessionPartId()).to.not.be.null;
     });
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -12,6 +12,7 @@ import type {
   SessionPartEndReason,
   SessionPartStartReason,
 } from '../../api-sessions/index.ts';
+import type { Navigation, SoftNavigationEvent } from '../../common/index.ts';
 import {
   DEFAULT_LIMITS,
   EmbraceLimitManager,
@@ -53,6 +54,40 @@ class FakeTarget implements EventTarget {
 
   public listenerCount(type: string): number {
     return this._listeners.get(type)?.size ?? 0;
+  }
+}
+
+class FakeNavigation implements Navigation {
+  private readonly _listeners: Array<(event: SoftNavigationEvent) => void> = [];
+
+  public addEventListener(
+    _type: 'currententrychange',
+    listener: (event: SoftNavigationEvent) => void,
+  ): void {
+    this._listeners.push(listener);
+  }
+
+  public removeEventListener(
+    _type: 'currententrychange',
+    listener: (event: SoftNavigationEvent) => void,
+  ): void {
+    const i = this._listeners.indexOf(listener);
+    if (i !== -1) {
+      this._listeners.splice(i, 1);
+    }
+  }
+
+  public fire(from: string): void {
+    const event = Object.assign(new Event('currententrychange'), {
+      from: { url: from },
+    });
+    for (const listener of [...this._listeners]) {
+      listener(event);
+    }
+  }
+
+  public listenerCount(): number {
+    return this._listeners.length;
   }
 }
 
@@ -468,7 +503,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
   });
 
   describe('soft navigation (currententrychange)', () => {
-    let navigationTarget: FakeTarget;
+    let navigationTarget: FakeNavigation;
     let softNavManager: EmbraceUserSessionManager;
     let softNavStartSpy: sinon.SinonSpy<
       [options: StartSessionPartOptions],
@@ -484,11 +519,11 @@ describe('EmbraceUserSessionManager browser activity', () => {
         .map((c) => (c.args[0] as EndSessionPartOptions).reason);
 
     const fireCurrentEntryChange = () => {
-      navigationTarget.dispatchEvent(new Event('currententrychange'));
+      navigationTarget.fire('http://previous.example.com/');
     };
 
     beforeEach(() => {
-      navigationTarget = new FakeTarget();
+      navigationTarget = new FakeNavigation();
       softNavManager = new EmbraceUserSessionManager({
         limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
         perf: new MockPerformanceManager(clock),
@@ -497,7 +532,10 @@ describe('EmbraceUserSessionManager browser activity', () => {
         target,
         activityThrottleMs: THROTTLE_MS,
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
-        navigationHost: { navigation: navigationTarget },
+        navigationHost: {
+          navigation: navigationTarget,
+          location: { href: 'http://current.example.com/' },
+        },
       });
       softNavManager.setTracerProvider(new WebTracerProvider());
       softNavStartSpy = sinon.spy(softNavManager, 'startSessionPartInternal');
@@ -516,6 +554,15 @@ describe('EmbraceUserSessionManager browser activity', () => {
       expect(softNavEndReasons()).to.deep.equal(['web_soft_nav']);
       expect(softNavStartReasons()).to.deep.equal(['init', 'web_soft_nav']);
       void expect(softNavManager.getSessionPartId()).to.not.be.null;
+    });
+
+    it('is a no-op when navigating to the same URL', () => {
+      softNavManager.startSessionPartInternal({ reason: 'init' });
+
+      navigationTarget.fire('http://current.example.com/');
+
+      expect(softNavEndReasons()).to.deep.equal([]);
+      expect(softNavStartReasons()).to.deep.equal(['init']);
     });
 
     it('is a no-op when a navigation fires with no active part', () => {
@@ -546,7 +593,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
         target,
         activityThrottleMs: THROTTLE_MS,
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
-        navigationHost: {},
+        navigationHost: { location: { href: 'http://current.example.com/' } },
       });
       expect(() => {
         noNavManager.setTracerProvider(new WebTracerProvider());

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -12,7 +12,6 @@ import type {
   SessionPartEndReason,
   SessionPartStartReason,
 } from '../../api-sessions/index.ts';
-import type { Navigation, SoftNavigationEvent } from '../../common/index.ts';
 import {
   DEFAULT_LIMITS,
   EmbraceLimitManager,
@@ -57,19 +56,21 @@ class FakeTarget implements EventTarget {
   }
 }
 
-class FakeNavigation implements Navigation {
-  private readonly _listeners: Array<(event: SoftNavigationEvent) => void> = [];
+class FakeNavigation {
+  private readonly _listeners: Array<
+    (event: NavigationCurrentEntryChangeEvent) => void
+  > = [];
 
   public addEventListener(
     _type: 'currententrychange',
-    listener: (event: SoftNavigationEvent) => void,
+    listener: (event: NavigationCurrentEntryChangeEvent) => void,
   ): void {
     this._listeners.push(listener);
   }
 
   public removeEventListener(
     _type: 'currententrychange',
-    listener: (event: SoftNavigationEvent) => void,
+    listener: (event: NavigationCurrentEntryChangeEvent) => void,
   ): void {
     const i = this._listeners.indexOf(listener);
     if (i !== -1) {
@@ -80,7 +81,7 @@ class FakeNavigation implements Navigation {
   public fire(from: string): void {
     const event = Object.assign(new Event('currententrychange'), {
       from: { url: from },
-    });
+    }) as NavigationCurrentEntryChangeEvent;
     for (const listener of [...this._listeners]) {
       listener(event);
     }
@@ -533,7 +534,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
         activityThrottleMs: THROTTLE_MS,
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
         navigationHost: {
-          navigation: navigationTarget,
+          navigation: navigationTarget as unknown as Navigation,
           location: { href: 'http://current.example.com/' },
         },
       });

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -466,4 +466,93 @@ describe('EmbraceUserSessionManager browser activity', () => {
     clock.tick(FOREGROUND_INACTIVITY_MS * 2);
     expect(endSpy.callCount).to.equal(endCallsBefore);
   });
+
+  describe('soft navigation (currententrychange)', () => {
+    let navigationTarget: FakeTarget;
+    let softNavManager: EmbraceUserSessionManager;
+    let softNavStartSpy: sinon.SinonSpy<
+      [options: StartSessionPartOptions],
+      void
+    >;
+    let softNavEndSpy: sinon.SinonSpy;
+
+    const softNavStartReasons = (): SessionPartStartReason[] =>
+      softNavStartSpy.getCalls().map((c) => c.args[0].reason);
+    const softNavEndReasons = (): SessionPartEndReason[] =>
+      softNavEndSpy
+        .getCalls()
+        .map((c) => (c.args[0] as EndSessionPartOptions).reason);
+
+    const fireCurrentEntryChange = () => {
+      navigationTarget.dispatchEvent(new Event('currententrychange'));
+    };
+
+    beforeEach(() => {
+      navigationTarget = new FakeTarget();
+      softNavManager = new EmbraceUserSessionManager({
+        limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+        perf: new MockPerformanceManager(clock),
+        storage: setupTestStorage(),
+        visibilityDoc,
+        target,
+        activityThrottleMs: THROTTLE_MS,
+        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
+        navigationHost: { navigation: navigationTarget },
+      });
+      softNavManager.setTracerProvider(new WebTracerProvider());
+      softNavStartSpy = sinon.spy(softNavManager, 'startSessionPartInternal');
+      softNavEndSpy = sinon.spy(softNavManager, 'endSessionPartInternal');
+    });
+
+    afterEach(() => {
+      softNavManager._shutdown();
+    });
+
+    it('rolls over the part with web_soft_nav reasons when a navigation fires while a part is active', () => {
+      softNavManager.startSessionPartInternal({ reason: 'init' });
+
+      fireCurrentEntryChange();
+
+      expect(softNavEndReasons()).to.deep.equal(['web_soft_nav']);
+      expect(softNavStartReasons()).to.deep.equal(['init', 'web_soft_nav']);
+      void expect(softNavManager.getSessionPartId()).to.not.be.null;
+    });
+
+    it('is a no-op when a navigation fires with no active part', () => {
+      fireCurrentEntryChange();
+
+      expect(softNavEndReasons()).to.deep.equal([]);
+      expect(softNavStartReasons()).to.deep.equal([]);
+    });
+
+    it('removes the currententrychange listener on shutdown', () => {
+      softNavManager.startSessionPartInternal({ reason: 'init' });
+      softNavManager._shutdown();
+      softNavStartSpy.resetHistory();
+      softNavEndSpy.resetHistory();
+
+      fireCurrentEntryChange();
+
+      expect(softNavEndReasons()).to.deep.equal([]);
+      expect(softNavStartReasons()).to.deep.equal([]);
+    });
+
+    it('handles absent navigation gracefully (old browser)', () => {
+      const noNavManager = new EmbraceUserSessionManager({
+        limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+        perf: new MockPerformanceManager(clock),
+        storage: setupTestStorage(),
+        visibilityDoc,
+        target,
+        activityThrottleMs: THROTTLE_MS,
+        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
+        navigationHost: {},
+      });
+      expect(() => {
+        noNavManager.setTracerProvider(new WebTracerProvider());
+        noNavManager.startSessionPartInternal({ reason: 'init' });
+        noNavManager._shutdown();
+      }).to.not.throw();
+    });
+  });
 });

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartActivity.test.ts
@@ -281,7 +281,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
 
     fireVisibilityChange('hidden');
 
-    expect(endReasons()).to.deep.equal(['web_background']);
+    expect(endReasons()).to.deep.equal(['background']);
     void expect(manager.getSessionPartId()).to.be.null;
   });
 
@@ -300,7 +300,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
 
     fireVisibilityChange('visible');
 
-    expect(startReasons()).to.deep.equal(['init', 'web_foreground']);
+    expect(startReasons()).to.deep.equal(['init', 'foreground']);
     void expect(manager.getSessionPartId()).to.not.be.null;
   });
 
@@ -330,7 +330,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
 
     fireBlur();
 
-    expect(endReasons()).to.deep.equal(['web_background']);
+    expect(endReasons()).to.deep.equal(['background']);
     void expect(manager.getSessionPartId()).to.be.null;
   });
 
@@ -342,7 +342,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
 
     fireFocus();
 
-    expect(startReasons()).to.deep.equal(['init', 'web_foreground']);
+    expect(startReasons()).to.deep.equal(['init', 'foreground']);
     void expect(manager.getSessionPartId()).to.not.be.null;
   });
 
@@ -363,12 +363,12 @@ describe('EmbraceUserSessionManager browser activity', () => {
   // intermediate state transitions, pinning down which listener "wins"
   // in production.
 
-  it('ends the active part exactly once as web_background on a real active-tab unload sequence', () => {
+  it('ends the active part exactly once as background on a real active-tab unload sequence', () => {
     manager.startSessionPartInternal({ reason: 'init' });
 
     fireFocusShiftingUnload();
 
-    expect(endReasons()).to.deep.equal(['web_background']);
+    expect(endReasons()).to.deep.equal(['background']);
     expect(endSpy.callCount).to.equal(1);
     void expect(manager.getSessionPartId()).to.be.null;
   });
@@ -378,12 +378,12 @@ describe('EmbraceUserSessionManager browser activity', () => {
 
     fireTabHidden();
 
-    expect(endReasons()).to.deep.equal(['web_background']);
+    expect(endReasons()).to.deep.equal(['background']);
     expect(endSpy.callCount).to.equal(1);
     void expect(manager.getSessionPartId()).to.be.null;
   });
 
-  it('starts the new part exactly once as web_foreground on a real BFCache restore sequence', () => {
+  it('starts the new part exactly once as foreground on a real BFCache restore sequence', () => {
     manager.startSessionPartInternal({ reason: 'init' });
     fireTabHidden();
     startSpy.resetHistory();
@@ -391,7 +391,7 @@ describe('EmbraceUserSessionManager browser activity', () => {
 
     fireBfcacheRestore();
 
-    expect(startReasons()).to.deep.equal(['web_foreground']);
+    expect(startReasons()).to.deep.equal(['foreground']);
     expect(startSpy.callCount).to.equal(1);
     void expect(manager.getSessionPartId()).to.not.be.null;
   });
@@ -402,8 +402,8 @@ describe('EmbraceUserSessionManager browser activity', () => {
     fireFocusShiftingUnload();
     fireBfcacheRestore();
 
-    expect(endReasons()).to.deep.equal(['web_background']);
-    expect(startReasons()).to.deep.equal(['init', 'web_foreground']);
+    expect(endReasons()).to.deep.equal(['background']);
+    expect(startReasons()).to.deep.equal(['init', 'foreground']);
     expect(endSpy.callCount).to.equal(1);
     expect(startSpy.callCount).to.equal(2);
     void expect(manager.getSessionPartId()).to.not.be.null;

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceSessionPartLifecycle.test.ts
@@ -104,7 +104,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     void expect(manager.getSessionPartSpan()).to.not.be.null;
     const sessionPartId = manager.getSessionPartId();
     void expect(sessionPartId).to.not.be.null;
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
     void expect(manager.getSessionPartSpan()).to.be.null;
     void expect(manager.getSessionPartId()).to.be.null;
     const finishedSpans = memoryExporter.getFinishedSpans();
@@ -112,7 +112,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     const sessionPartSpan = finishedSpans[0];
     expect(sessionPartSpan.attributes).to.have.property(
       'emb.session_part_end_reason',
-      'web_background',
+      'background',
     );
     expect(sessionPartSpan.attributes).to.have.property(
       'emb.session_part_id',
@@ -130,15 +130,15 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     // produce the same values and the assertions would pass vacuously.
     clock.tick(250);
     manager.endSessionPartInternal({
-      reason: 'web_background',
+      reason: 'background',
       timestamp: boundaryTimestamp,
     });
     manager.startSessionPartInternal({
-      reason: 'web_foreground',
+      reason: 'foreground',
       timestamp: boundaryTimestamp,
     });
     clock.tick(1000);
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(2);
@@ -169,7 +169,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     });
     manager.endUserSession();
     removeListener();
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(2);
@@ -200,7 +200,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   });
 
   it('should not end a session if there is no active session', () => {
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(0);
     expect(diag.getDebugLogs()).to.have.lengthOf(1);
@@ -224,7 +224,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     void expect(manager.getSessionPartId()).to.not.be.null;
 
     manager.addBreadcrumb('some breadcrumb');
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -245,7 +245,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     // on the part span when it starts.
     manager.addProperty('queued-property', 'queued-value');
     manager.startSessionPartInternal({ reason: 'init' });
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -260,7 +260,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
     manager.addProperty('custom-property-1', 'custom value1');
     manager.addProperty('custom-property-2', 'custom value2');
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -276,7 +276,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     );
     expect(sessionPartSpan.attributes).to.have.property(
       'emb.session_part_end_reason',
-      'web_background',
+      'background',
     );
     expect(sessionPartSpan.attributes).to.have.property(
       'emb.type',
@@ -297,7 +297,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
     localManager.startSessionPartInternal({ reason: 'init' });
-    localManager.endSessionPartInternal({ reason: 'web_background' });
+    localManager.endSessionPartInternal({ reason: 'background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -388,14 +388,14 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
     localManager.startSessionPartInternal({ reason: 'init' });
     let sessionPartId = localManager.getSessionPartId();
-    localManager.endSessionPartInternal({ reason: 'web_background' });
+    localManager.endSessionPartInternal({ reason: 'background' });
 
     void expect(listenerSessionPartId).to.be.eq(sessionPartId);
 
     removeListener();
     localManager.startSessionPartInternal({ reason: 'init' });
     sessionPartId = localManager.getSessionPartId();
-    localManager.endSessionPartInternal({ reason: 'web_background' });
+    localManager.endSessionPartInternal({ reason: 'background' });
 
     void expect(listenerSessionPartId).not.to.be.eq(sessionPartId);
   });
@@ -407,7 +407,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       manager.addBreadcrumb('this is a breadcrumb');
     }
 
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionPartSpan = finishedSpans[0];
@@ -437,7 +437,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     memoryExporter.reset();
     manager.startSessionPartInternal({ reason: 'init' });
     manager.addBreadcrumb('this is a breadcrumb');
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
     const nextSessionFinishedSpans = memoryExporter.getFinishedSpans();
     expect(nextSessionFinishedSpans).to.have.lengthOf(1);
     const nextSessionPartSpan = nextSessionFinishedSpans[0];
@@ -457,7 +457,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       'this is a breadcrumb which has a name longer than the allowed maximum length',
     );
 
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionPartSpan = finishedSpans[0];
@@ -492,7 +492,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       manager.addProperty(`property${i.toString()}`, i.toString());
     }
 
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionPartSpan = finishedSpans[0];
@@ -527,7 +527,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     memoryExporter.reset();
     manager.startSessionPartInternal({ reason: 'init' });
     manager.addProperty('my-new-prop', 'new');
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
     const nextSessionFinishedSpans = memoryExporter.getFinishedSpans();
     expect(nextSessionFinishedSpans).to.have.lengthOf(1);
     const nextSessionPartSpan = nextSessionFinishedSpans[0];
@@ -546,7 +546,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       'session property long value with extra information',
     );
 
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
     const sessionPartSpan = finishedSpans[0];
@@ -600,7 +600,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       value,
     );
 
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     // Survives across user-session boundaries.
     expect(blob('embrace_permanent_properties')).to.have.property(
@@ -640,7 +640,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
     manager.startSessionPartInternal({ reason: 'init' });
     manager.addProperty(propertyKey, value);
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     const secondManager = new EmbraceUserSessionManager({
       diag,
@@ -651,7 +651,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
     });
     secondManager.startSessionPartInternal({ reason: 'init' });
-    secondManager.endSessionPartInternal({ reason: 'web_background' });
+    secondManager.endSessionPartInternal({ reason: 'background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(2);
@@ -752,12 +752,12 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       lifespan: 'permanent',
     });
     expect(blob()).to.have.property(propertyKey, value);
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     manager.startSessionPartInternal({ reason: 'init' });
     manager.removeProperty(propertyKey);
     void expect(blob()[propertyKey]).to.be.undefined;
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     void expect(blob()[propertyKey]).to.be.undefined;
   });
@@ -778,7 +778,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     manager.addProperty(permanentPropertyKey, permanentValue, {
       lifespan: 'permanent',
     });
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     manager.startSessionPartInternal({ reason: 'init' });
     expect(manager.getSessionPartProperties()).to.have.property(
@@ -825,11 +825,11 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     manager.addProperty(propertyKey, value, {
       lifespan: 'permanent',
     });
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     manager.startSessionPartInternal({ reason: 'init' });
     manager.removeProperty(propertyKey);
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     manager.startSessionPartInternal({ reason: 'init' });
     expect(manager.getSessionPartProperties()).to.not.have.property(
@@ -847,7 +847,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     manager.addProperty(propertyKey, value, {
       lifespan: 'permanent',
     });
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     manager.startSessionPartInternal({ reason: 'init' });
     expect(manager.getSessionPartProperties()).to.have.property(
@@ -859,7 +859,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       value,
     );
     manager.removeProperty(propertyKey);
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     manager.startSessionPartInternal({ reason: 'init' });
     expect(manager.getSessionPartProperties()).to.not.have.property(
@@ -886,7 +886,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     });
 
     failingManager.startSessionPartInternal({ reason: 'init' });
-    failingManager.endSessionPartInternal({ reason: 'web_background' });
+    failingManager.endSessionPartInternal({ reason: 'background' });
 
     const finishedSpans = memoryExporter.getFinishedSpans();
     expect(finishedSpans).to.have.lengthOf(1);
@@ -982,7 +982,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
     manager.setTracerProvider(tracerProvider);
     manager.startSessionPartInternal({ reason: 'init' });
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(0);
     expect(secondMemoryExporter.getFinishedSpans()).to.have.lengthOf(1);
@@ -997,7 +997,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       manager.setTracerProvider(tracerProvider);
 
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = exporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(1);
@@ -1191,11 +1191,11 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       );
 
       // Tab becomes engaged again. The manager's _onEngagementChange would
-      // call startSessionPartInternal({ reason: 'web_foreground' }) in production;
+      // call startSessionPartInternal({ reason: 'foreground' }) in production;
       // simulate that here. A new user session is created.
       visibilityState.current = 'visible';
       visibilityState.focused = true;
-      localManager.startSessionPartInternal({ reason: 'web_foreground' });
+      localManager.startSessionPartInternal({ reason: 'foreground' });
 
       void expect(localManager.getSessionPartId()).to.not.be.null;
       expect(localManager.getSessionPartId()).to.not.equal(firstPartId);
@@ -1219,7 +1219,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
       localManager.startSessionPartInternal({ reason: 'init' });
       const firstUserSessionId = localManager.getUserSessionId();
-      localManager.endSessionPartInternal({ reason: 'web_background' });
+      localManager.endSessionPartInternal({ reason: 'background' });
 
       clock.tick(61 * 1000);
 
@@ -1232,7 +1232,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     it('should keep the same user session id across consecutive parts within inactivity timeout', () => {
       manager.startSessionPartInternal({ reason: 'init' });
       const firstUserSessionId = manager.getUserSessionId();
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       manager.startSessionPartInternal({ reason: 'init' });
       const secondUserSessionId = manager.getUserSessionId();
@@ -1263,7 +1263,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       // brand new part span. The new part span must carry the previous user
       // session's id on emb.user_session_previous_id.
       localManager.endUserSession();
-      localManager.endSessionPartInternal({ reason: 'web_background' });
+      localManager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = exporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1278,7 +1278,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   describe('emb.session_part_start_reason', () => {
     it('should default to "init" on the part span when no reason is passed', () => {
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(1);
@@ -1290,7 +1290,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
     it('should stamp "activity" on the part span when started with that reason', () => {
       manager.startSessionPartInternal({ reason: 'web_activity' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(1);
@@ -1305,7 +1305,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       // Triggers the rollover path inside endUserSession, which restarts a
       // part with reason 'user_session_rollover'.
       manager.endUserSession();
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1337,7 +1337,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
       clock.tick(3601 * 1000);
 
-      localManager.endSessionPartInternal({ reason: 'web_background' });
+      localManager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1355,13 +1355,13 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   describe('emb.session_part_end_reason', () => {
     it('should stamp "background" when the part ends on visibility hidden', () => {
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(1);
       expect(finishedSpans[0].attributes).to.have.property(
         'emb.session_part_end_reason',
-        'web_background',
+        'background',
       );
     });
 
@@ -1380,7 +1380,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
     it('should stamp "user_session_ended" when the user-session manager ends the part on rollover', () => {
       manager.startSessionPartInternal({ reason: 'init' });
       manager.endUserSession();
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1390,7 +1390,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       );
       expect(finishedSpans[1].attributes).to.have.property(
         'emb.session_part_end_reason',
-        'web_background',
+        'background',
       );
     });
   });
@@ -1398,9 +1398,9 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   describe('emb.session_part_number', () => {
     it('emits a 1-indexed monotonic counter on the part span, persisted across visits', () => {
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1436,7 +1436,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       };
 
       localManager.startSessionPartInternal({ reason: 'init' });
-      localManager.endSessionPartInternal({ reason: 'web_background' });
+      localManager.endSessionPartInternal({ reason: 'background' });
 
       // End-of-part writes an inactivity deadline onto the state row.
       const deadlineAfterEnd = readDeadline();
@@ -1479,7 +1479,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       // the lazy expiry window backward.
       clock.tick(250);
       localManager.endSessionPartInternal({
-        reason: 'web_background',
+        reason: 'background',
         timestamp: boundaryTimestamp,
       });
 
@@ -1506,7 +1506,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         .throws(new Error('poisoned attribute value'));
 
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       // The span must still be ended and exported, despite the throw.
       expect(memoryExporter.getFinishedSpans()).to.have.lengthOf(1);
@@ -1539,7 +1539,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
       void expect(manager.getSessionPartSpan()).to.not.be.null;
 
       expect(() =>
-        manager.endSessionPartInternal({ reason: 'web_background' }),
+        manager.endSessionPartInternal({ reason: 'background' }),
       ).to.not.throw();
 
       void expect(manager.getSessionPartSpan()).to.be.null;
@@ -1555,11 +1555,11 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
   describe('emb.cold_start', () => {
     it('should stamp true on the first part and false on subsequent parts from the same manager', () => {
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(3);
@@ -1579,7 +1579,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
 
     it('should stamp true again on the first part from a new manager instance sharing storage', () => {
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       const secondManager = new EmbraceUserSessionManager({
         diag,
@@ -1590,7 +1590,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
       secondManager.startSessionPartInternal({ reason: 'init' });
-      secondManager.endSessionPartInternal({ reason: 'web_background' });
+      secondManager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);
@@ -1624,7 +1624,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
       localManager.startSessionPartInternal({ reason: 'init' });
-      localManager.endSessionPartInternal({ reason: 'web_background' });
+      localManager.endSessionPartInternal({ reason: 'background' });
 
       const [span] = memoryExporter.getFinishedSpans();
       expect(span.attributes).to.have.property(KEY_EMB_PAGE_LOAD, true);
@@ -1640,7 +1640,7 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
       localManager.startSessionPartInternal({ reason: 'init' });
-      localManager.endSessionPartInternal({ reason: 'web_background' });
+      localManager.endSessionPartInternal({ reason: 'background' });
 
       const [span] = memoryExporter.getFinishedSpans();
       expect(span.attributes).to.have.property(KEY_EMB_PAGE_LOAD, false);
@@ -1656,9 +1656,9 @@ describe('EmbraceUserSessionManager session part lifecycle', () => {
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
       });
       localManager.startSessionPartInternal({ reason: 'init' });
-      localManager.endSessionPartInternal({ reason: 'web_background' });
-      localManager.startSessionPartInternal({ reason: 'web_foreground' });
-      localManager.endSessionPartInternal({ reason: 'web_background' });
+      localManager.endSessionPartInternal({ reason: 'background' });
+      localManager.startSessionPartInternal({ reason: 'foreground' });
+      localManager.endSessionPartInternal({ reason: 'background' });
 
       const finishedSpans = memoryExporter.getFinishedSpans();
       expect(finishedSpans).to.have.lengthOf(2);

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -137,9 +137,9 @@ describe('EmbraceUserSessionManager', () => {
 
     manager.startSessionPartInternal({ reason: 'init' });
     const attrs1 = manager.getUserSessionAttributes();
-    // web_background ends the part but keeps the user session alive
+    // background ends the part but keeps the user session alive
     // (inactivity now ends both the part and the user session in one step).
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     // Advance time within inactivity timeout (29 min)
     clock.tick(29 * 60 * 1000);
@@ -159,7 +159,7 @@ describe('EmbraceUserSessionManager', () => {
 
     manager.startSessionPartInternal({ reason: 'init' });
     const attrs1 = manager.getUserSessionAttributes();
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     // Advance past inactivity timeout (31 min)
     clock.tick(31 * 60 * 1000);
@@ -179,7 +179,7 @@ describe('EmbraceUserSessionManager', () => {
 
     manager.startSessionPartInternal({ reason: 'init' });
     const attrs1 = manager.getUserSessionAttributes();
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     // Advance past max duration (3601 seconds)
     clock.tick(3601 * 1000);
@@ -272,9 +272,9 @@ describe('EmbraceUserSessionManager', () => {
     const manager1 = createManager();
     manager1.startSessionPartInternal({ reason: 'init' });
     const attrs1 = manager1.getUserSessionAttributes();
-    // web_background keeps the user session alive; another tab joining
+    // background keeps the user session alive; another tab joining
     // should adopt it. (inactivity now ends both part and user session.)
-    manager1.endSessionPartInternal({ reason: 'web_background' });
+    manager1.endSessionPartInternal({ reason: 'background' });
 
     // Simulate another tab creating a manager with the same storage
     const manager2 = createManager();
@@ -308,7 +308,7 @@ describe('EmbraceUserSessionManager', () => {
 
       manager.startSessionPartInternal({ reason: 'init' });
       const attrs1 = manager.getUserSessionAttributes();
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       // Advance within the inactivity timeout.
       clock.tick(29 * 60 * 1000);
@@ -339,7 +339,7 @@ describe('EmbraceUserSessionManager', () => {
         expectedPartIndex <= 4;
         expectedPartIndex++
       ) {
-        manager.endSessionPartInternal({ reason: 'web_background' });
+        manager.endSessionPartInternal({ reason: 'background' });
         clock.tick(5 * 60 * 1000);
         manager.startSessionPartInternal({ reason: 'init' });
 
@@ -356,7 +356,7 @@ describe('EmbraceUserSessionManager', () => {
 
       manager.startSessionPartInternal({ reason: 'init' });
       const attrs1 = manager.getUserSessionAttributes();
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       // Past the default 30 min inactivity timeout. The part ended without a
       // live timer, so the next start detects lazy expiry from the deadline
@@ -388,7 +388,7 @@ describe('EmbraceUserSessionManager', () => {
 
       manager.startSessionPartInternal({ reason: 'init' });
       const attrs1 = manager.getUserSessionAttributes();
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       // Past the 1 hour max duration. The max-duration timer lives in memory, so
       // it rolls the user session over even though nothing was ever persisted.
@@ -438,7 +438,7 @@ describe('EmbraceUserSessionManager', () => {
 
       manager.startSessionPartInternal({ reason: 'init' });
       const attrs1 = manager.getUserSessionAttributes();
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       inMemoryStorage.clear();
       clock.tick(5 * 60 * 1000);
@@ -479,13 +479,13 @@ describe('EmbraceUserSessionManager', () => {
     const manager = createManager();
 
     manager.startSessionPartInternal({ reason: 'init' });
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
     // Expire the session
     clock.tick(31 * 60 * 1000);
 
     manager.startSessionPartInternal({ reason: 'init' });
     const attrs2 = manager.getUserSessionAttributes();
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
     clock.tick(31 * 60 * 1000);
 
     manager.startSessionPartInternal({ reason: 'init' });
@@ -510,7 +510,7 @@ describe('EmbraceUserSessionManager', () => {
     const firstSessionId = manager.getUserSessionId();
     expect(firstSessionId).to.not.be.null;
 
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     clock.tick(3601 * 1000);
 
@@ -518,7 +518,7 @@ describe('EmbraceUserSessionManager', () => {
     // user-session id resets. The next part start rolls a fresh session.
     expect(manager.getUserSessionId()).to.be.null;
 
-    manager.startSessionPartInternal({ reason: 'web_foreground' });
+    manager.startSessionPartInternal({ reason: 'foreground' });
     expect(manager.getUserSessionId()).to.not.equal(firstSessionId);
   });
 
@@ -574,10 +574,10 @@ describe('EmbraceUserSessionManager', () => {
 
     inMemoryStorage.clear();
 
-    // web_background is the non-final part end that triggers the
+    // background is the non-final part end that triggers the
     // continuation persist; this is the path that previously rewrote
     // the cleared row.
-    manager.endSessionPartInternal({ reason: 'web_background' });
+    manager.endSessionPartInternal({ reason: 'background' });
 
     void expect(inMemoryStorage.getItem('embrace_user_session_state')).to.be
       .null;
@@ -904,7 +904,7 @@ describe('EmbraceUserSessionManager', () => {
       const { manager, refreshRemoteConfig } = createManagerWithLiveConfig();
 
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
       clock.tick(60 * 1000); // within the default inactivity timeout
       manager.startSessionPartInternal({ reason: 'init' }); // same session continues
 
@@ -915,7 +915,7 @@ describe('EmbraceUserSessionManager', () => {
       const { manager, refreshRemoteConfig } = createManagerWithLiveConfig();
 
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
       clock.tick(31 * 60 * 1000); // past the default 30 min inactivity timeout
       manager.startSessionPartInternal({ reason: 'init' }); // fresh session
 
@@ -954,9 +954,9 @@ describe('EmbraceUserSessionManager', () => {
       const manager1 = createManager();
       manager1.startSessionPartInternal({ reason: 'init' });
       const attrs1 = manager1.getUserSessionAttributes();
-      // web_background keeps state on disk for the second manager to
+      // background keeps state on disk for the second manager to
       // read back; the test then mutates the persisted row.
-      manager1.endSessionPartInternal({ reason: 'web_background' });
+      manager1.endSessionPartInternal({ reason: 'background' });
 
       // Simulate device clock jumping backward (before userSessionStartTs).
       const rawBefore = inMemoryStorage.getItem('embrace_user_session_state');
@@ -1006,9 +1006,9 @@ describe('EmbraceUserSessionManager', () => {
       });
       manager.startSessionPartInternal({ reason: 'init' });
       clock.tick(10 * 1000);
-      // web_background keeps the user session alive and writes the
+      // background keeps the user session alive and writes the
       // deadline; inactivity would terminate the session in one step.
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
 
       expect(readStoredDeadline()).to.equal(10 * 1000 + 120 * 1000);
     });
@@ -1016,7 +1016,7 @@ describe('EmbraceUserSessionManager', () => {
     it('should clear the inactivity deadline when a continuing part starts', () => {
       const manager = createManager();
       manager.startSessionPartInternal({ reason: 'init' });
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
       void expect(readStoredDeadline()).to.not.be.null;
 
       // A continuing part (within timeout) should clear the persisted value.
@@ -1069,7 +1069,7 @@ describe('EmbraceUserSessionManager', () => {
       // A mid-session remote-config change must not shift the active session.
       config.userSessionInactivityTimeoutSeconds = 600;
       clock.tick(10 * 1000);
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
       // The persisted deadline uses the frozen 120s, not the live 600s.
       expect(readStoredDeadline()).to.equal(10 * 1000 + 120 * 1000);
 
@@ -1108,7 +1108,7 @@ describe('EmbraceUserSessionManager', () => {
 
       // Inactivity expiry rolls into a fresh session, which resolves durations
       // again and picks up the changed 7200s max.
-      manager.endSessionPartInternal({ reason: 'web_background' });
+      manager.endSessionPartInternal({ reason: 'background' });
       clock.tick(31 * 60 * 1000); // past the default 30 min inactivity timeout
       manager.startSessionPartInternal({ reason: 'init' });
       expect(
@@ -1152,7 +1152,7 @@ describe('EmbraceUserSessionManager', () => {
       });
       manager1.startSessionPartInternal({ reason: 'init' });
       const attrs1 = manager1.getUserSessionAttributes();
-      manager1.endSessionPartInternal({ reason: 'web_background' });
+      manager1.endSessionPartInternal({ reason: 'background' });
       // Cancel manager1's max-duration timer so it doesn't auto-rollover during
       // the tick. We're simulating a page reload: the prior page is gone,
       // storage carries the dying state forward, and a fresh manager loads.

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -940,7 +940,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   };
 
   // Window focus lost (alt-tab, DevTools, another window). Engagement
-  // transition ends the active part as web_background. pagehide/pageshow
+  // transition ends the active part as background. pagehide/pageshow
   // are not listened to: blur or visibilitychange-to-hidden end the part
   // first (see README "Unload and BFCache handling" for the verified
   // cross-engine ordering). The part-end doubles as the unload flush via
@@ -956,12 +956,12 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
       const active = this._activeSessionPartId !== null;
       if (!engaged && active) {
         this._diag.debug(`tab disengaged via ${source}; ending current part`);
-        this.endSessionPartInternal({ reason: 'web_background' });
+        this.endSessionPartInternal({ reason: 'background' });
         return;
       }
       if (engaged && !active) {
         this._diag.debug(`tab engaged via ${source}; starting new part`);
-        this.startSessionPartInternal({ reason: 'web_foreground' });
+        this.startSessionPartInternal({ reason: 'foreground' });
         return;
       }
       if (engaged && active) {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -17,7 +17,6 @@ import type {
 } from '../../api-sessions/manager/types.ts';
 import type {
   NavigationHost,
-  SoftNavigationEvent,
   VisibilityStateDocument,
 } from '../../common/index.ts';
 import {
@@ -898,8 +897,11 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     this._clearMaxDurationTimer();
   }
 
-  private readonly _onSoftNavigation = (event: SoftNavigationEvent): void => {
+  private readonly _onSoftNavigation = (
+    event: NavigationCurrentEntryChangeEvent,
+  ): void => {
     // Skip same-URL replacements (e.g. framework hydration via history.replaceState).
+    // eslint-disable-next-line baseline-js/use-baseline
     if (event.from.url === this._navigationHost.location.href) {
       return;
     }

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -904,14 +904,10 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
       return;
     }
 
-    try {
-      this._rolloverSessionPart({
-        endReason: 'web_soft_nav',
-        startReason: 'web_soft_nav',
-      });
-    } catch (e) {
-      this._diag.warn('Error handling navigation currententrychange event', e);
-    }
+    this._rolloverSessionPart({
+      endReason: 'web_soft_nav',
+      startReason: 'web_soft_nav',
+    });
   };
 
   private readonly _onActivity = (): void => {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -15,7 +15,10 @@ import type {
   SessionPartStartReason,
   UserSessionEndReason,
 } from '../../api-sessions/manager/types.ts';
-import type { VisibilityStateDocument } from '../../common/index.ts';
+import type {
+  NavigationHost,
+  VisibilityStateDocument,
+} from '../../common/index.ts';
 import {
   EMB_STATES,
   EMB_TYPES,
@@ -134,6 +137,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   private readonly _limitManager: LimitManagerInternal;
   private readonly _dynamicConfigManager: DynamicConfigManager;
   private readonly _target: EventTarget;
+  private readonly _navigationHost: NavigationHost;
   private readonly _activityEvents: ReadonlyArray<string>;
   private readonly _onActivityThrottled: (event: Event) => void;
   private _sessionPartInactivityTimer: TimeoutRef | null = null;
@@ -146,6 +150,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     storage,
     limitManager,
     target = window,
+    navigationHost = window as NavigationHost,
     activityThrottleMs = DEFAULT_ACTIVITY_THROTTLE_MS,
     activityEvents = DEFAULT_ACTIVITY_EVENTS,
   }: EmbraceUserSessionManagerArgs) {
@@ -165,6 +170,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     );
     this._tracer = trace.getTracer('embrace-web-sdk-session-parts');
     this._target = target;
+    this._navigationHost = navigationHost;
     this._activityEvents = activityEvents;
     this._onActivityThrottled = throttle(this._onActivity, activityThrottleMs);
   }
@@ -248,11 +254,13 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     addActivityListeners({
       target: this._target,
       visibilityDoc: this._visibilityDoc,
+      navigationHost: this._navigationHost,
       activityEvents: this._activityEvents,
       onActivity: this._onActivityThrottled,
       onVisibilityChange: this._onVisibilityChange,
       onFocus: this._onFocus,
       onBlur: this._onBlur,
+      onSoftNavigation: this._onSoftNavigation,
     });
     // Eager state init so getUserSessionId() returns a real id before the
     // first part starts, and so other tabs see the row when we create a
@@ -821,8 +829,6 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
    * engagement starts one.
    */
 
-  // @ts-expect-error suppressed until a caller is wired; remove the directive then
-  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: no caller is wired yet
   private _rolloverSessionPart({
     endReason,
     startReason,
@@ -879,15 +885,28 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     removeActivityListeners({
       target: this._target,
       visibilityDoc: this._visibilityDoc,
+      navigationHost: this._navigationHost,
       activityEvents: this._activityEvents,
       onActivity: this._onActivityThrottled,
       onVisibilityChange: this._onVisibilityChange,
       onFocus: this._onFocus,
       onBlur: this._onBlur,
+      onSoftNavigation: this._onSoftNavigation,
     });
     this._clearSessionPartInactivityTimer();
     this._clearMaxDurationTimer();
   }
+
+  private readonly _onSoftNavigation = (): void => {
+    try {
+      this._rolloverSessionPart({
+        endReason: 'web_soft_nav',
+        startReason: 'web_soft_nav',
+      });
+    } catch (e) {
+      this._diag.warn('Error handling navigation currententrychange event', e);
+    }
+  };
 
   private readonly _onActivity = (): void => {
     try {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -907,8 +907,8 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     }
 
     this._rolloverSessionPart({
-      endReason: 'web_soft_nav',
-      startReason: 'web_soft_nav',
+      endReason: 'web_soft_navigation',
+      startReason: 'web_soft_navigation',
     });
   };
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../api-sessions/manager/types.ts';
 import type {
   NavigationHost,
+  SoftNavigationEvent,
   VisibilityStateDocument,
 } from '../../common/index.ts';
 import {
@@ -897,7 +898,12 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     this._clearMaxDurationTimer();
   }
 
-  private readonly _onSoftNavigation = (): void => {
+  private readonly _onSoftNavigation = (event: SoftNavigationEvent): void => {
+    // Skip same-URL replacements (e.g. framework hydration via history.replaceState).
+    if (event.from.url === this._navigationHost.location.href) {
+      return;
+    }
+
     try {
       this._rolloverSessionPart({
         endReason: 'web_soft_nav',

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/README.md
@@ -94,9 +94,9 @@ by design.
 | Value | Trigger |
 | --- | --- |
 | `init` | SDK init flow on page load. |
-| `web_foreground` | `visibilitychange` to visible or `focus` while no part is active and the tab is engaged. Also covers the BFCache restore path. |
+| `foreground` | `visibilitychange` to visible or `focus` while no part is active and the tab is engaged. Also covers the BFCache restore path. |
 | `web_activity` | `keydown`, `mousedown`, `mousemove`, or `scroll` while no part is active and the tab is engaged. Subject to the 30 second activity throttle. |
-| `web_soft_nav` | A soft navigation rolled the active part over, starting the next part in the same user session. Stamped on the new part. |
+| `web_soft_navigation` | A soft navigation rolled the active part over, starting the next part in the same user session. Stamped on the new part. |
 | `user_session_rollover` | Begins the next user session's first part immediately after a user session ends. |
 
 ### End triggers
@@ -105,9 +105,9 @@ by design.
 
 | Value | Trigger |
 | --- | --- |
-| `web_background` | `visibilitychange` to hidden or `blur`. Also covers hard-nav unload and BFCache freeze, since blur or an earlier `visibilitychange` to hidden ends the part before `pagehide` fires. |
+| `background` | `visibilitychange` to hidden or `blur`. Also covers hard-nav unload and BFCache freeze, since blur or an earlier `visibilitychange` to hidden ends the part before `pagehide` fires. |
 | `web_foreground_inactivity` | The foreground part-inactivity timer (`userSessionForegroundInactivityTimeoutSeconds`, default 30 minutes) fires without any user input event resetting it. |
-| `web_soft_nav` | A soft navigation rolled the active part over. Not a final reason: the enclosing user session continues and a new part starts immediately. |
+| `web_soft_navigation` | A soft navigation rolled the active part over. Not a final reason: the enclosing user session continues and a new part starts immediately. |
 | `user_session_ended` | The active part is ended as part of a user-session rollover, triggered by manual `endUserSession()` or max-duration expiry. |
 
 The part-level `web_foreground_inactivity` is distinct from the user-session-level `inactivity` reason in the [`UserSessionEndReason`](#termination) table below: when the part-inactivity timer fires it stamps `web_foreground_inactivity` as the part end reason and `inactivity` as the enclosing user session's termination reason on the same final part span.
@@ -120,7 +120,7 @@ part span before ending it. A throwing attribute write is isolated from the
 span end, so a poisoned property value cannot prevent the span from ending.
 Part-end subscribers are notified.
 
-If the end reason is not final (in practice `web_background`), the user session
+If the end reason is not final (in practice `background`), the user session
 continues: an inactivity deadline of
 `now + userSessionInactivityTimeoutSeconds * 1000` is written into the state
 blob, computed from the actual call time rather than any anchored span-end
@@ -255,7 +255,7 @@ A storage write failure never terminates the user session.
 
 A session part can only start when the tab is visible and focused. Only the
 focused tab can hold a part. A tab that loses focus ends its part with reason
-`web_background`. This makes `localStorage` the single source of truth with
+`background`. This makes `localStorage` the single source of truth with
 no write contention during active parts and no need for cross-tab event
 listeners. The class-level doc comment on `EmbraceUserSessionManager` records
 the choice.
@@ -309,17 +309,17 @@ the browsers below:
 
 - **Active-tab unload** (hard nav OR BFCache freeze). On a focus-shifting nav
   (address-bar typing, omnibox suggestion), `blur` fires first while
-  `visibilityState` is still `'visible'` and ends the part as `web_background`.
+  `visibilityState` is still `'visible'` and ends the part as `background`.
   On a programmatic `location.href` nav, no `blur` fires; instead `pagehide`
   and `visibilitychange` to hidden fire in the same task at navigation commit,
-  and the `visibilitychange` listener ends the part as `web_background`. In
+  and the `visibilitychange` listener ends the part as `background`. In
   both cases the part is ended before any `pagehide` handler could run.
 - **Backgrounded-tab unload**. `visibilitychange` to hidden already fired
-  earlier (when the user switched away), ending the part as `web_background`
+  earlier (when the user switched away), ending the part as `background`
   at that moment. The later `pagehide` is on an already-ended part.
 - **BFCache restore**. Per the spec, `focus` and `visibilitychange` to
   `'visible'` fire before `pageshow`. The combined visible+focused transition
-  starts a new part as `web_foreground`; `pageshow` would be redundant. This
+  starts a new part as `foreground`; `pageshow` would be redundant. This
   path is spec-derived rather than empirically verified here because Playwright
   suppresses BFCache (`pageshow.persisted` is always `false` on `goBack()`).
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
@@ -5,7 +5,10 @@ import type {
   UserSessionEndReason,
   UserSessionManager,
 } from '../../api-sessions/manager/types.ts';
-import type { VisibilityStateDocument } from '../../common/index.ts';
+import type {
+  NavigationHost,
+  VisibilityStateDocument,
+} from '../../common/index.ts';
 import type { DynamicConfigManager } from '../../sdk/index.ts';
 import type {
   NamespacedStorage,
@@ -168,6 +171,12 @@ export interface EmbraceUserSessionManagerArgs {
    * listeners that drive session-part lifecycle. Defaults to `window`.
    */
   target?: EventTarget;
+  /**
+   * Window-shaped object used to detect and listen for soft navigations via
+   * the Navigation API. Defaults to `window`. Optional `navigation` property
+   * handles old browsers that lack the API.
+   */
+  navigationHost?: NavigationHost;
   /**
    * Upper bound on how often the activity handler runs; prevents
    * mousemove from re-arming the inactivity timer for every sub-second event.

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/utils/activity.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/utils/activity.ts
@@ -1,6 +1,5 @@
 import type {
   NavigationHost,
-  SoftNavigationEvent,
   VisibilityStateDocument,
 } from '../../../common/index.ts';
 
@@ -16,7 +15,7 @@ export interface ActivityListenersArgs {
   onVisibilityChange: (event: Event) => void;
   onFocus: (event: Event) => void;
   onBlur: (event: Event) => void;
-  onSoftNavigation: (event: SoftNavigationEvent) => void;
+  onSoftNavigation: (event: NavigationCurrentEntryChangeEvent) => void;
 }
 
 export const addActivityListeners = ({

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/utils/activity.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/utils/activity.ts
@@ -1,5 +1,6 @@
 import type {
   NavigationHost,
+  SoftNavigationEvent,
   VisibilityStateDocument,
 } from '../../../common/index.ts';
 
@@ -15,7 +16,7 @@ export interface ActivityListenersArgs {
   onVisibilityChange: (event: Event) => void;
   onFocus: (event: Event) => void;
   onBlur: (event: Event) => void;
-  onSoftNavigation: (event: Event) => void;
+  onSoftNavigation: (event: SoftNavigationEvent) => void;
 }
 
 export const addActivityListeners = ({

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/utils/activity.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/utils/activity.ts
@@ -1,4 +1,7 @@
-import type { VisibilityStateDocument } from '../../../common/index.ts';
+import type {
+  NavigationHost,
+  VisibilityStateDocument,
+} from '../../../common/index.ts';
 
 export const isTabEngaged = (visibilityDoc: VisibilityStateDocument): boolean =>
   visibilityDoc.visibilityState === 'visible' && visibilityDoc.hasFocus();
@@ -6,21 +9,25 @@ export const isTabEngaged = (visibilityDoc: VisibilityStateDocument): boolean =>
 export interface ActivityListenersArgs {
   target: EventTarget;
   visibilityDoc: VisibilityStateDocument;
+  navigationHost: NavigationHost;
   activityEvents: ReadonlyArray<string>;
   onActivity: (event: Event) => void;
   onVisibilityChange: (event: Event) => void;
   onFocus: (event: Event) => void;
   onBlur: (event: Event) => void;
+  onSoftNavigation: (event: Event) => void;
 }
 
 export const addActivityListeners = ({
   target,
   visibilityDoc,
+  navigationHost,
   activityEvents,
   onActivity,
   onVisibilityChange,
   onFocus,
   onBlur,
+  onSoftNavigation,
 }: ActivityListenersArgs): void => {
   for (const event of activityEvents) {
     target.addEventListener(event, onActivity);
@@ -30,16 +37,22 @@ export const addActivityListeners = ({
   // Window focus changes (alt-tab, click into DevTools, multi-monitor).
   target.addEventListener('focus', onFocus);
   target.addEventListener('blur', onBlur);
+  navigationHost.navigation?.addEventListener(
+    'currententrychange',
+    onSoftNavigation,
+  );
 };
 
 export const removeActivityListeners = ({
   target,
   visibilityDoc,
+  navigationHost,
   activityEvents,
   onActivity,
   onVisibilityChange,
   onFocus,
   onBlur,
+  onSoftNavigation,
 }: ActivityListenersArgs): void => {
   for (const event of activityEvents) {
     target.removeEventListener(event, onActivity);
@@ -47,4 +60,8 @@ export const removeActivityListeners = ({
   visibilityDoc.removeEventListener?.('visibilitychange', onVisibilityChange);
   target.removeEventListener('focus', onFocus);
   target.removeEventListener('blur', onBlur);
+  navigationHost.navigation?.removeEventListener(
+    'currententrychange',
+    onSoftNavigation,
+  );
 };

--- a/server/server.ts
+++ b/server/server.ts
@@ -152,8 +152,20 @@ const server = createServer((req, res) => {
         }
 
         if (userSessionId) {
-          receivedSpans[userSessionId] = true;
+          if (!receivedSpans[userSessionId]) {
+            receivedSpans[userSessionId] = {};
+          }
           if (sessionPartSpan) {
+            const sessionPartId = sessionPartSpan.attributes.find(
+              (attr) => attr.key === 'emb.session_part_id',
+            )?.value.stringValue;
+            const endReason =
+              sessionPartSpan.attributes.find(
+                (attr) => attr.key === 'emb.session_part_end_reason',
+              )?.value.stringValue ?? 'unknown';
+            if (sessionPartId) {
+              receivedSpans[userSessionId][sessionPartId] = { endReason };
+            }
             logReceivedSessionPartSpan(
               resourceSpans,
               sessionPartSpan,

--- a/server/server.ts
+++ b/server/server.ts
@@ -162,7 +162,12 @@ const server = createServer((req, res) => {
             const endReason =
               sessionPartSpan.attributes.find(
                 (attr) => attr.key === 'emb.session_part_end_reason',
-              )?.value.stringValue ?? 'unknown';
+              )?.value.stringValue ?? undefined;
+            if (!endReason) {
+              logWarn(
+                'emb-session-part received without emb.session_part_end_reason; SDK contract broken?',
+              );
+            }
             if (sessionPartId) {
               receivedSpans[userSessionId][sessionPartId] = { endReason };
             }

--- a/tests/integration/tests/e2e/vite-react-router-tests.spec.ts
+++ b/tests/integration/tests/e2e/vite-react-router-tests.spec.ts
@@ -37,11 +37,6 @@ test.describe('Vite React Router SPA Navigation', () => {
     triggerSessionEnd,
     validateThatSessionPartsEnded,
   }) => {
-    // Skipped: each soft navigation should end the current session part, but
-    // the soft navigation instrumentation is not yet implemented
-    // biome-ignore lint/suspicious/noSkippedTests: soft navigation instrumentation not yet implemented
-    test.skip(true, 'soft navigation instrumentation not yet implemented');
-
     await loadHome();
     await test
       .expect(page.getByRole('heading', { name: 'Home' }))
@@ -68,11 +63,6 @@ test.describe('Vite React Router SPA Navigation', () => {
     triggerSessionEnd,
     validateThatSessionPartsEnded,
   }) => {
-    // Skipped: each soft navigation should end the current session part, but
-    // the soft navigation instrumentation is not yet implemented
-    // biome-ignore lint/suspicious/noSkippedTests: soft navigation instrumentation not yet implemented
-    test.skip(true, 'soft navigation instrumentation not yet implemented');
-
     await loadHome();
 
     await page.getByRole('link', { name: 'Products' }).click();
@@ -101,11 +91,6 @@ test.describe('Vite React Router SPA Navigation', () => {
     triggerSessionEnd,
     validateThatSessionPartsEnded,
   }) => {
-    // Skipped: each soft navigation should end the current session part, but
-    // the soft navigation instrumentation is not yet implemented
-    // biome-ignore lint/suspicious/noSkippedTests: soft navigation instrumentation not yet implemented
-    test.skip(true, 'soft navigation instrumentation not yet implemented');
-
     await loadHome();
 
     await page.getByRole('link', { name: 'Products' }).click();

--- a/tests/integration/types.ts
+++ b/tests/integration/types.ts
@@ -5,7 +5,7 @@ declare global {
 }
 
 type SessionPartInfo = {
-  endReason: string;
+  endReason?: string;
 };
 
 type ReceivedSpans = Record<string, Record<string, SessionPartInfo>>;

--- a/tests/integration/types.ts
+++ b/tests/integration/types.ts
@@ -4,6 +4,10 @@ declare global {
   }
 }
 
-type ReceivedSpans = Record<string, boolean>;
+type SessionPartInfo = {
+  endReason: string;
+};
 
-export type { ReceivedSpans };
+type ReceivedSpans = Record<string, Record<string, SessionPartInfo>>;
+
+export type { ReceivedSpans, SessionPartInfo };

--- a/tests/integration/utils/run-e2e-tests.ts
+++ b/tests/integration/utils/run-e2e-tests.ts
@@ -240,7 +240,7 @@ const runE2ETests = ({
       async ({
         navigateAndWaitUntilReady,
         page,
-        validateThatSessionPartEnded,
+        validateThatSessionPartsEnded,
         getCurrentUserSessionId,
         browserName,
       }) => {
@@ -252,7 +252,7 @@ const runE2ETests = ({
 
         await page.close();
 
-        await validateThatSessionPartEnded(currentUserSessionId);
+        await validateThatSessionPartsEnded(1, currentUserSessionId);
       },
     );
 
@@ -261,7 +261,7 @@ const runE2ETests = ({
       async ({
         navigateAndWaitUntilReady,
         page,
-        validateThatSessionPartEnded,
+        validateThatSessionPartsEnded,
       }) => {
         await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
 
@@ -275,7 +275,7 @@ const runE2ETests = ({
           document.dispatchEvent(new Event('visibilitychange'));
         });
 
-        await validateThatSessionPartEnded();
+        await validateThatSessionPartsEnded();
       },
     );
 
@@ -284,7 +284,7 @@ const runE2ETests = ({
       async ({
         navigateAndWaitUntilReady,
         page,
-        validateThatSessionPartEnded,
+        validateThatSessionPartsEnded,
         getCurrentUserSessionId,
         browserName,
       }) => {
@@ -295,7 +295,7 @@ const runE2ETests = ({
 
         await page.reload();
 
-        await validateThatSessionPartEnded(currentUserSessionId);
+        await validateThatSessionPartsEnded(1, currentUserSessionId);
       },
     );
 
@@ -304,7 +304,7 @@ const runE2ETests = ({
       async ({
         navigateAndWaitUntilReady,
         page,
-        validateThatSessionPartEnded,
+        validateThatSessionPartsEnded,
         getCurrentUserSessionId,
         browserName,
       }) => {
@@ -318,7 +318,7 @@ const runE2ETests = ({
         });
         await button.click();
 
-        await validateThatSessionPartEnded(currentUserSessionId);
+        await validateThatSessionPartsEnded(1, currentUserSessionId);
       },
     );
 
@@ -327,7 +327,7 @@ const runE2ETests = ({
       async ({
         navigateAndWaitUntilReady,
         page,
-        validateThatSessionPartEnded,
+        validateThatSessionPartsEnded,
         getCurrentUserSessionId,
         browserName,
       }) => {
@@ -341,7 +341,7 @@ const runE2ETests = ({
         // Not exactly the same as a user typing in the URL bar, but is the best we can do
         await page.goto('about:blank');
 
-        await validateThatSessionPartEnded(currentUserSessionId);
+        await validateThatSessionPartsEnded(1, currentUserSessionId);
       },
     );
 

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -61,8 +61,10 @@ type TestWithMockApi = {
   withRemoteConfig: (remoteConfig?: Record<string, unknown>) => Promise<void>;
   withSimulatedResponse: (response: SimulatedResponse) => Promise<void>;
   getCurrentUserSessionId: () => Promise<string>;
-  validateThatSessionPartEnded: (userSessionId?: string) => Promise<void>;
-  validateThatSessionPartsEnded: (expectedCount: number) => Promise<void>;
+  validateThatSessionPartsEnded: (
+    expectedCount?: number,
+    userSessionId?: string,
+  ) => Promise<void>;
 };
 
 // Instrumentation on this list will only compare that the same amount of spans
@@ -255,13 +257,15 @@ const testWithMockApi = base.extend<TestWithMockApi>({
       return userSessionId;
     });
   },
-  validateThatSessionPartEnded: async ({ getCurrentUserSessionId }, use) => {
-    await use(async (userSessionId?: string) => {
+  validateThatSessionPartsEnded: async ({ getCurrentUserSessionId }, use) => {
+    await use(async (expectedCount = 1, userSessionId?: string) => {
       const currentUserSessionId =
         userSessionId ?? (await getCurrentUserSessionId());
 
       const timeout = setTimeout(() => {
-        throw new Error('Server did not register the session end in time');
+        throw new Error(
+          `Expected ${expectedCount.toString()} session parts but timed out`,
+        );
       }, 4000);
 
       await new Promise((resolve) => {
@@ -271,48 +275,15 @@ const testWithMockApi = base.extend<TestWithMockApi>({
               'http://localhost:3001/received-spans',
             );
             const receivedSpans = (await response.json()) as ReceivedSpans;
+            const parts = receivedSpans[currentUserSessionId];
+            const count = parts ? Object.keys(parts).length : 0;
 
-            if (receivedSpans[currentUserSessionId]) {
+            if (count >= expectedCount) {
               clearInterval(interval);
               clearTimeout(timeout);
               resolve(null);
             }
           })();
-        }, 200);
-      });
-    });
-  },
-  validateThatSessionPartsEnded: async ({ requests }, use) => {
-    await use(async (expectedCount: number) => {
-      const timeout = setTimeout(() => {
-        throw new Error(
-          `Expected ${expectedCount.toString()} session parts but timed out`,
-        );
-      }, 4000);
-
-      await new Promise((resolve) => {
-        const interval = setInterval(() => {
-          const count = requests.reduce((acc, req) => {
-            const resourceSpans =
-              (req.data as IExportTraceServiceRequest).resourceSpans ?? [];
-            return (
-              acc +
-              resourceSpans.flatMap(
-                (rs) =>
-                  rs.scopeSpans?.flatMap(
-                    (ss) =>
-                      ss.spans?.filter((s) => s.name === 'emb-session-part') ??
-                      [],
-                  ) ?? [],
-              ).length
-            );
-          }, 0);
-
-          if (count >= expectedCount) {
-            clearInterval(interval);
-            clearTimeout(timeout);
-            resolve(null);
-          }
         }, 200);
       });
     });


### PR DESCRIPTION
## What problem is this solving?

SPA soft navigations (React Router link clicks, browser back/forward) were not triggering session part rollovers. The Navigation API's `currententrychange` event is the right hook but was unwired.

## Short description of changes

- Wire `_rolloverSessionPart` to `navigation.currententrychange` via a new `onSoftNavigation` activity listener in `activity.ts`
- Add `Navigation` and `SoftNavigationEvent` interfaces in `common/types.ts` to type the Navigation API without casting; `NavigationHost` now types `navigation` as `Navigation` instead of `EventTarget`
- Add `location: { href: string }` to `NavigationHost` so the handler can detect same-URL replacements without accessing `window.location` directly
- Skip rollover when `event.from.url === navigationHost.location.href` to avoid spurious rollovers from framework hydration (e.g. Next.js App Router fires `currententrychange` via `history.replaceState` during hydration with the same URL)
- Add `navigationHost?: NavigationHost` to `EmbraceUserSessionManagerArgs`; defaults to `window`
- Add 5 unit tests covering: rollover on soft-nav, no-op when no active part, listener cleanup on shutdown, graceful handling of absent Navigation API, no-op on same-URL navigation
- Increase bundle size limit from 55 to 56 KB
- Restructure integration test `ReceivedSpans` from `Record<string, boolean>` to `Record<string, Record<string, { endReason }>>`, keyed by session part ID — enables server-side count validation
- Consolidate `validateThatSessionPartEnded` / `validateThatSessionPartsEnded` into a single `validateThatSessionPartsEnded(expectedCount = 1, userSessionId?)` that polls `/received-spans` for accuracy
- Remove `test.skip` from all three Vite React Router SPA navigation e2e tests

## How has this been tested?

- Unit tests: all 27 tests in `EmbraceSessionPartActivity.test.ts` pass (22 existing + 5 new)
- Integration tests: SPA navigation e2e tests in `vite-react-router-tests.spec.ts` are unskipped and exercise forward links, browser back, and browser forward scenarios; Next.js integration tests all pass (same-URL skip fix prevents spurious rollovers during hydration)

## Checklist

- [x] Tests added
- [ ] Documentation added