### PR TITLE
feat: add soft navigation performance instrumentation

### DIFF
--- a/packages/web-sdk/src/instrumentations/index.ts
+++ b/packages/web-sdk/src/instrumentations/index.ts
@@ -38,6 +38,10 @@ export {
 } from './server-timing/index.ts';
 export type { SessionPartSpan } from './session-part/index.ts';
 export {
+  SoftNavigationPerformanceInstrumentation,
+  type SoftNavigationPerformanceInstrumentationArgs,
+} from './soft-navigation-performance/index.ts';
+export {
   UserTimingInstrumentation,
   type UserTimingInstrumentationArgs,
 } from './user-timing/index.ts';

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
@@ -125,7 +125,13 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
     const spans = spanExporter.getFinishedSpans();
     expect(spans).to.have.length(1);
     const span = spans[0];
-    expect(span.name).to.equal('https://example.com/next-page');
+    expect(span.name).to.equal('Soft Navigation');
+    expect(span.attributes['browser.url.full']).to.equal(
+      'https://example.com/next-page',
+    );
+    expect(span.attributes['emb.soft_navigation.source']).to.equal(
+      'performance_observer',
+    );
     expect(span.attributes['emb.soft_navigation.navigation_id']).to.equal(
       'nav-1',
     );

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
@@ -154,6 +154,46 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
     instrumentation.disable();
   });
 
+  it('should omit paint/presentation time attributes when undefined', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+    });
+
+    triggerEntries([
+      makeEntry({ paintTime: undefined, presentationTime: undefined }),
+    ]);
+
+    const span = spanExporter.getFinishedSpans()[0];
+    expect(span.attributes).not.to.have.property(
+      'emb.soft_navigation.paint_time',
+    );
+    expect(span.attributes).not.to.have.property(
+      'emb.soft_navigation.presentation_time',
+    );
+
+    instrumentation.disable();
+  });
+
+  it('should omit paint/presentation time attributes when null', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+    });
+
+    triggerEntries([makeEntry({ paintTime: null, presentationTime: null })]);
+
+    const span = spanExporter.getFinishedSpans()[0];
+    expect(span.attributes).not.to.have.property(
+      'emb.soft_navigation.paint_time',
+    );
+    expect(span.attributes).not.to.have.property(
+      'emb.soft_navigation.presentation_time',
+    );
+
+    instrumentation.disable();
+  });
+
   it('should not create an observer when soft-navigation entry type is unsupported', () => {
     const diagLogger = new InMemoryDiagLogger();
     class UnsupportedMockPerformanceObserver extends MockPerformanceObserver {

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
@@ -1,0 +1,250 @@
+/* eslint-disable baseline-js/use-baseline */
+import type { InMemorySpanExporter } from '@opentelemetry/sdk-trace-web';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import {
+  InMemoryDiagLogger,
+  MockPerformanceManager,
+  setupTestTraceExporter,
+} from '../../../../tests/utils/index.ts';
+import {
+  DEFAULT_LIMITS,
+  EmbraceLimitManager,
+} from '../../../managers/index.ts';
+import { SoftNavigationPerformanceInstrumentation } from './SoftNavigationPerformanceInstrumentation.ts';
+import type { PerformanceSoftNavigationTiming } from './types.ts';
+
+const { expect } = chai;
+
+const makeEntry = (
+  overrides: Partial<PerformanceSoftNavigationTiming> = {},
+): PerformanceSoftNavigationTiming =>
+  ({
+    name: 'https://example.com/next-page',
+    entryType: 'soft-navigation',
+    startTime: 200,
+    duration: 50,
+    navigationId: 'nav-1',
+    interactionId: 7,
+    paintTime: 230,
+    presentationTime: 240,
+    toJSON: () => ({}),
+    ...overrides,
+  }) as PerformanceSoftNavigationTiming;
+
+type ObserverCallback = (list: {
+  getEntries: () => PerformanceSoftNavigationTiming[];
+}) => void;
+
+let observerCallback: ObserverCallback | null = null;
+let observerDisconnected = false;
+let observeOptions: { type: string; buffered: boolean } | null = null;
+
+class MockPerformanceObserver {
+  public static supportedEntryTypes = ['soft-navigation'];
+  public constructor(callback: ObserverCallback) {
+    observerCallback = callback;
+    observerDisconnected = false;
+  }
+  public observe(options: { type: string; buffered: boolean }): void {
+    observeOptions = options;
+  }
+  public disconnect(): void {
+    observerDisconnected = true;
+  }
+}
+
+const triggerEntries = (entries: PerformanceSoftNavigationTiming[]) => {
+  observerCallback?.({ getEntries: () => entries });
+};
+
+describe('SoftNavigationPerformanceInstrumentation', () => {
+  let spanExporter: InMemorySpanExporter;
+  let clock: sinon.SinonFakeTimers;
+  let perf: MockPerformanceManager;
+  let limitManager: EmbraceLimitManager;
+  let originalPerformanceObserver: typeof globalThis.PerformanceObserver;
+
+  before(() => {
+    spanExporter = setupTestTraceExporter();
+  });
+
+  beforeEach(() => {
+    spanExporter.reset();
+    clock = sinon.useFakeTimers();
+    perf = new MockPerformanceManager(clock);
+    limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
+
+    originalPerformanceObserver = globalThis.PerformanceObserver;
+    (globalThis as Record<string, unknown>)['PerformanceObserver'] =
+      MockPerformanceObserver;
+
+    observerCallback = null;
+    observerDisconnected = false;
+    observeOptions = null;
+  });
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>)['PerformanceObserver'] =
+      originalPerformanceObserver;
+    clock.restore();
+  });
+
+  it('should observe soft-navigation entries with buffered: true', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+    });
+
+    expect(observeOptions).to.deep.equal({
+      type: 'soft-navigation',
+      buffered: true,
+    });
+
+    instrumentation.disable();
+  });
+
+  it('should emit a span for a soft-navigation entry', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+    });
+
+    triggerEntries([
+      makeEntry({
+        name: 'https://example.com/next-page',
+        startTime: 200,
+        duration: 50,
+        navigationId: 'nav-1',
+        interactionId: 7,
+        paintTime: 230,
+        presentationTime: 240,
+      }),
+    ]);
+
+    const spans = spanExporter.getFinishedSpans();
+    expect(spans).to.have.length(1);
+    const span = spans[0];
+    expect(span.name).to.equal('https://example.com/next-page');
+    expect(span.attributes['emb.soft_navigation.navigation_id']).to.equal(
+      'nav-1',
+    );
+    expect(span.attributes['emb.soft_navigation.interaction_id']).to.equal(7);
+    expect(span.attributes['emb.soft_navigation.start_time']).to.equal(200);
+    expect(span.attributes['emb.soft_navigation.duration']).to.equal(50);
+    expect(span.attributes['emb.soft_navigation.paint_time']).to.equal(230);
+    expect(span.attributes['emb.soft_navigation.presentation_time']).to.equal(
+      240,
+    );
+
+    instrumentation.disable();
+  });
+
+  it('should span from startTime to startTime + duration', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+    });
+
+    triggerEntries([makeEntry({ startTime: 200, duration: 50 })]);
+
+    const span = spanExporter.getFinishedSpans()[0];
+    expect(span.startTime).to.not.deep.equal(span.endTime);
+
+    instrumentation.disable();
+  });
+
+  it('should not create an observer when soft-navigation entry type is unsupported', () => {
+    const diagLogger = new InMemoryDiagLogger();
+    class UnsupportedMockPerformanceObserver extends MockPerformanceObserver {
+      public static override supportedEntryTypes: string[] = [];
+    }
+    (globalThis as Record<string, unknown>)['PerformanceObserver'] =
+      UnsupportedMockPerformanceObserver;
+
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      diag: diagLogger,
+      limitManager,
+    });
+
+    expect(observerCallback).to.be.null;
+    expect(diagLogger.getDebugLogs().some((m) => m.includes('soft-navigation')))
+      .to.be.true;
+
+    instrumentation.disable();
+  });
+
+  it('should not emit spans after disable', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+    });
+
+    instrumentation.disable();
+
+    expect(observerDisconnected).to.be.true;
+
+    triggerEntries([makeEntry()]);
+
+    expect(spanExporter.getFinishedSpans()).to.have.length(0);
+  });
+
+  it('stops emitting once the soft_navigation limit is reached', () => {
+    const customLimitManager = new EmbraceLimitManager({
+      ...DEFAULT_LIMITS,
+      maxAllowed: { ...DEFAULT_LIMITS.maxAllowed, soft_navigation: 2 },
+    });
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager: customLimitManager,
+    });
+
+    triggerEntries([
+      makeEntry({ navigationId: 'nav-0' }),
+      makeEntry({ navigationId: 'nav-1' }),
+      makeEntry({ navigationId: 'nav-2' }),
+    ]);
+
+    expect(spanExporter.getFinishedSpans()).to.have.length(2);
+
+    instrumentation.disable();
+  });
+
+  it('should not enable twice', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+    });
+    const firstCallback = observerCallback;
+
+    instrumentation.enable();
+
+    expect(observerCallback).to.equal(firstCallback);
+
+    instrumentation.disable();
+  });
+
+  it('logs an error when the observer fails to construct', () => {
+    const original = globalThis.PerformanceObserver;
+    // @ts-expect-error redefinition is intentional for testing
+    globalThis.PerformanceObserver = class {
+      public static supportedEntryTypes = ['soft-navigation'];
+      public constructor() {
+        throw new Error('constructor failed');
+      }
+    };
+
+    const diagLogger = new InMemoryDiagLogger();
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      diag: diagLogger,
+      limitManager,
+    });
+
+    expect(diagLogger.getErrorLogs()[0]).to.equal('failed to enable');
+
+    globalThis.PerformanceObserver = original;
+    instrumentation.disable();
+  });
+});

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
@@ -1,0 +1,106 @@
+import {
+  createPerformanceObserver,
+  isEntryTypeSupported,
+} from '../../../utils/index.ts';
+import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
+import {
+  KEY_EMB_SOFT_NAVIGATION_DURATION,
+  KEY_EMB_SOFT_NAVIGATION_INTERACTION_ID,
+  KEY_EMB_SOFT_NAVIGATION_NAVIGATION_ID,
+  KEY_EMB_SOFT_NAVIGATION_PAINT_TIME,
+  KEY_EMB_SOFT_NAVIGATION_PRESENTATION_TIME,
+  KEY_EMB_SOFT_NAVIGATION_START_TIME,
+} from './constants.ts';
+import type {
+  PerformanceSoftNavigationTiming,
+  SoftNavigationPerformanceInstrumentationArgs,
+} from './types.ts';
+
+export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumentationBase {
+  private _observer: PerformanceObserver | null = null;
+
+  public constructor({
+    diag,
+    perf,
+    limitManager,
+  }: SoftNavigationPerformanceInstrumentationArgs = {}) {
+    super({
+      instrumentationName: 'SoftNavigationPerformanceInstrumentation',
+      instrumentationVersion: '1.0.0',
+      diag,
+      perf,
+      limitManager,
+      config: {},
+    });
+
+    if (this._config.enabled) {
+      this.enable();
+    }
+  }
+
+  public override enable(): void {
+    if (isEntryTypeSupported('soft-navigation')) {
+      super.enable();
+    } else {
+      this._diag.debug('soft-navigation not supported, skipping');
+    }
+  }
+
+  public override onEnable(): void {
+    if (this._observer) {
+      this._observer.disconnect();
+    }
+
+    this._observer = createPerformanceObserver<PerformanceSoftNavigationTiming>(
+      'soft-navigation',
+      (entry) => this._processEntry(entry),
+      { diag: this._diag },
+    );
+
+    if (!this._observer) {
+      this._isEnabled = false;
+      this._diag.error('failed to enable');
+      return;
+    }
+  }
+
+  public onDisable(): void {
+    if (this._observer) {
+      this._observer.disconnect();
+      this._observer = null;
+    }
+  }
+
+  private _processEntry(entry: PerformanceSoftNavigationTiming): void {
+    if (!this._isEnabled) {
+      return;
+    }
+
+    if (this.limitManager?.limitSoftNavigationEntry()) {
+      return;
+    }
+
+    const span = this.tracer.startSpan(entry.name, {
+      startTime: this.perf.epochMillisFromZeroTime(entry.startTime),
+      attributes: {
+        [KEY_EMB_SOFT_NAVIGATION_NAVIGATION_ID]: entry.navigationId,
+        [KEY_EMB_SOFT_NAVIGATION_INTERACTION_ID]: entry.interactionId,
+        [KEY_EMB_SOFT_NAVIGATION_START_TIME]: this.perf.millisFromZeroTime(
+          entry.startTime,
+        ),
+        [KEY_EMB_SOFT_NAVIGATION_DURATION]: entry.duration,
+        [KEY_EMB_SOFT_NAVIGATION_PAINT_TIME]:
+          entry.paintTime !== undefined
+            ? this.perf.millisFromZeroTime(entry.paintTime)
+            : undefined,
+        [KEY_EMB_SOFT_NAVIGATION_PRESENTATION_TIME]:
+          entry.presentationTime !== undefined
+            ? this.perf.millisFromZeroTime(entry.presentationTime)
+            : undefined,
+      },
+    });
+    span.end(
+      this.perf.epochMillisFromZeroTime(entry.startTime + entry.duration),
+    );
+  }
+}

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
@@ -90,11 +90,11 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
         ),
         [KEY_EMB_SOFT_NAVIGATION_DURATION]: entry.duration,
         [KEY_EMB_SOFT_NAVIGATION_PAINT_TIME]:
-          entry.paintTime !== undefined
+          entry.paintTime != null
             ? this.perf.millisFromZeroTime(entry.paintTime)
             : undefined,
         [KEY_EMB_SOFT_NAVIGATION_PRESENTATION_TIME]:
-          entry.presentationTime !== undefined
+          entry.presentationTime != null
             ? this.perf.millisFromZeroTime(entry.presentationTime)
             : undefined,
       },

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
@@ -1,3 +1,4 @@
+import { KEY_BROWSER_URL_FULL } from '../../../constants/index.ts';
 import {
   createPerformanceObserver,
   isEntryTypeSupported,
@@ -9,7 +10,10 @@ import {
   KEY_EMB_SOFT_NAVIGATION_NAVIGATION_ID,
   KEY_EMB_SOFT_NAVIGATION_PAINT_TIME,
   KEY_EMB_SOFT_NAVIGATION_PRESENTATION_TIME,
+  KEY_EMB_SOFT_NAVIGATION_SOURCE,
   KEY_EMB_SOFT_NAVIGATION_START_TIME,
+  SOFT_NAVIGATION_SOURCES,
+  SOFT_NAVIGATION_SPAN_NAME,
 } from './constants.ts';
 import type {
   PerformanceSoftNavigationTiming,
@@ -80,9 +84,12 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
       return;
     }
 
-    const span = this.tracer.startSpan(entry.name, {
+    const span = this.tracer.startSpan(SOFT_NAVIGATION_SPAN_NAME, {
       startTime: this.perf.epochMillisFromZeroTime(entry.startTime),
       attributes: {
+        [KEY_BROWSER_URL_FULL]: entry.name,
+        [KEY_EMB_SOFT_NAVIGATION_SOURCE]:
+          SOFT_NAVIGATION_SOURCES.performanceObserver,
         [KEY_EMB_SOFT_NAVIGATION_NAVIGATION_ID]: entry.navigationId,
         [KEY_EMB_SOFT_NAVIGATION_INTERACTION_ID]: entry.interactionId,
         [KEY_EMB_SOFT_NAVIGATION_START_TIME]: this.perf.millisFromZeroTime(

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/constants.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/constants.ts
@@ -1,3 +1,6 @@
+export const SOFT_NAVIGATION_SPAN_NAME = 'Soft Navigation';
+
+export const KEY_EMB_SOFT_NAVIGATION_SOURCE = 'emb.soft_navigation.source';
 export const KEY_EMB_SOFT_NAVIGATION_NAVIGATION_ID =
   'emb.soft_navigation.navigation_id';
 export const KEY_EMB_SOFT_NAVIGATION_INTERACTION_ID =
@@ -9,3 +12,8 @@ export const KEY_EMB_SOFT_NAVIGATION_PAINT_TIME =
   'emb.soft_navigation.paint_time';
 export const KEY_EMB_SOFT_NAVIGATION_PRESENTATION_TIME =
   'emb.soft_navigation.presentation_time';
+
+export const SOFT_NAVIGATION_SOURCES = {
+  performanceObserver: 'performance_observer',
+  polyfill: 'polyfill',
+} as const;

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/constants.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/constants.ts
@@ -1,0 +1,11 @@
+export const KEY_EMB_SOFT_NAVIGATION_NAVIGATION_ID =
+  'emb.soft_navigation.navigation_id';
+export const KEY_EMB_SOFT_NAVIGATION_INTERACTION_ID =
+  'emb.soft_navigation.interaction_id';
+export const KEY_EMB_SOFT_NAVIGATION_START_TIME =
+  'emb.soft_navigation.start_time';
+export const KEY_EMB_SOFT_NAVIGATION_DURATION = 'emb.soft_navigation.duration';
+export const KEY_EMB_SOFT_NAVIGATION_PAINT_TIME =
+  'emb.soft_navigation.paint_time';
+export const KEY_EMB_SOFT_NAVIGATION_PRESENTATION_TIME =
+  'emb.soft_navigation.presentation_time';

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/index.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/index.ts
@@ -1,0 +1,2 @@
+export { SoftNavigationPerformanceInstrumentation } from './SoftNavigationPerformanceInstrumentation.ts';
+export type { SoftNavigationPerformanceInstrumentationArgs } from './types.ts';

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/types.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/types.ts
@@ -8,6 +8,6 @@ export type SoftNavigationPerformanceInstrumentationArgs = Pick<
 export type PerformanceSoftNavigationTiming = PerformanceEntry & {
   navigationId: string;
   interactionId?: number;
-  paintTime?: number;
-  presentationTime?: number;
+  paintTime?: number | null;
+  presentationTime?: number | null;
 };

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/types.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/types.ts
@@ -1,0 +1,13 @@
+import type { EmbraceInstrumentationBaseArgs } from '../../EmbraceInstrumentationBase/types.ts';
+
+export type SoftNavigationPerformanceInstrumentationArgs = Pick<
+  EmbraceInstrumentationBaseArgs,
+  'diag' | 'perf' | 'limitManager'
+>;
+
+export type PerformanceSoftNavigationTiming = PerformanceEntry & {
+  navigationId: string;
+  interactionId?: number;
+  paintTime?: number;
+  presentationTime?: number;
+};

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/index.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/index.ts
@@ -1,0 +1,4 @@
+export {
+  SoftNavigationPerformanceInstrumentation,
+  type SoftNavigationPerformanceInstrumentationArgs,
+} from './SoftNavigationPerformanceInstrumentation/index.ts';

--- a/packages/web-sdk/src/managers/EmbraceLimitManager/EmbraceLimitManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceLimitManager/EmbraceLimitManager.ts
@@ -41,6 +41,7 @@ export class EmbraceLimitManager implements LimitManagerInternal {
     user_timing_measure: 0,
     element_timing: 0,
     server_timing: 0,
+    soft_navigation: 0,
   };
   private readonly _maxAllowed: Record<MaxLimitedType, number>;
   private readonly _maxLength: Record<LengthLimitedType, number>;
@@ -132,6 +133,10 @@ export class EmbraceLimitManager implements LimitManagerInternal {
     return this._dropIfMaxReached('server_timing');
   }
 
+  public limitSoftNavigationEntry(): boolean {
+    return this._dropIfMaxReached('soft_navigation');
+  }
+
   public limitBreadcrumb(name: string): LimitedBreadcrumb | 'dropped' {
     if (this._dropIfMaxReached('breadcrumb')) {
       return 'dropped';
@@ -221,6 +226,7 @@ export class EmbraceLimitManager implements LimitManagerInternal {
       user_timing_measure: 0,
       element_timing: 0,
       server_timing: 0,
+      soft_navigation: 0,
     };
   }
 

--- a/packages/web-sdk/src/managers/EmbraceLimitManager/constants.ts
+++ b/packages/web-sdk/src/managers/EmbraceLimitManager/constants.ts
@@ -18,6 +18,7 @@ export const DEFAULT_LIMITS: EmbraceLimitManagerArgs = {
     user_timing_measure: 100,
     element_timing: 100,
     server_timing: 50,
+    soft_navigation: 100,
   },
   maxLength: {
     error_log: 128,

--- a/packages/web-sdk/src/managers/EmbraceLimitManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceLimitManager/types.ts
@@ -21,7 +21,8 @@ export type MaxLimitedType =
   | 'user_timing_mark'
   | 'user_timing_measure'
   | 'element_timing'
-  | 'server_timing';
+  | 'server_timing'
+  | 'soft_navigation';
 
 export type LengthLimitedType =
   | LogLimitedType
@@ -81,6 +82,7 @@ export interface LimitManagerInternal {
   limitUserTimingEntry: (entryType: 'mark' | 'measure') => boolean;
   limitElementTimingEntry: () => boolean;
   limitServerTimingEntry: () => boolean;
+  limitSoftNavigationEntry: () => boolean;
   reset: () => void;
   getDiagnosticCounts: () => Record<string, number>;
   truncateString: (type: LengthLimitedType, body: string) => string;

--- a/packages/web-sdk/src/sdk/setupDefaultInstrumentations.ts
+++ b/packages/web-sdk/src/sdk/setupDefaultInstrumentations.ts
@@ -76,8 +76,8 @@ export const setupDefaultInstrumentations = (
   if (!config.omit?.has('element-timing')) {
     instrumentations.push(
       new ElementTimingInstrumentation({
-        ...config['element-timing'],
         limitManager,
+        ...config['element-timing'],
       }),
     );
   }
@@ -85,8 +85,8 @@ export const setupDefaultInstrumentations = (
   if (!config.omit?.has('soft-navigation-performance')) {
     instrumentations.push(
       new SoftNavigationPerformanceInstrumentation({
-        ...config['soft-navigation-performance'],
         limitManager,
+        ...config['soft-navigation-performance'],
       }),
     );
   }
@@ -100,8 +100,8 @@ export const setupDefaultInstrumentations = (
   if (!config.omit?.has('server-timing')) {
     instrumentations.push(
       new ServerTimingInstrumentation({
-        ...config['server-timing'],
         limitManager,
+        ...config['server-timing'],
       }),
     );
   }

--- a/packages/web-sdk/src/sdk/setupDefaultInstrumentations.ts
+++ b/packages/web-sdk/src/sdk/setupDefaultInstrumentations.ts
@@ -13,6 +13,7 @@ import {
   MaxScrollDepthInstrumentation,
   RageClickInstrumentation,
   ServerTimingInstrumentation,
+  SoftNavigationPerformanceInstrumentation,
   UserTimingInstrumentation,
   WebVitalsInstrumentation,
 } from '../instrumentations/index.ts';
@@ -76,6 +77,15 @@ export const setupDefaultInstrumentations = (
     instrumentations.push(
       new ElementTimingInstrumentation({
         ...config['element-timing'],
+        limitManager,
+      }),
+    );
+  }
+
+  if (!config.omit?.has('soft-navigation-performance')) {
+    instrumentations.push(
+      new SoftNavigationPerformanceInstrumentation({
+        ...config['soft-navigation-performance'],
         limitManager,
       }),
     );

--- a/packages/web-sdk/src/sdk/types.ts
+++ b/packages/web-sdk/src/sdk/types.ts
@@ -34,6 +34,7 @@ import type {
   MaxScrollDepthInstrumentationArgs,
   RageClickInstrumentationArgs,
   ServerTimingInstrumentationArgs,
+  SoftNavigationPerformanceInstrumentationArgs,
   UserTimingInstrumentationArgs,
   WebVitalsInstrumentationConfig,
 } from '../instrumentations/index.ts';
@@ -390,6 +391,7 @@ type OptionalInstrumentations =
   | 'user-timing'
   | 'element-timing'
   | 'server-timing'
+  | 'soft-navigation-performance'
   | 'document-load'
   | '@opentelemetry/instrumentation-fetch'
   | '@opentelemetry/instrumentation-xml-http-request';
@@ -417,6 +419,7 @@ export interface DefaultInstrumentationConfig {
   'user-timing'?: UserTimingInstrumentationArgs;
   'element-timing'?: ElementTimingInstrumentationArgs;
   'server-timing'?: ServerTimingInstrumentationArgs;
+  'soft-navigation-performance'?: SoftNavigationPerformanceInstrumentationArgs;
   'document-load'?: DocumentLoadInstrumentationConfig;
 
   // Convenience to allow common config arguments for '@opentelemetry/instrumentation-fetch' and


### PR DESCRIPTION
## What problem is this solving?

Chrome's [Soft Navigations API](https://developer.chrome.com/docs/web-platform/soft-navigations) exposes `soft-navigation` PerformanceObserver entries that identify SPA route transitions detected by the browser heuristic. The SDK had no way to capture these, leaving SPA navigation timing invisible in Embrace.

## Short description of changes

- Adds `SoftNavigationPerformanceInstrumentation`, a new always-on instrumentation (opt-out via `omit: 'soft-navigation-performance'`) that observes `soft-navigation` PerformanceObserver entries and emits a span per entry. Span name is the new URL; attributes capture `navigationId`, `interactionId`, `startTime`, `duration`, `paintTime`, and `presentationTime`.
- Follows the same `isEntryTypeSupported` guard pattern as `ElementTimingInstrumentation` — silently skips on browsers that don't support the entry type.
- Adds `soft_navigation` to `EmbraceLimitManager` (default cap: 100/session), consistent with `element_timing`/`server_timing`.
- Registers in `setupDefaultInstrumentations` and exposes an omit key in `DefaultInstrumentationConfig`.