### PR TITLE
chore: add first_interaction.time attribute

### DIFF
--- a/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.test.ts
@@ -70,14 +70,13 @@ describe('FirstInteractionInstrumentation', () => {
     target.id = 'go';
     testContainer.append(target);
 
-    target.dispatchEvent(
-      new PointerEvent('click', {
-        bubbles: true,
-        clientX: 12,
-        clientY: 34,
-        pointerType: 'mouse',
-      }),
-    );
+    const clickEvent = new PointerEvent('click', {
+      bubbles: true,
+      clientX: 12,
+      clientY: 34,
+      pointerType: 'mouse',
+    });
+    target.dispatchEvent(clickEvent);
 
     const logs = getLogs();
 
@@ -91,6 +90,7 @@ describe('FirstInteractionInstrumentation', () => {
       'first_interaction.element_selector': '#go',
       'first_interaction.x': 12,
       'first_interaction.y': 34,
+      'first_interaction.time': clickEvent.timeStamp,
     });
   });
 

--- a/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.ts
@@ -7,6 +7,7 @@ import {
   ATTR_FIRST_INTERACTION_ELEMENT_SELECTOR,
   ATTR_FIRST_INTERACTION_ELEMENT_TYPE,
   ATTR_FIRST_INTERACTION_INTERACTION_TYPE,
+  ATTR_FIRST_INTERACTION_TIME,
   ATTR_FIRST_INTERACTION_X,
   ATTR_FIRST_INTERACTION_Y,
   FIRST_INTERACTION_EVENT_NAME,
@@ -142,6 +143,9 @@ export class FirstInteractionInstrumentation extends EmbraceInstrumentationBase 
       [ATTR_FIRST_INTERACTION_INTERACTION_TYPE]: data.interactionType,
       [ATTR_FIRST_INTERACTION_ELEMENT_TYPE]: elementType,
       [ATTR_FIRST_INTERACTION_ELEMENT_SELECTOR]: elementSelector,
+      [ATTR_FIRST_INTERACTION_TIME]: this.perf.millisFromZeroTime(
+        data.timestamp,
+      ),
     };
 
     if (data.x !== undefined && data.y !== undefined) {

--- a/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/constants.ts
+++ b/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/constants.ts
@@ -8,5 +8,6 @@ export const ATTR_FIRST_INTERACTION_ELEMENT_SELECTOR =
   'first_interaction.element_selector';
 export const ATTR_FIRST_INTERACTION_X = 'first_interaction.x';
 export const ATTR_FIRST_INTERACTION_Y = 'first_interaction.y';
+export const ATTR_FIRST_INTERACTION_TIME = 'first_interaction.time';
 
 export type FirstInteractionType = 'click' | 'tap' | 'keypress' | 'scroll';

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "B81D8C1864222747F849A929A3F4B5D6"
+              "stringValue": "FB26E5F9D7782690DC560B252A17658F"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1780486653013300049",
-              "observedTimeUnixNano": "1780486652964000000",
+              "timeUnixNano": "1782919220218500244",
+              "observedTimeUnixNano": "1782919220156000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":1.100000023841858,\"dnsDuration\":0,\"connectionDuration\":0.09999996423721313,\"requestDuration\":0.800000011920929}"
+                "stringValue": "{\"waitingDuration\":0.09999990463256836,\"cacheDuration\":2.700000047683716,\"dnsDuration\":0.2999999523162842,\"connectionDuration\":0.20000004768371582,\"requestDuration\":1.2000000476837158}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 2
+                    "doubleValue": 4.5
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 2
+                    "doubleValue": 4.5
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1780486652961-1419194491443"
+                    "stringValue": "v5-1782919220152-7417405626339"
                   }
                 },
                 {
@@ -189,19 +189,19 @@
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 2
+                    "intValue": 4
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "3C1EC9D01D7661C1FBFA26F3E498A7FC"
+                    "stringValue": "900B09BA52D26D00B05E03302A9959C2"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "48503244466909220B98AB3BA90DE7F0"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "48503244466909220B98AB3BA90DE7F0"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "F21BF50DF2D97CB089A7900F71B1141A"
+                    "stringValue": "603FBC8D48FF2EC05188F3CF4783E99A"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1780486653024500000",
-              "observedTimeUnixNano": "1780486652975000000",
+              "timeUnixNano": "1782919220231400146",
+              "observedTimeUnixNano": "1782919220169000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":58,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":4.5,\"firstByteToFCP\":71.5,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -261,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 60
+                    "intValue": 76
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 60
+                    "intValue": 76
                   }
                 },
                 {
@@ -279,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1780486652960-2243019859707"
+                    "stringValue": "v5-1782919220152-6213206393486"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "14F35935E1395F53C2116572F21F9927"
+                    "stringValue": "F336CD852462E8886B877304E461F48B"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "48503244466909220B98AB3BA90DE7F0"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "48503244466909220B98AB3BA90DE7F0"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
@@ -341,7 +341,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "F21BF50DF2D97CB089A7900F71B1141A"
+                    "stringValue": "603FBC8D48FF2EC05188F3CF4783E99A"
                   }
                 },
                 {
@@ -354,11 +354,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1780486653141399902",
-              "observedTimeUnixNano": "1780486653092000000",
+              "timeUnixNano": "1782919220347700195",
+              "observedTimeUnixNano": "1782919220285000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":2,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":58,\"target\":\"#root>h1\"}"
+                "stringValue": "{\"timeToFirstByte\":4.5,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":71.5,\"target\":\"#root>h1\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -377,13 +377,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 60
+                    "intValue": 76
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 60
+                    "intValue": 76
                   }
                 },
                 {
@@ -395,7 +395,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1780486652960-5896927369751"
+                    "stringValue": "v5-1782919220152-1348044455172"
                   }
                 },
                 {
@@ -427,13 +427,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "9782E5139994D1ABAE011D28B6F3DE85"
+                    "stringValue": "BAD180D4CC2B7EDCA4FAD7A5ACF8528C"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "48503244466909220B98AB3BA90DE7F0"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
@@ -445,7 +445,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "48503244466909220B98AB3BA90DE7F0"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
@@ -457,7 +457,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "F21BF50DF2D97CB089A7900F71B1141A"
+                    "stringValue": "603FBC8D48FF2EC05188F3CF4783E99A"
                   }
                 },
                 {
@@ -478,8 +478,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1780486653134000000",
-              "observedTimeUnixNano": "1780486653086000000",
+              "timeUnixNano": "1782919220341200195",
+              "observedTimeUnixNano": "1782919220281000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -509,6 +509,12 @@
                   }
                 },
                 {
+                  "key": "first_interaction.time",
+                  "value": {
+                    "doubleValue": 186.5
+                  }
+                },
+                {
                   "key": "first_interaction.x",
                   "value": {
                     "intValue": 409
@@ -523,13 +529,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "3AB618EF227EA484C8E7719ABC3FEA5C"
+                    "stringValue": "8F17F3BB59CABFA57E53645367798A84"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "48503244466909220B98AB3BA90DE7F0"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
@@ -541,7 +547,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "48503244466909220B98AB3BA90DE7F0"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
@@ -553,7 +559,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "F21BF50DF2D97CB089A7900F71B1141A"
+                    "stringValue": "603FBC8D48FF2EC05188F3CF4783E99A"
                   }
                 },
                 {
@@ -585,8 +591,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1780486653559199951",
-              "observedTimeUnixNano": "1780486653510000000",
+              "timeUnixNano": "1782919220765900146",
+              "observedTimeUnixNano": "1782919220704000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -602,13 +608,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at rf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:98883)\n    at My.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:38002)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:37543)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:237122\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:237094)\n    at ag (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:8:127515)"
+                    "stringValue": "Error\n    at nf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:100334)\n    at Hy.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:38002)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:37543)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242325\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242297)\n    at lm (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127515)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:11:126\":\"186c7210976877b22d7d13d27d4adcb4\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:126\":\"8ad5455d6272b4b18a20538605d0249b\"}"
                   }
                 },
                 {
@@ -620,13 +626,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "01476F9B2E11505B4E128439CDD6EBC1"
+                    "stringValue": "A8FF1542B7A3A9F84BC9E979ACA56399"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "48503244466909220B98AB3BA90DE7F0"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
@@ -638,7 +644,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "48503244466909220B98AB3BA90DE7F0"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
@@ -650,7 +656,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "F21BF50DF2D97CB089A7900F71B1141A"
+                    "stringValue": "603FBC8D48FF2EC05188F3CF4783E99A"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "FB26E5F9D7782690DC560B252A17658F"
+              "stringValue": "563045F73064972E3E53A5C34690310D"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.7827.55 Safari/537.36"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "78210bbe0aab68f795a433136432dee3",
-              "spanId": "ae007ae5bc4a506d",
+              "traceId": "2d32945873484211f5ae65e0fd3235ab",
+              "spanId": "6d2690cbd04e3152",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1782919220151000000",
-              "endTimeUnixNano": "1782919220809000244",
+              "startTimeUnixNano": "1782925509102000000",
+              "endTimeUnixNano": "1782925509714399902",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
+                    "stringValue": "BAA2A047D3A395F08EE314149498B089"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
+                    "stringValue": "BAA2A047D3A395F08EE314149498B089"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "doubleValue": 1782919220150.8
+                    "intValue": 1782925509102
                   }
                 },
                 {
@@ -173,7 +173,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "603FBC8D48FF2EC05188F3CF4783E99A"
+                    "stringValue": "B2E2099582748FC08C4E373275461D60"
                   }
                 },
                 {
@@ -197,7 +197,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 6
+                    "intValue": 11
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1782919220341200195",
+                  "timeUnixNano": "1782925509312199951",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1782919220765100098",
+                  "timeUnixNano": "1782925509646500000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "d490f0b3302a29640bab9b3060485d65",
-              "spanId": "23f114b0561d18a3",
-              "parentSpanId": "b26c7c10b4cb735b",
+              "traceId": "e89507efc50814953054af2e686a2d88",
+              "spanId": "420e5e93da1ac8d9",
+              "parentSpanId": "b2e464095aa3d171",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782919220092400049",
-              "endTimeUnixNano": "1782919220097100049",
+              "startTimeUnixNano": "1782925509035800098",
+              "endTimeUnixNano": "1782925509039000098",
               "attributes": [
                 {
                   "key": "url.full",
@@ -339,55 +339,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919220092400049",
+                  "timeUnixNano": "1782925509035800098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782919220095100049",
+                  "timeUnixNano": "1782925509037100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782919220095400049",
+                  "timeUnixNano": "1782925509037100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782919220095400049",
+                  "timeUnixNano": "1782925509037100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1782919220092300049",
+                  "timeUnixNano": "1782925509035600098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782919220095600049",
+                  "timeUnixNano": "1782925509037300098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782919220095600049",
+                  "timeUnixNano": "1782925509037300098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782919220096800049",
+                  "timeUnixNano": "1782925509038600098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782919220097100049",
+                  "timeUnixNano": "1782925509039000098",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -400,13 +400,13 @@
               "flags": 257
             },
             {
-              "traceId": "d490f0b3302a29640bab9b3060485d65",
-              "spanId": "7c41c8dace80341e",
-              "parentSpanId": "b26c7c10b4cb735b",
+              "traceId": "e89507efc50814953054af2e686a2d88",
+              "spanId": "6f453d32feb04d0e",
+              "parentSpanId": "b2e464095aa3d171",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782919220099700049",
-              "endTimeUnixNano": "1782919220107300049",
+              "startTimeUnixNano": "1782925509041200049",
+              "endTimeUnixNano": "1782925509049000049",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -480,49 +480,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919220099700049",
+                  "timeUnixNano": "1782925509041200049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782919220099700049",
+                  "timeUnixNano": "1782925509041200049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782919220099700049",
+                  "timeUnixNano": "1782925509041200049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782919220099700049",
+                  "timeUnixNano": "1782925509041200049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782919220099700049",
+                  "timeUnixNano": "1782925509041200049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782919220104800049",
+                  "timeUnixNano": "1782925509045200049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782919220106300049",
+                  "timeUnixNano": "1782925509047700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782919220107300049",
+                  "timeUnixNano": "1782925509049000049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -535,12 +535,12 @@
               "flags": 257
             },
             {
-              "traceId": "d490f0b3302a29640bab9b3060485d65",
-              "spanId": "b26c7c10b4cb735b",
+              "traceId": "e89507efc50814953054af2e686a2d88",
+              "spanId": "b2e464095aa3d171",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1782919220092499903",
-              "endTimeUnixNano": "1782919220153999903",
+              "startTimeUnixNano": "1782925509036000049",
+              "endTimeUnixNano": "1782925509108800049",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -557,7 +557,7 @@
                 {
                   "key": "user_agent.original",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.7827.55 Safari/537.36"
                   }
                 },
                 {
@@ -578,43 +578,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919220092499903",
+                  "timeUnixNano": "1782925509036000049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1782919220101899903",
+                  "timeUnixNano": "1782925509043600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1782919220153799903",
+                  "timeUnixNano": "1782925509108600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1782919220153799903",
+                  "timeUnixNano": "1782925509108600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1782919220153799903",
+                  "timeUnixNano": "1782925509108600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1782919220153799903",
+                  "timeUnixNano": "1782925509108700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1782919220153999903",
+                  "timeUnixNano": "1782925509108800049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -635,12 +635,12 @@
           },
           "spans": [
             {
-              "traceId": "a14c8f33d15b78e7c966d9098be1a4f0",
-              "spanId": "b1641bb5c527ddc3",
+              "traceId": "45eb44a1f6c7dc8f2ac26c49e8716066",
+              "spanId": "c1aa4ee1a626e727",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1782919220281000000",
-              "endTimeUnixNano": "1782919220285000000",
+              "startTimeUnixNano": "1782925509240000000",
+              "endTimeUnixNano": "1782925509244000000",
               "attributes": [
                 {
                   "key": "component",
@@ -687,7 +687,7 @@
                 {
                   "key": "http.user_agent",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.7827.55 Safari/537.36"
                   }
                 },
                 {
@@ -748,49 +748,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919220281599952",
+                  "timeUnixNano": "1782925509240500098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782919220281599952",
+                  "timeUnixNano": "1782925509240500098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782919220281599952",
+                  "timeUnixNano": "1782925509240500098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782919220281599952",
+                  "timeUnixNano": "1782925509240500098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782919220281599952",
+                  "timeUnixNano": "1782925509240500098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782919220281599952",
+                  "timeUnixNano": "1782925509240500098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782919220282999951",
+                  "timeUnixNano": "1782925509242400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782919220282999951",
+                  "timeUnixNano": "1782925509242400098",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "D44A9692C8C6791A2D6BAF026046983B"
+              "stringValue": "FB26E5F9D7782690DC560B252A17658F"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.7827.55 Safari/537.36"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "9ac5a508f1bd336c92b105edcdda6ddc",
-              "spanId": "880f3e4ee8176645",
+              "traceId": "78210bbe0aab68f795a433136432dee3",
+              "spanId": "ae007ae5bc4a506d",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1782849192482000000",
-              "endTimeUnixNano": "1782849193144099854",
+              "startTimeUnixNano": "1782919220151000000",
+              "endTimeUnixNano": "1782919220809000244",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "130C8F35C736905281032906E974E9F1"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "130C8F35C736905281032906E974E9F1"
+                    "stringValue": "FE3A62AEFF33E591491DA8E9EE4393C9"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "doubleValue": 1782849192481.9001
+                    "doubleValue": 1782919220150.8
                   }
                 },
                 {
@@ -173,7 +173,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "65108C62F46FB05EB3EF6159169CC93C"
+                    "stringValue": "603FBC8D48FF2EC05188F3CF4783E99A"
                   }
                 },
                 {
@@ -197,7 +197,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 9
+                    "intValue": 6
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1782849192678000000",
+                  "timeUnixNano": "1782919220341200195",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1782849193102399902",
+                  "timeUnixNano": "1782919220765100098",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "7d8ae08a3e639d2316a739bf7614ca86",
-              "spanId": "d181fa42e7a73d7f",
-              "parentSpanId": "67d9bffdf1930d0a",
+              "traceId": "d490f0b3302a29640bab9b3060485d65",
+              "spanId": "23f114b0561d18a3",
+              "parentSpanId": "b26c7c10b4cb735b",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782849192425600000",
-              "endTimeUnixNano": "1782849192427300000",
+              "startTimeUnixNano": "1782919220092400049",
+              "endTimeUnixNano": "1782919220097100049",
               "attributes": [
                 {
                   "key": "url.full",
@@ -339,55 +339,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849192425600000",
+                  "timeUnixNano": "1782919220092400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782849192426400000",
+                  "timeUnixNano": "1782919220095100049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782849192426400000",
+                  "timeUnixNano": "1782919220095400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782849192426400000",
+                  "timeUnixNano": "1782919220095400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1782849192425500000",
+                  "timeUnixNano": "1782919220092300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782849192426700000",
+                  "timeUnixNano": "1782919220095600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782849192426700000",
+                  "timeUnixNano": "1782919220095600049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782849192427100000",
+                  "timeUnixNano": "1782919220096800049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782849192427300000",
+                  "timeUnixNano": "1782919220097100049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -400,13 +400,13 @@
               "flags": 257
             },
             {
-              "traceId": "7d8ae08a3e639d2316a739bf7614ca86",
-              "spanId": "24a179d2153f816e",
-              "parentSpanId": "67d9bffdf1930d0a",
+              "traceId": "d490f0b3302a29640bab9b3060485d65",
+              "spanId": "7c41c8dace80341e",
+              "parentSpanId": "b26c7c10b4cb735b",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782849192429099951",
-              "endTimeUnixNano": "1782849192432299951",
+              "startTimeUnixNano": "1782919220099700049",
+              "endTimeUnixNano": "1782919220107300049",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -417,13 +417,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 400404
+                    "intValue": 400446
                   }
                 },
                 {
@@ -447,19 +447,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 400404
+                    "intValue": 400446
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 400704
+                    "intValue": 400746
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 400404
+                    "intValue": 400446
                   }
                 },
                 {
@@ -480,49 +480,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849192429099951",
+                  "timeUnixNano": "1782919220099700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782849192429099951",
+                  "timeUnixNano": "1782919220099700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782849192429099951",
+                  "timeUnixNano": "1782919220099700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782849192429099951",
+                  "timeUnixNano": "1782919220099700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782849192429099951",
+                  "timeUnixNano": "1782919220099700049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782849192430799951",
+                  "timeUnixNano": "1782919220104800049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782849192431499951",
+                  "timeUnixNano": "1782919220106300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782849192432299951",
+                  "timeUnixNano": "1782919220107300049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -535,12 +535,12 @@
               "flags": 257
             },
             {
-              "traceId": "7d8ae08a3e639d2316a739bf7614ca86",
-              "spanId": "67d9bffdf1930d0a",
+              "traceId": "d490f0b3302a29640bab9b3060485d65",
+              "spanId": "b26c7c10b4cb735b",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1782849192425700098",
-              "endTimeUnixNano": "1782849192487000098",
+              "startTimeUnixNano": "1782919220092499903",
+              "endTimeUnixNano": "1782919220153999903",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -557,7 +557,7 @@
                 {
                   "key": "user_agent.original",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.7827.55 Safari/537.36"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
                   }
                 },
                 {
@@ -578,43 +578,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849192425700098",
+                  "timeUnixNano": "1782919220092499903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1782849192431200098",
+                  "timeUnixNano": "1782919220101899903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1782849192486900098",
+                  "timeUnixNano": "1782919220153799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1782849192486900098",
+                  "timeUnixNano": "1782919220153799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1782849192486900098",
+                  "timeUnixNano": "1782919220153799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1782849192486900098",
+                  "timeUnixNano": "1782919220153799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1782849192487000098",
+                  "timeUnixNano": "1782919220153999903",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -635,12 +635,12 @@
           },
           "spans": [
             {
-              "traceId": "e49cf1bd71ac7312fd6930e0f652802f",
-              "spanId": "b0c134160fb0bb55",
+              "traceId": "a14c8f33d15b78e7c966d9098be1a4f0",
+              "spanId": "b1641bb5c527ddc3",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1782849192618000000",
-              "endTimeUnixNano": "1782849192622000000",
+              "startTimeUnixNano": "1782919220281000000",
+              "endTimeUnixNano": "1782919220285000000",
               "attributes": [
                 {
                   "key": "component",
@@ -687,7 +687,7 @@
                 {
                   "key": "http.user_agent",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.7827.55 Safari/537.36"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
                   }
                 },
                 {
@@ -748,49 +748,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849192618700000",
+                  "timeUnixNano": "1782919220281599952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782849192618700000",
+                  "timeUnixNano": "1782919220281599952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782849192618700000",
+                  "timeUnixNano": "1782919220281599952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782849192618700000",
+                  "timeUnixNano": "1782919220281599952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782849192618700000",
+                  "timeUnixNano": "1782919220281599952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782849192618700000",
+                  "timeUnixNano": "1782919220281599952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782849192621000000",
+                  "timeUnixNano": "1782919220282999951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782849192621000000",
+                  "timeUnixNano": "1782919220282999951",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "238A373ABCCFAE84B126F6AB9422E03E"
+              "stringValue": "AEB248EF3C65ACA5E6A3B7EE424AD484"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1781898492796600098",
-              "observedTimeUnixNano": "1781898492759000000",
+              "timeUnixNano": "1782919216608899902",
+              "observedTimeUnixNano": "1782919216540000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":0.7000000476837158,\"dnsDuration\":0,\"connectionDuration\":0.5999999046325684,\"requestDuration\":0.7000000476837158}"
+                "stringValue": "{\"waitingDuration\":0.20000004768371582,\"cacheDuration\":6.799999952316284,\"dnsDuration\":0,\"connectionDuration\":0.10000014305114746,\"requestDuration\":8.5}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 2
+                    "doubleValue": 15.600000143051147
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 2
+                    "doubleValue": 15.600000143051147
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1781898492756-3973920253339"
+                    "stringValue": "v5-1782919216534-8872227218444"
                   }
                 },
                 {
@@ -171,7 +171,7 @@
                 {
                   "key": "emb.web_vital.attribution.tcpConnection",
                   "value": {
-                    "intValue": 1
+                    "intValue": 0
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 1
+                    "intValue": 8
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 0
+                    "intValue": 9
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "9EE9E1D04DF0F414252C40A2894849A8"
+                    "stringValue": "F461EA2E181B14884AF70D2791CE700E"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "468AE17C18CB5489C7A87674E69A8B0D"
+                    "stringValue": "D5C1FE7EEFEFBBF705FC4069D2858E3E"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "468AE17C18CB5489C7A87674E69A8B0D"
+                    "stringValue": "D5C1FE7EEFEFBBF705FC4069D2858E3E"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "5E7707F808023DC69D4F484D8F7F1A61"
+                    "stringValue": "90D164B2F3B46262664646F5764FE44B"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1781898492806700195",
-              "observedTimeUnixNano": "1781898492770000000",
+              "timeUnixNano": "1782919216620800049",
+              "observedTimeUnixNano": "1782919216551000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":46,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":15.600000143051147,\"firstByteToFCP\":68.39999985694885,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -261,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 48
+                    "intValue": 84
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 48
+                    "intValue": 84
                   }
                 },
                 {
@@ -279,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1781898492756-5703408112013"
+                    "stringValue": "v5-1782919216534-6512131613400"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "7FAD6F3FB663A6A46A3DCFC5D5156AA1"
+                    "stringValue": "9B1401905856894CD94A4F913D77D46E"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "468AE17C18CB5489C7A87674E69A8B0D"
+                    "stringValue": "D5C1FE7EEFEFBBF705FC4069D2858E3E"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "468AE17C18CB5489C7A87674E69A8B0D"
+                    "stringValue": "D5C1FE7EEFEFBBF705FC4069D2858E3E"
                   }
                 },
                 {
@@ -341,7 +341,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "5E7707F808023DC69D4F484D8F7F1A61"
+                    "stringValue": "90D164B2F3B46262664646F5764FE44B"
                   }
                 },
                 {
@@ -362,8 +362,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1781898492915600098",
-              "observedTimeUnixNano": "1781898492879000000",
+              "timeUnixNano": "1782919216731500000",
+              "observedTimeUnixNano": "1782919216664000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -393,6 +393,12 @@
                   }
                 },
                 {
+                  "key": "first_interaction.time",
+                  "value": {
+                    "doubleValue": 195.5
+                  }
+                },
+                {
                   "key": "first_interaction.x",
                   "value": {
                     "intValue": 53
@@ -407,13 +413,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "BA80E7C37E52DD931F167378F42E598F"
+                    "stringValue": "6308A9C50553DA8045619BCAC28E34BF"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "468AE17C18CB5489C7A87674E69A8B0D"
+                    "stringValue": "D5C1FE7EEFEFBBF705FC4069D2858E3E"
                   }
                 },
                 {
@@ -425,7 +431,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "468AE17C18CB5489C7A87674E69A8B0D"
+                    "stringValue": "D5C1FE7EEFEFBBF705FC4069D2858E3E"
                   }
                 },
                 {
@@ -437,7 +443,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "5E7707F808023DC69D4F484D8F7F1A61"
+                    "stringValue": "90D164B2F3B46262664646F5764FE44B"
                   }
                 },
                 {
@@ -470,8 +476,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1781898492880000000",
-              "observedTimeUnixNano": "1781898492880000000",
+              "timeUnixNano": "1782919216664000000",
+              "observedTimeUnixNano": "1782919216664000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -509,13 +515,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "23C226B74D369D62616E65A281A7CA67"
+                    "stringValue": "B885EB2FEFA1B50D3D60D4CBD3193C8F"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "468AE17C18CB5489C7A87674E69A8B0D"
+                    "stringValue": "D5C1FE7EEFEFBBF705FC4069D2858E3E"
                   }
                 },
                 {
@@ -527,7 +533,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "468AE17C18CB5489C7A87674E69A8B0D"
+                    "stringValue": "D5C1FE7EEFEFBBF705FC4069D2858E3E"
                   }
                 },
                 {
@@ -539,7 +545,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "5E7707F808023DC69D4F484D8F7F1A61"
+                    "stringValue": "90D164B2F3B46262664646F5764FE44B"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "5ED71BF9B544F4E0272AA0E45F75FFA6"
+              "stringValue": "BA0F69743B40085216C66597046C4010"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1780486649712399902",
-              "observedTimeUnixNano": "1780486649671000000",
+              "timeUnixNano": "1782919217032199951",
+              "observedTimeUnixNano": "1782919216978000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0.10000002384185791,\"cacheDuration\":0.800000011920929,\"dnsDuration\":0,\"connectionDuration\":0.09999996423721313,\"requestDuration\":0.6000000238418579}"
+                "stringValue": "{\"waitingDuration\":0.09999990463256836,\"cacheDuration\":0.9000000953674316,\"dnsDuration\":0.09999990463256836,\"connectionDuration\":0.20000004768371582,\"requestDuration\":0.5999999046325684}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 1.600000023841858
+                    "doubleValue": 1.8999998569488525
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 1.600000023841858
+                    "doubleValue": 1.8999998569488525
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1780486649667-1510483289534"
+                    "stringValue": "v5-1782919216972-4162673375032"
                   }
                 },
                 {
@@ -195,13 +195,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "9044B49A544CE16A1F320A79AAD36CE6"
+                    "stringValue": "371F5C5EB9A675F7D1D527727E2A5B85"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5B8E9D8BC7F1CFAA73CC184A10083334"
+                    "stringValue": "1011DE096971330362B8383177F875A9"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5B8E9D8BC7F1CFAA73CC184A10083334"
+                    "stringValue": "1011DE096971330362B8383177F875A9"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "5B4B3D01A41CC9A96C03134D070A5E02"
+                    "stringValue": "DF83CD74EE279095B6E3435A6B9BDFD4"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1780486649726499756",
-              "observedTimeUnixNano": "1780486649685000000",
+              "timeUnixNano": "1782919217055800049",
+              "observedTimeUnixNano": "1782919217001000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":1.600000023841858,\"firstByteToFCP\":54.39999997615814,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":1.8999998569488525,\"firstByteToFCP\":78.10000014305115,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -261,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 56
+                    "intValue": 80
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 56
+                    "intValue": 80
                   }
                 },
                 {
@@ -279,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1780486649667-9270718499106"
+                    "stringValue": "v5-1782919216972-2664137120481"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "AF8F1FD99F55E39D20193FCF2A5980AA"
+                    "stringValue": "C796E32C1325D91D3B655E0425D9C1CC"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5B8E9D8BC7F1CFAA73CC184A10083334"
+                    "stringValue": "1011DE096971330362B8383177F875A9"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5B8E9D8BC7F1CFAA73CC184A10083334"
+                    "stringValue": "1011DE096971330362B8383177F875A9"
                   }
                 },
                 {
@@ -341,7 +341,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "5B4B3D01A41CC9A96C03134D070A5E02"
+                    "stringValue": "DF83CD74EE279095B6E3435A6B9BDFD4"
                   }
                 },
                 {
@@ -362,8 +362,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1780486649930399902",
-              "observedTimeUnixNano": "1780486649890000000",
+              "timeUnixNano": "1782919217210300049",
+              "observedTimeUnixNano": "1782919217156000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -393,6 +393,12 @@
                   }
                 },
                 {
+                  "key": "first_interaction.time",
+                  "value": {
+                    "doubleValue": 235.59999990463257
+                  }
+                },
+                {
                   "key": "first_interaction.x",
                   "value": {
                     "intValue": 135
@@ -407,13 +413,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "A104AAD9883A2D86C590638C3B4EDC70"
+                    "stringValue": "92D3CF89E7C63156733D4D06554D4F24"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5B8E9D8BC7F1CFAA73CC184A10083334"
+                    "stringValue": "1011DE096971330362B8383177F875A9"
                   }
                 },
                 {
@@ -425,7 +431,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5B8E9D8BC7F1CFAA73CC184A10083334"
+                    "stringValue": "1011DE096971330362B8383177F875A9"
                   }
                 },
                 {
@@ -437,7 +443,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "5B4B3D01A41CC9A96C03134D070A5E02"
+                    "stringValue": "DF83CD74EE279095B6E3435A6B9BDFD4"
                   }
                 },
                 {
@@ -469,8 +475,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1780486649932099854",
-              "observedTimeUnixNano": "1780486649891000000",
+              "timeUnixNano": "1782919217211599854",
+              "observedTimeUnixNano": "1782919217157000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -486,13 +492,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at rf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:98883)\n    at My.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:38002)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:37543)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:237122\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:237094)\n    at ag (http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:8:127515)"
+                    "stringValue": "Error\n    at nf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:100334)\n    at Hy.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:38002)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:37543)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242325\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:966\n    at new Promise (<anonymous>)\n    at Ut (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242297)\n    at lm (http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127515)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:11:126\":\"186c7210976877b22d7d13d27d4adcb4\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:126\":\"8ad5455d6272b4b18a20538605d0249b\"}"
                   }
                 },
                 {
@@ -504,13 +510,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "85C0015DFBF67EBAD8965B7ABED9D148"
+                    "stringValue": "93D205EBDF92A094D131BEAE036A9E8C"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5B8E9D8BC7F1CFAA73CC184A10083334"
+                    "stringValue": "1011DE096971330362B8383177F875A9"
                   }
                 },
                 {
@@ -522,7 +528,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5B8E9D8BC7F1CFAA73CC184A10083334"
+                    "stringValue": "1011DE096971330362B8383177F875A9"
                   }
                 },
                 {
@@ -534,7 +540,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "5B4B3D01A41CC9A96C03134D070A5E02"
+                    "stringValue": "DF83CD74EE279095B6E3435A6B9BDFD4"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs-after-part.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs-after-part.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "A00A4BDF1A77594697D855EC1EED5607"
+              "stringValue": "E078C4268759B1E226DA245C245EC51D"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1366x768"
+              "stringValue": "1280x720"
             }
           },
           {
@@ -86,8 +86,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782849214160000000",
-              "observedTimeUnixNano": "1782849214160000000",
+              "timeUnixNano": "1782919249642000000",
+              "observedTimeUnixNano": "1782919249642000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -125,13 +125,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "FA339E2A0FC4EDA3D5043AF0ADD6BDDA"
+                    "stringValue": "F028CE6700665E1E3C58D792633BEB9C"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
@@ -143,7 +143,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
@@ -155,7 +155,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AF904AD09D24F2719DC566C7D5AAFEBF"
+                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs-after-part.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs-after-part.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "E078C4268759B1E226DA245C245EC51D"
+              "stringValue": "728FFE82D576309350FDCC677C7B59D4"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1280x720"
+              "stringValue": "1366x768"
             }
           },
           {
@@ -86,8 +86,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782919249642000000",
-              "observedTimeUnixNano": "1782919249642000000",
+              "timeUnixNano": "1782925543144000000",
+              "observedTimeUnixNano": "1782925543144000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -125,13 +125,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "F028CE6700665E1E3C58D792633BEB9C"
+                    "stringValue": "4DAC2D400BE98FE8FA447CCEC679E0E7"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -143,7 +143,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -155,7 +155,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
+                    "stringValue": "C2D28AE01155643B59551BC2F60D5AEA"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "A00A4BDF1A77594697D855EC1EED5607"
+              "stringValue": "E078C4268759B1E226DA245C245EC51D"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1366x768"
+              "stringValue": "1280x720"
             }
           },
           {
@@ -86,127 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782849213582000000",
-              "observedTimeUnixNano": "1782849213506000000",
+              "timeUnixNano": "1782919249115000000",
+              "observedTimeUnixNano": "1782919248994000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":10,\"firstByteToFCP\":65,\"loadState\":\"dom-interactive\"}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "fcp"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 75
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 75
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v5-1782849213494-5337013366391"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {}
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {}
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "8041D42595B2D2019573AA262F6CE432"
-                  }
-                },
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
-                  }
-                },
-                {
-                  "key": "session.previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "AF904AD09D24F2719DC566C7D5AAFEBF"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            },
-            {
-              "timeUnixNano": "1782849213582000000",
-              "observedTimeUnixNano": "1782849213506000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":8,\"dnsDuration\":0,\"connectionDuration\":1,\"requestDuration\":1}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":6,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -225,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 10
+                    "intValue": 7
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 10
+                    "intValue": 7
                   }
                 },
                 {
@@ -243,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782849213494-6735286739875"
+                    "stringValue": "v5-1782919248976-1245513067170"
                   }
                 },
                 {
@@ -287,7 +171,7 @@
                 {
                   "key": "emb.web_vital.attribution.tcpConnection",
                   "value": {
-                    "intValue": 1
+                    "intValue": 0
                   }
                 },
                 {
@@ -299,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 1
+                    "intValue": 0
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 8
+                    "intValue": 7
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "AB2FE8489DC1B169D1CECE3F2BE2137D"
+                    "stringValue": "D12F53A4403F877D1F0800E7C0F0E75F"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
@@ -329,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
@@ -341,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AF904AD09D24F2719DC566C7D5AAFEBF"
+                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
                   }
                 },
                 {
@@ -354,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1782849213759000000",
-              "observedTimeUnixNano": "1782849213683000000",
+              "timeUnixNano": "1782919249123000000",
+              "observedTimeUnixNano": "1782919249001000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":10,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":65,\"target\":\"#root>h1\"}"
+                "stringValue": "{\"timeToFirstByte\":7,\"firstByteToFCP\":115,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -371,19 +255,19 @@
                 {
                   "key": "browser.web_vital.name",
                   "value": {
-                    "stringValue": "lcp"
+                    "stringValue": "fcp"
                   }
                 },
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 75
+                    "intValue": 122
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 75
+                    "intValue": 122
                   }
                 },
                 {
@@ -395,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782849213494-8624802961003"
+                    "stringValue": "v5-1782919248975-4205011888051"
                   }
                 },
                 {
@@ -427,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "168300369515D0B23643264D891116C5"
+                    "stringValue": "30623B129EFD53B64E15450C6EDEF6AF"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
@@ -445,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
@@ -457,7 +341,123 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AF904AD09D24F2719DC566C7D5AAFEBF"
+                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1782919249339000000",
+              "observedTimeUnixNano": "1782919249218000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":7,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":115,\"target\":\"#root>h1\"}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "lcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 122
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 122
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v5-1782919248975-9674912433972"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {}
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "7ADDABFFB0235C537AE71FBDAE3003DD"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
                   }
                 },
                 {
@@ -478,8 +478,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782849213753000000",
-              "observedTimeUnixNano": "1782849213678000000",
+              "timeUnixNano": "1782919249331000000",
+              "observedTimeUnixNano": "1782919249212000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -509,6 +509,12 @@
                   }
                 },
                 {
+                  "key": "first_interaction.time",
+                  "value": {
+                    "intValue": 344
+                  }
+                },
+                {
                   "key": "first_interaction.x",
                   "value": {
                     "intValue": 405
@@ -523,13 +529,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "3ABBBD32BC829B633705DC545E164E77"
+                    "stringValue": "E44AD3B99BE59DBCA834A8333B4EA9DB"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
@@ -541,7 +547,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
@@ -553,7 +559,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AF904AD09D24F2719DC566C7D5AAFEBF"
+                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
                   }
                 },
                 {
@@ -585,8 +591,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782849214193000000",
-              "observedTimeUnixNano": "1782849214118000000",
+              "timeUnixNano": "1782919249676000000",
+              "observedTimeUnixNano": "1782919249555000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -602,13 +608,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:100334\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:38002\nTM</Fr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:37543\nTM</bM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:242250\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:1:999\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:1:819\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:242224\nlm@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:127516\nTM</Uy/nc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:132570\nhd@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:15162\nnc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:128751\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:28582\n_y@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:28402\nEventListener.handleEvent*um@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:128312\ntc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:127712\nTM</Uy/ec/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:127878\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:127823\nTM</Uy/Ur.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:36449\nTM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:242835\nAy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:242889\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:100334\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:38002\nvM</Fr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:37543\nvM</yM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242325\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:966\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:786\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242299\nlm@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127516\nvM</Uy/nc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:132570\nhd@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:15162\nnc@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:128751\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:28582\n_y@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:28402\nEventListener.handleEvent*um@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:128312\ntc@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127712\nvM</Uy/ec/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127878\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127823\nvM</Uy/Ur.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:36449\nvM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242910\nAy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:680\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242964\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:11:126\\n\":\"74143846598ffa972572173bdfed9c1b\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:126\\n\":\"8ad5455d6272b4b18a20538605d0249b\"}"
                   }
                 },
                 {
@@ -620,13 +626,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "57C800F9D2BAADCFE7B835366888C573"
+                    "stringValue": "91376BF1ACAB2C8A11930D519812EE17"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
@@ -638,7 +644,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
@@ -650,7 +656,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AF904AD09D24F2719DC566C7D5AAFEBF"
+                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "E078C4268759B1E226DA245C245EC51D"
+              "stringValue": "728FFE82D576309350FDCC677C7B59D4"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1280x720"
+              "stringValue": "1366x768"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782919249115000000",
-              "observedTimeUnixNano": "1782919248994000000",
+              "timeUnixNano": "1782925542620000000",
+              "observedTimeUnixNano": "1782925542390000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":6,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":23,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":7}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 7
+                    "intValue": 30
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 7
+                    "intValue": 30
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782919248976-1245513067170"
+                    "stringValue": "v5-1782925542373-3898035017985"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 0
+                    "intValue": 7
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 7
+                    "intValue": 23
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "D12F53A4403F877D1F0800E7C0F0E75F"
+                    "stringValue": "9F7AB9C5124AADACE04D9D511530E79A"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
+                    "stringValue": "C2D28AE01155643B59551BC2F60D5AEA"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1782919249123000000",
-              "observedTimeUnixNano": "1782919249001000000",
+              "timeUnixNano": "1782925542623000000",
+              "observedTimeUnixNano": "1782925542393000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":7,\"firstByteToFCP\":115,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":30,\"firstByteToFCP\":201,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -261,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 122
+                    "intValue": 231
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 122
+                    "intValue": 231
                   }
                 },
                 {
@@ -279,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782919248975-4205011888051"
+                    "stringValue": "v5-1782925542373-6384350544260"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "30623B129EFD53B64E15450C6EDEF6AF"
+                    "stringValue": "4CB52E83269952310175E469BAB8E18C"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -341,7 +341,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
+                    "stringValue": "C2D28AE01155643B59551BC2F60D5AEA"
                   }
                 },
                 {
@@ -354,11 +354,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1782919249339000000",
-              "observedTimeUnixNano": "1782919249218000000",
+              "timeUnixNano": "1782925542798000000",
+              "observedTimeUnixNano": "1782925542567000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":7,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":115,\"target\":\"#root>h1\"}"
+                "stringValue": "{\"timeToFirstByte\":30,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":201,\"target\":\"#root>h1\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -377,13 +377,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 122
+                    "intValue": 231
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 122
+                    "intValue": 231
                   }
                 },
                 {
@@ -395,7 +395,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782919248975-9674912433972"
+                    "stringValue": "v5-1782925542372-4485140813456"
                   }
                 },
                 {
@@ -427,13 +427,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "7ADDABFFB0235C537AE71FBDAE3003DD"
+                    "stringValue": "F603BE4BF217BD8BBE15AC81A83B9A70"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -445,7 +445,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -457,7 +457,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
+                    "stringValue": "C2D28AE01155643B59551BC2F60D5AEA"
                   }
                 },
                 {
@@ -478,8 +478,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782919249331000000",
-              "observedTimeUnixNano": "1782919249212000000",
+              "timeUnixNano": "1782925542789000000",
+              "observedTimeUnixNano": "1782925542562000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -511,7 +511,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 344
+                    "intValue": 406
                   }
                 },
                 {
@@ -529,13 +529,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "E44AD3B99BE59DBCA834A8333B4EA9DB"
+                    "stringValue": "C2CDB7135A050C1E64B87553C72B8874"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -547,7 +547,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -559,7 +559,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
+                    "stringValue": "C2D28AE01155643B59551BC2F60D5AEA"
                   }
                 },
                 {
@@ -591,8 +591,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782919249676000000",
-              "observedTimeUnixNano": "1782919249555000000",
+              "timeUnixNano": "1782925543230000000",
+              "observedTimeUnixNano": "1782925542999000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -626,13 +626,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "91376BF1ACAB2C8A11930D519812EE17"
+                    "stringValue": "5D6EC3F5B9585F0AF8FAE5627AB254CE"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -644,7 +644,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -656,7 +656,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
+                    "stringValue": "C2D28AE01155643B59551BC2F60D5AEA"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "A00A4BDF1A77594697D855EC1EED5607"
+              "stringValue": "E078C4268759B1E226DA245C245EC51D"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1366x768"
+              "stringValue": "1280x720"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "84b4fc5f7680b37c7ecf553d8a0ed8ef",
-              "spanId": "9ce66387cff319e8",
+              "traceId": "dfcf7f4b6e2795bdf8f33f973c38abf1",
+              "spanId": "1bddac711e996b4f",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1782849213493000000",
-              "endTimeUnixNano": "1782849214236000000",
+              "startTimeUnixNano": "1782919248973000000",
+              "endTimeUnixNano": "1782919249764000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "7063C17A0F403E9904C2861172BBF5B8"
+                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1782849213491
+                    "intValue": 1782919248971
                   }
                 },
                 {
@@ -173,7 +173,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AF904AD09D24F2719DC566C7D5AAFEBF"
+                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
                   }
                 },
                 {
@@ -197,7 +197,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 6
+                    "intValue": 12
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1782849213753000000",
+                  "timeUnixNano": "1782919249331000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1782849214192000000",
+                  "timeUnixNano": "1782919249675000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "902711ecf824936d11690c50439f9337",
-              "spanId": "49395feba36b196d",
-              "parentSpanId": "0e922856d527d711",
+              "traceId": "5b5ef26926dd1e7270e0c6dd7005cbea",
+              "spanId": "242e94616dcd10f5",
+              "parentSpanId": "671aa955130113b3",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782849213429000000",
-              "endTimeUnixNano": "1782849213439000000",
+              "startTimeUnixNano": "1782919248864000000",
+              "endTimeUnixNano": "1782919248872000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -339,55 +339,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849213429000000",
+                  "timeUnixNano": "1782919248864000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782849213437000000",
+                  "timeUnixNano": "1782919248871000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782849213437000000",
+                  "timeUnixNano": "1782919248871000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782849213437000000",
+                  "timeUnixNano": "1782919248871000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1782849213429000000",
+                  "timeUnixNano": "1782919248865000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782849213438000000",
+                  "timeUnixNano": "1782919248871000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782849213438000000",
+                  "timeUnixNano": "1782919248872000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782849213439000000",
+                  "timeUnixNano": "1782919248872000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782849213439000000",
+                  "timeUnixNano": "1782919248872000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -400,13 +400,13 @@
               "flags": 257
             },
             {
-              "traceId": "902711ecf824936d11690c50439f9337",
-              "spanId": "151ed1d5506e5772",
-              "parentSpanId": "0e922856d527d711",
+              "traceId": "5b5ef26926dd1e7270e0c6dd7005cbea",
+              "spanId": "fc1e289758331e18",
+              "parentSpanId": "671aa955130113b3",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782849213442000000",
-              "endTimeUnixNano": "1782849213459000000",
+              "startTimeUnixNano": "1782919248880000000",
+              "endTimeUnixNano": "1782919248929000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -417,13 +417,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 400404
+                    "intValue": 400446
                   }
                 },
                 {
@@ -441,19 +441,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 400404
+                    "intValue": 400446
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 400704
+                    "intValue": 400746
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 400404
+                    "intValue": 400446
                   }
                 },
                 {
@@ -474,49 +474,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849213442000000",
+                  "timeUnixNano": "1782919248880000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782849213442000000",
+                  "timeUnixNano": "1782919248880000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782849213442000000",
+                  "timeUnixNano": "1782919248880000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782849213442000000",
+                  "timeUnixNano": "1782919248880000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782849213442000000",
+                  "timeUnixNano": "1782919248880000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782849213458000000",
+                  "timeUnixNano": "1782919248928000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782849213459000000",
+                  "timeUnixNano": "1782919248928000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782849213459000000",
+                  "timeUnixNano": "1782919248929000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -529,12 +529,12 @@
               "flags": 257
             },
             {
-              "traceId": "902711ecf824936d11690c50439f9337",
-              "spanId": "0e922856d527d711",
+              "traceId": "5b5ef26926dd1e7270e0c6dd7005cbea",
+              "spanId": "671aa955130113b3",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1782849213428000000",
-              "endTimeUnixNano": "1782849213505000000",
+              "startTimeUnixNano": "1782919248865000000",
+              "endTimeUnixNano": "1782919248988000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -551,7 +551,7 @@
                 {
                   "key": "user_agent.original",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
                   }
                 },
                 {
@@ -571,44 +571,50 @@
               "events": [
                 {
                   "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1782919248865000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1782849213445000000",
+                  "timeUnixNano": "1782919248883000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1782849213504000000",
+                  "timeUnixNano": "1782919248979000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1782849213505000000",
+                  "timeUnixNano": "1782919248979000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1782849213505000000",
+                  "timeUnixNano": "1782919248987000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1782849213505000000",
+                  "timeUnixNano": "1782919248987000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1782849213505000000",
+                  "timeUnixNano": "1782919248988000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "firstContentfulPaint",
-                  "timeUnixNano": "1782849213503000000",
+                  "timeUnixNano": "1782919248988000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -629,12 +635,12 @@
           },
           "spans": [
             {
-              "traceId": "6a8989015e2ecfd205faf848846883fd",
-              "spanId": "fc48275a621a47d1",
+              "traceId": "98b8f9ee732820a4d381fd9b9ad1f0c9",
+              "spanId": "217ce76d867d3781",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1782849213678000000",
-              "endTimeUnixNano": "1782849213685000000",
+              "startTimeUnixNano": "1782919249212000000",
+              "endTimeUnixNano": "1782919249220000000",
               "attributes": [
                 {
                   "key": "component",
@@ -681,7 +687,7 @@
                 {
                   "key": "http.user_agent",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
                   }
                 },
                 {
@@ -742,49 +748,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849213678000000",
+                  "timeUnixNano": "1782919249212000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782849213678000000",
+                  "timeUnixNano": "1782919249212000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782849213678000000",
+                  "timeUnixNano": "1782919249212000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782849213678000000",
+                  "timeUnixNano": "1782919249212000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782849213678000000",
+                  "timeUnixNano": "1782919249212000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782849213678000000",
+                  "timeUnixNano": "1782919249212000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782849213678000000",
+                  "timeUnixNano": "1782919249212000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782849213678000000",
+                  "timeUnixNano": "1782919249212000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "E078C4268759B1E226DA245C245EC51D"
+              "stringValue": "728FFE82D576309350FDCC677C7B59D4"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1280x720"
+              "stringValue": "1366x768"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "dfcf7f4b6e2795bdf8f33f973c38abf1",
-              "spanId": "1bddac711e996b4f",
+              "traceId": "830233f3fe8142df9073444f2b074a96",
+              "spanId": "8abf539976c44917",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1782919248973000000",
-              "endTimeUnixNano": "1782919249764000000",
+              "startTimeUnixNano": "1782925542370000000",
+              "endTimeUnixNano": "1782925543375000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B42DC9381B930B31CD332B86ACE2DA00"
+                    "stringValue": "7253377D9BB3D3C375C2A5AD91D64DE2"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1782919248971
+                    "intValue": 1782925542368
                   }
                 },
                 {
@@ -173,7 +173,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D9922B6DB31FB392AAC5B51D46CFC3E8"
+                    "stringValue": "C2D28AE01155643B59551BC2F60D5AEA"
                   }
                 },
                 {
@@ -197,7 +197,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 12
+                    "intValue": 11
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1782919249331000000",
+                  "timeUnixNano": "1782925542789000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1782919249675000000",
+                  "timeUnixNano": "1782925543229000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "5b5ef26926dd1e7270e0c6dd7005cbea",
-              "spanId": "242e94616dcd10f5",
-              "parentSpanId": "671aa955130113b3",
+              "traceId": "c293f3438c54d004819fcc7e16a6fd4d",
+              "spanId": "d0b16e422e88049a",
+              "parentSpanId": "bf02ecf9c5c9d711",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782919248864000000",
-              "endTimeUnixNano": "1782919248872000000",
+              "startTimeUnixNano": "1782925542153000000",
+              "endTimeUnixNano": "1782925542183000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -339,55 +339,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919248864000000",
+                  "timeUnixNano": "1782925542153000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782919248871000000",
+                  "timeUnixNano": "1782925542176000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782919248871000000",
+                  "timeUnixNano": "1782925542176000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782919248871000000",
+                  "timeUnixNano": "1782925542176000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1782919248865000000",
+                  "timeUnixNano": "1782925542153000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782919248871000000",
+                  "timeUnixNano": "1782925542176000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782919248872000000",
+                  "timeUnixNano": "1782925542176000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782919248872000000",
+                  "timeUnixNano": "1782925542183000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782919248872000000",
+                  "timeUnixNano": "1782925542183000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -400,13 +400,13 @@
               "flags": 257
             },
             {
-              "traceId": "5b5ef26926dd1e7270e0c6dd7005cbea",
-              "spanId": "fc1e289758331e18",
-              "parentSpanId": "671aa955130113b3",
+              "traceId": "c293f3438c54d004819fcc7e16a6fd4d",
+              "spanId": "231ad48a0e570db7",
+              "parentSpanId": "bf02ecf9c5c9d711",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782919248880000000",
-              "endTimeUnixNano": "1782919248929000000",
+              "startTimeUnixNano": "1782925542190000000",
+              "endTimeUnixNano": "1782925542211000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -474,49 +474,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919248880000000",
+                  "timeUnixNano": "1782925542190000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782919248880000000",
+                  "timeUnixNano": "1782925542190000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782919248880000000",
+                  "timeUnixNano": "1782925542190000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782919248880000000",
+                  "timeUnixNano": "1782925542190000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782919248880000000",
+                  "timeUnixNano": "1782925542190000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782919248928000000",
+                  "timeUnixNano": "1782925542207000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782919248928000000",
+                  "timeUnixNano": "1782925542211000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782919248929000000",
+                  "timeUnixNano": "1782925542211000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -529,29 +529,60 @@
               "flags": 257
             },
             {
-              "traceId": "5b5ef26926dd1e7270e0c6dd7005cbea",
-              "spanId": "671aa955130113b3",
-              "name": "documentLoad",
+              "traceId": "c293f3438c54d004819fcc7e16a6fd4d",
+              "spanId": "453d6c94bd1fe3d6",
+              "parentSpanId": "bf02ecf9c5c9d711",
+              "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782919248865000000",
-              "endTimeUnixNano": "1782919248988000000",
+              "startTimeUnixNano": "1782925542195000000",
+              "endTimeUnixNano": "1782925542195000000",
               "attributes": [
                 {
                   "key": "emb.type",
                   "value": {
-                    "stringValue": "ux.document_load"
+                    "stringValue": "ux.resource_fetch"
                   }
                 },
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                    "stringValue": "http://localhost:3001/favicon.ico"
                   }
                 },
                 {
-                  "key": "user_agent.original",
+                  "key": "http.response_content_length",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.request.initiator_type",
+                  "value": {
+                    "stringValue": "other"
+                  }
+                },
+                {
+                  "key": "http.response.body.size",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.response.size",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.response.decoded_body_size",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.response.cors_opaque",
+                  "value": {
+                    "boolValue": true
                   }
                 },
                 {
@@ -572,49 +603,141 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919248865000000",
+                  "timeUnixNano": "1782925542195000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1782925542195000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1782925542195000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1782925542195000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1782925542195000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1782925542195000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1782925542195000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1782925542195000000",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            },
+            {
+              "traceId": "c293f3438c54d004819fcc7e16a6fd4d",
+              "spanId": "bf02ecf9c5c9d711",
+              "name": "documentLoad",
+              "kind": 1,
+              "startTimeUnixNano": "1782925542153000000",
+              "endTimeUnixNano": "1782925542384000000",
+              "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.document_load"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1782919248883000000",
+                  "timeUnixNano": "1782925542193000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1782919248979000000",
+                  "timeUnixNano": "1782925542376000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1782919248979000000",
+                  "timeUnixNano": "1782925542377000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1782919248987000000",
+                  "timeUnixNano": "1782925542384000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1782919248987000000",
+                  "timeUnixNano": "1782925542384000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1782919248988000000",
+                  "timeUnixNano": "1782925542384000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "firstContentfulPaint",
-                  "timeUnixNano": "1782919248988000000",
+                  "timeUnixNano": "1782925542384000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -635,12 +758,12 @@
           },
           "spans": [
             {
-              "traceId": "98b8f9ee732820a4d381fd9b9ad1f0c9",
-              "spanId": "217ce76d867d3781",
+              "traceId": "6922ad02faf3d5be3248a64e17e4207f",
+              "spanId": "b235f95dc1eb7181",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1782919249212000000",
-              "endTimeUnixNano": "1782919249220000000",
+              "startTimeUnixNano": "1782925542563000000",
+              "endTimeUnixNano": "1782925542571000000",
               "attributes": [
                 {
                   "key": "component",
@@ -687,7 +810,7 @@
                 {
                   "key": "http.user_agent",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
                   }
                 },
                 {
@@ -748,49 +871,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919249212000000",
+                  "timeUnixNano": "1782925542564000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782919249212000000",
+                  "timeUnixNano": "1782925542564000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782919249212000000",
+                  "timeUnixNano": "1782925542564000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782919249212000000",
+                  "timeUnixNano": "1782925542564000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782919249212000000",
+                  "timeUnixNano": "1782925542564000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782919249212000000",
+                  "timeUnixNano": "1782925542564000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782919249212000000",
+                  "timeUnixNano": "1782925542564000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782919249212000000",
+                  "timeUnixNano": "1782925542564000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "CA1F591EB5B3EB16038A28BB4BABAD19"
+              "stringValue": "3E904858BE79A180A256D96C15092A43"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1280x720"
+              "stringValue": "1366x768"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782919912136000000",
-              "observedTimeUnixNano": "1782919912026000000",
+              "timeUnixNano": "1782925534579000000",
+              "observedTimeUnixNano": "1782925534464000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":5,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":7,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 6
+                    "intValue": 8
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 6
+                    "intValue": 8
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782919912011-7633238998653"
+                    "stringValue": "v5-1782925534436-3756485352595"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 1
+                    "intValue": 0
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 5
+                    "intValue": 8
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "592040675B0E63A4F5118F55785065D6"
+                    "stringValue": "3E4527CEAC7A7E23642C9ADD419A8C90"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
+                    "stringValue": "F4EE114BC7C859EB38309E308F5485EB"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
+                    "stringValue": "F4EE114BC7C859EB38309E308F5485EB"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "23B76FDA0F2D56FB0020BF2938EEEF8B"
+                    "stringValue": "8D40887E30EC698EE9911EAA055E6C71"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1782919912140000000",
-              "observedTimeUnixNano": "1782919912029000000",
+              "timeUnixNano": "1782925534583000000",
+              "observedTimeUnixNano": "1782925534469000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":6,\"firstByteToFCP\":104,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":8,\"firstByteToFCP\":108,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -261,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 110
+                    "intValue": 116
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 110
+                    "intValue": 116
                   }
                 },
                 {
@@ -279,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782919912011-5435778460789"
+                    "stringValue": "v5-1782925534436-2017582885672"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "FF46097D10C8FBB6EAEF61490587515C"
+                    "stringValue": "5C2DC07B69B98FB47EDAACB92E6652FD"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
+                    "stringValue": "F4EE114BC7C859EB38309E308F5485EB"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
+                    "stringValue": "F4EE114BC7C859EB38309E308F5485EB"
                   }
                 },
                 {
@@ -341,7 +341,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "23B76FDA0F2D56FB0020BF2938EEEF8B"
+                    "stringValue": "8D40887E30EC698EE9911EAA055E6C71"
                   }
                 },
                 {
@@ -362,8 +362,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782919912285000000",
-              "observedTimeUnixNano": "1782919912177000000",
+              "timeUnixNano": "1782925534772000000",
+              "observedTimeUnixNano": "1782925534658000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -395,7 +395,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 264
+                    "intValue": 313
                   }
                 },
                 {
@@ -413,13 +413,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "373A60D2EBE2C85ABD2E42824B2D3718"
+                    "stringValue": "300F3C48CDEBC8542CC3EA42071AABAA"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
+                    "stringValue": "F4EE114BC7C859EB38309E308F5485EB"
                   }
                 },
                 {
@@ -431,7 +431,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
+                    "stringValue": "F4EE114BC7C859EB38309E308F5485EB"
                   }
                 },
                 {
@@ -443,7 +443,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "23B76FDA0F2D56FB0020BF2938EEEF8B"
+                    "stringValue": "8D40887E30EC698EE9911EAA055E6C71"
                   }
                 },
                 {
@@ -476,8 +476,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782919912177000000",
-              "observedTimeUnixNano": "1782919912177000000",
+              "timeUnixNano": "1782925534660000000",
+              "observedTimeUnixNano": "1782925534660000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -515,13 +515,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "F796B4B7A870217901C195BB9DCF95B1"
+                    "stringValue": "3A0493B9B725F8BA98D375288FF05F55"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
+                    "stringValue": "F4EE114BC7C859EB38309E308F5485EB"
                   }
                 },
                 {
@@ -533,7 +533,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
+                    "stringValue": "F4EE114BC7C859EB38309E308F5485EB"
                   }
                 },
                 {
@@ -545,7 +545,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "23B76FDA0F2D56FB0020BF2938EEEF8B"
+                    "stringValue": "8D40887E30EC698EE9911EAA055E6C71"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "EB15087BCE73EDDE1088FF0F1C8D0178"
+              "stringValue": "CA1F591EB5B3EB16038A28BB4BABAD19"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1366x768"
+              "stringValue": "1280x720"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782849207769000000",
-              "observedTimeUnixNano": "1782849207676000000",
+              "timeUnixNano": "1782919912136000000",
+              "observedTimeUnixNano": "1782919912026000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":3,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":5,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 4
+                    "intValue": 6
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 4
+                    "intValue": 6
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782849207661-1619419393616"
+                    "stringValue": "v5-1782919912011-7633238998653"
                   }
                 },
                 {
@@ -189,19 +189,19 @@
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 3
+                    "intValue": 5
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "66D83EFF9160214DFC5D06223E50EE23"
+                    "stringValue": "592040675B0E63A4F5118F55785065D6"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "4EA1DE63CF85EDF7C2BBDB37719F46D6"
+                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "4EA1DE63CF85EDF7C2BBDB37719F46D6"
+                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "184B953DE707B7C9E2ED7AD5B5810AA6"
+                    "stringValue": "23B76FDA0F2D56FB0020BF2938EEEF8B"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1782849207772000000",
-              "observedTimeUnixNano": "1782849207679000000",
+              "timeUnixNano": "1782919912140000000",
+              "observedTimeUnixNano": "1782919912029000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":4,\"firstByteToFCP\":91,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":6,\"firstByteToFCP\":104,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -261,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 95
+                    "intValue": 110
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 95
+                    "intValue": 110
                   }
                 },
                 {
@@ -279,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782849207661-4688392589676"
+                    "stringValue": "v5-1782919912011-5435778460789"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "BEC474657AFF33D76B6129D20AE954BD"
+                    "stringValue": "FF46097D10C8FBB6EAEF61490587515C"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "4EA1DE63CF85EDF7C2BBDB37719F46D6"
+                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "4EA1DE63CF85EDF7C2BBDB37719F46D6"
+                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
                   }
                 },
                 {
@@ -341,7 +341,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "184B953DE707B7C9E2ED7AD5B5810AA6"
+                    "stringValue": "23B76FDA0F2D56FB0020BF2938EEEF8B"
                   }
                 },
                 {
@@ -362,8 +362,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782849207934000000",
-              "observedTimeUnixNano": "1782849207842000000",
+              "timeUnixNano": "1782919912285000000",
+              "observedTimeUnixNano": "1782919912177000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -393,6 +393,12 @@
                   }
                 },
                 {
+                  "key": "first_interaction.time",
+                  "value": {
+                    "intValue": 264
+                  }
+                },
+                {
                   "key": "first_interaction.x",
                   "value": {
                     "intValue": 51
@@ -407,13 +413,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "052E0B92030EB66A36363E9532566C45"
+                    "stringValue": "373A60D2EBE2C85ABD2E42824B2D3718"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "4EA1DE63CF85EDF7C2BBDB37719F46D6"
+                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
                   }
                 },
                 {
@@ -425,7 +431,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "4EA1DE63CF85EDF7C2BBDB37719F46D6"
+                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
                   }
                 },
                 {
@@ -437,7 +443,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "184B953DE707B7C9E2ED7AD5B5810AA6"
+                    "stringValue": "23B76FDA0F2D56FB0020BF2938EEEF8B"
                   }
                 },
                 {
@@ -470,8 +476,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782849207843000000",
-              "observedTimeUnixNano": "1782849207843000000",
+              "timeUnixNano": "1782919912177000000",
+              "observedTimeUnixNano": "1782919912177000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -509,13 +515,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0C31AFC4AB711A476FD98CB6FB2A942B"
+                    "stringValue": "F796B4B7A870217901C195BB9DCF95B1"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "4EA1DE63CF85EDF7C2BBDB37719F46D6"
+                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
                   }
                 },
                 {
@@ -527,7 +533,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "4EA1DE63CF85EDF7C2BBDB37719F46D6"
+                    "stringValue": "B34A5FFBEB05540F856399B7AE6A2CAD"
                   }
                 },
                 {
@@ -539,7 +545,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "184B953DE707B7C9E2ED7AD5B5810AA6"
+                    "stringValue": "23B76FDA0F2D56FB0020BF2938EEEF8B"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "79C18D91A2084C420D26DCEEA01CC5ED"
+              "stringValue": "903498D73A822F8440F00EC016380763"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1280x720"
+              "stringValue": "1366x768"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782919240349000000",
-              "observedTimeUnixNano": "1782919240148000000",
+              "timeUnixNano": "1782925535339000000",
+              "observedTimeUnixNano": "1782925535246000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":74,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":2}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":4,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 76
+                    "intValue": 5
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 76
+                    "intValue": 5
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782919240136-6449336202062"
+                    "stringValue": "v5-1782925535225-4873129629233"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 2
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 74
+                    "intValue": 4
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "C4A73C91B8D43E6C28CC3CC4CDD1BAAA"
+                    "stringValue": "C5EDD1872F564BC24DE56B0E694923D0"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
+                    "stringValue": "F0A946EFC807F72B8A0240ABC3A4D5EF"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
+                    "stringValue": "F0A946EFC807F72B8A0240ABC3A4D5EF"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "48EDED4157663B02F8BC95DBDE945597"
+                    "stringValue": "76514DFCF05C4389A6CF4750465D2686"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1782919240351000000",
-              "observedTimeUnixNano": "1782919240150000000",
+              "timeUnixNano": "1782925535346000000",
+              "observedTimeUnixNano": "1782925535251000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":76,\"firstByteToFCP\":125,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":5,\"firstByteToFCP\":90,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -261,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 201
+                    "intValue": 95
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 201
+                    "intValue": 95
                   }
                 },
                 {
@@ -279,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782919240136-1618908767768"
+                    "stringValue": "v5-1782925535225-7755071630433"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "56648BDA71CF79774396297593110116"
+                    "stringValue": "5AE2E8C74054FB342670A884533135D3"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
+                    "stringValue": "F0A946EFC807F72B8A0240ABC3A4D5EF"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
+                    "stringValue": "F0A946EFC807F72B8A0240ABC3A4D5EF"
                   }
                 },
                 {
@@ -341,7 +341,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "48EDED4157663B02F8BC95DBDE945597"
+                    "stringValue": "76514DFCF05C4389A6CF4750465D2686"
                   }
                 },
                 {
@@ -362,8 +362,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782919240626000000",
-              "observedTimeUnixNano": "1782919240425000000",
+              "timeUnixNano": "1782925535548000000",
+              "observedTimeUnixNano": "1782925535457000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -395,7 +395,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 480
+                    "intValue": 312
                   }
                 },
                 {
@@ -413,13 +413,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "608753EBF05A525727304892352BEE92"
+                    "stringValue": "FB6A790A950C0A3CC16BCD7DFC52160A"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
+                    "stringValue": "F0A946EFC807F72B8A0240ABC3A4D5EF"
                   }
                 },
                 {
@@ -431,7 +431,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
+                    "stringValue": "F0A946EFC807F72B8A0240ABC3A4D5EF"
                   }
                 },
                 {
@@ -443,7 +443,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "48EDED4157663B02F8BC95DBDE945597"
+                    "stringValue": "76514DFCF05C4389A6CF4750465D2686"
                   }
                 },
                 {
@@ -475,8 +475,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782919240627000000",
-              "observedTimeUnixNano": "1782919240427000000",
+              "timeUnixNano": "1782925535552000000",
+              "observedTimeUnixNano": "1782925535457000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -510,13 +510,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "A9DF2D5834F2E99273CC3642374A3E05"
+                    "stringValue": "568DFE14F4A7E4667F6979C34FA7134E"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
+                    "stringValue": "F0A946EFC807F72B8A0240ABC3A4D5EF"
                   }
                 },
                 {
@@ -528,7 +528,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
+                    "stringValue": "F0A946EFC807F72B8A0240ABC3A4D5EF"
                   }
                 },
                 {
@@ -540,7 +540,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "48EDED4157663B02F8BC95DBDE945597"
+                    "stringValue": "76514DFCF05C4389A6CF4750465D2686"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "B9881124F96E4C84B5BF85C6A9FC1F93"
+              "stringValue": "79C18D91A2084C420D26DCEEA01CC5ED"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1366x768"
+              "stringValue": "1280x720"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782849208543000000",
-              "observedTimeUnixNano": "1782849208453000000",
+              "timeUnixNano": "1782919240349000000",
+              "observedTimeUnixNano": "1782919240148000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":6,\"dnsDuration\":1,\"connectionDuration\":0,\"requestDuration\":0}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":74,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":2}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 7
+                    "intValue": 76
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 7
+                    "intValue": 76
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782849208437-3963497405430"
+                    "stringValue": "v5-1782919240136-6449336202062"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 0
+                    "intValue": 2
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 7
+                    "intValue": 74
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "EDDD0A9B5825FCDBD1D1C921BF1D5CED"
+                    "stringValue": "C4A73C91B8D43E6C28CC3CC4CDD1BAAA"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "0F219E5C64D49A574B3C1C3A264F1551"
+                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "0F219E5C64D49A574B3C1C3A264F1551"
+                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "35F3B50A60AA02ACD96EE7A7EC93DF44"
+                    "stringValue": "48EDED4157663B02F8BC95DBDE945597"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1782849208546000000",
-              "observedTimeUnixNano": "1782849208457000000",
+              "timeUnixNano": "1782919240351000000",
+              "observedTimeUnixNano": "1782919240150000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":7,\"firstByteToFCP\":82,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":76,\"firstByteToFCP\":125,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -261,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 89
+                    "intValue": 201
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 89
+                    "intValue": 201
                   }
                 },
                 {
@@ -279,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1782849208437-2639266983378"
+                    "stringValue": "v5-1782919240136-1618908767768"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "A2A4B5FF9143F97835432DE5B7FDF25F"
+                    "stringValue": "56648BDA71CF79774396297593110116"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "0F219E5C64D49A574B3C1C3A264F1551"
+                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "0F219E5C64D49A574B3C1C3A264F1551"
+                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
                   }
                 },
                 {
@@ -341,7 +341,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "35F3B50A60AA02ACD96EE7A7EC93DF44"
+                    "stringValue": "48EDED4157663B02F8BC95DBDE945597"
                   }
                 },
                 {
@@ -362,8 +362,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782849208705000000",
-              "observedTimeUnixNano": "1782849208617000000",
+              "timeUnixNano": "1782919240626000000",
+              "observedTimeUnixNano": "1782919240425000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -393,6 +393,12 @@
                   }
                 },
                 {
+                  "key": "first_interaction.time",
+                  "value": {
+                    "intValue": 480
+                  }
+                },
+                {
                   "key": "first_interaction.x",
                   "value": {
                     "intValue": 130
@@ -407,13 +413,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0B0CCE6D279D12EEDB576B9710AF67CA"
+                    "stringValue": "608753EBF05A525727304892352BEE92"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "0F219E5C64D49A574B3C1C3A264F1551"
+                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
                   }
                 },
                 {
@@ -425,7 +431,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "0F219E5C64D49A574B3C1C3A264F1551"
+                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
                   }
                 },
                 {
@@ -437,7 +443,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "35F3B50A60AA02ACD96EE7A7EC93DF44"
+                    "stringValue": "48EDED4157663B02F8BC95DBDE945597"
                   }
                 },
                 {
@@ -469,8 +475,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1782849208707000000",
-              "observedTimeUnixNano": "1782849208618000000",
+              "timeUnixNano": "1782919240627000000",
+              "observedTimeUnixNano": "1782919240427000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -486,13 +492,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:100334\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:38002\nTM</Fr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:37543\nTM</bM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:242250\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:1:999\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:1:819\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:242224\nlm@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:127516\nTM</Uy/nc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:132570\nhd@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:15162\nnc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:128751\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:28582\n_y@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:28402\nEventListener.handleEvent*um@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:128312\ntc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:127712\nTM</Uy/ec/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:127878\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:8:127823\nTM</Uy/Ur.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:36449\nTM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:242835\nAy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:9:242889\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:100334\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:38002\nvM</Fr/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:37543\nvM</yM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242325\nUt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:966\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:786\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242299\nlm@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127516\nvM</Uy/nc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:132570\nhd@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:15162\nnc@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:128751\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:28582\n_y@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:28402\nEventListener.handleEvent*um@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:128312\ntc@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127712\nvM</Uy/ec/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127878\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127823\nvM</Uy/Ur.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:36449\nvM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242910\nAy/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:680\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242964\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js:11:126\\n\":\"74143846598ffa972572173bdfed9c1b\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:126\\n\":\"8ad5455d6272b4b18a20538605d0249b\"}"
                   }
                 },
                 {
@@ -504,13 +510,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0BFAB6C70755A61B460430166D34F140"
+                    "stringValue": "A9DF2D5834F2E99273CC3642374A3E05"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "0F219E5C64D49A574B3C1C3A264F1551"
+                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
                   }
                 },
                 {
@@ -522,7 +528,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "0F219E5C64D49A574B3C1C3A264F1551"
+                    "stringValue": "74C4715CE3D41401F2CFD6DF6A6FE141"
                   }
                 },
                 {
@@ -534,7 +540,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "35F3B50A60AA02ACD96EE7A7EC93DF44"
+                    "stringValue": "48EDED4157663B02F8BC95DBDE945597"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "EB15087BCE73EDDE1088FF0F1C8D0178"
+              "stringValue": "37FF387C1A3115BD3FB75E35A073F270"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1366x768"
+              "stringValue": "1280x720"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "99a4c3231c1c433e47f2a4ca40d2ce28",
-              "spanId": "a5e0e3d6286b72d3",
+              "traceId": "1ae577c279a3c9f14086246a11a6bf87",
+              "spanId": "8aecc4000ad3cf8d",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1782849207659000000",
-              "endTimeUnixNano": "1782849207936000000",
+              "startTimeUnixNano": "1782919239061000000",
+              "endTimeUnixNano": "1782919239484000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "4EA1DE63CF85EDF7C2BBDB37719F46D6"
+                    "stringValue": "B20D5636CF4067336F53CBD72E3D74E3"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "4EA1DE63CF85EDF7C2BBDB37719F46D6"
+                    "stringValue": "B20D5636CF4067336F53CBD72E3D74E3"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1782849207658
+                    "intValue": 1782919239060
                   }
                 },
                 {
@@ -173,7 +173,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "184B953DE707B7C9E2ED7AD5B5810AA6"
+                    "stringValue": "9D0A9E3CEC998182BA414123027C5BDB"
                   }
                 },
                 {
@@ -197,7 +197,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 12
+                    "intValue": 9
                   }
                 },
                 {
@@ -250,13 +250,13 @@
           },
           "spans": [
             {
-              "traceId": "2c271f173dd126fc6c3885851a4312d8",
-              "spanId": "986c982131a4b83d",
-              "parentSpanId": "ca7df295504a0a07",
+              "traceId": "667f759fe88fd893990dca91ccf4e3e1",
+              "spanId": "c163f90fad7ae993",
+              "parentSpanId": "5c65b575f4cb36a3",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782849207579000000",
-              "endTimeUnixNano": "1782849207583000000",
+              "startTimeUnixNano": "1782919238945000000",
+              "endTimeUnixNano": "1782919238949000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -288,55 +288,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849207579000000",
+                  "timeUnixNano": "1782919238945000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782849207582000000",
+                  "timeUnixNano": "1782919238948000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782849207582000000",
+                  "timeUnixNano": "1782919238948000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782849207582000000",
+                  "timeUnixNano": "1782919238948000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1782849207579000000",
+                  "timeUnixNano": "1782919238965000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782849207582000000",
+                  "timeUnixNano": "1782919238948000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782849207582000000",
+                  "timeUnixNano": "1782919238948000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782849207583000000",
+                  "timeUnixNano": "1782919238949000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782849207583000000",
+                  "timeUnixNano": "1782919238949000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -349,13 +349,13 @@
               "flags": 257
             },
             {
-              "traceId": "2c271f173dd126fc6c3885851a4312d8",
-              "spanId": "f9c0c6ea565d8655",
-              "parentSpanId": "ca7df295504a0a07",
+              "traceId": "667f759fe88fd893990dca91ccf4e3e1",
+              "spanId": "10e0deebeb049e41",
+              "parentSpanId": "5c65b575f4cb36a3",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782849207588000000",
-              "endTimeUnixNano": "1782849207605000000",
+              "startTimeUnixNano": "1782919238983000000",
+              "endTimeUnixNano": "1782919239030000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -366,13 +366,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 400404
+                    "intValue": 400446
                   }
                 },
                 {
@@ -390,19 +390,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 400404
+                    "intValue": 400446
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 400704
+                    "intValue": 400746
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 400404
+                    "intValue": 400446
                   }
                 },
                 {
@@ -423,49 +423,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849207588000000",
+                  "timeUnixNano": "1782919238983000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782849207588000000",
+                  "timeUnixNano": "1782919238983000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782849207588000000",
+                  "timeUnixNano": "1782919238983000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782849207588000000",
+                  "timeUnixNano": "1782919238983000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782849207588000000",
+                  "timeUnixNano": "1782919238983000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782849207604000000",
+                  "timeUnixNano": "1782919239029000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782849207605000000",
+                  "timeUnixNano": "1782919239030000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782849207605000000",
+                  "timeUnixNano": "1782919239030000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -478,12 +478,12 @@
               "flags": 257
             },
             {
-              "traceId": "2c271f173dd126fc6c3885851a4312d8",
-              "spanId": "ca7df295504a0a07",
+              "traceId": "667f759fe88fd893990dca91ccf4e3e1",
+              "spanId": "5c65b575f4cb36a3",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1782849207579000000",
-              "endTimeUnixNano": "1782849207673000000",
+              "startTimeUnixNano": "1782919238945000000",
+              "endTimeUnixNano": "1782919239071000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -500,7 +500,7 @@
                 {
                   "key": "user_agent.original",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
                   }
                 },
                 {
@@ -520,44 +520,50 @@
               "events": [
                 {
                   "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1782919238945000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1782849207590000000",
+                  "timeUnixNano": "1782919238984000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1782849207666000000",
+                  "timeUnixNano": "1782919239066000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1782849207667000000",
+                  "timeUnixNano": "1782919239067000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1782849207673000000",
+                  "timeUnixNano": "1782919239071000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1782849207673000000",
+                  "timeUnixNano": "1782919239071000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1782849207673000000",
+                  "timeUnixNano": "1782919239071000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "firstContentfulPaint",
-                  "timeUnixNano": "1782849207674000000",
+                  "timeUnixNano": "1782919239072000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
@@ -54,19 +54,19 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "37FF387C1A3115BD3FB75E35A073F270"
+              "stringValue": "3E904858BE79A180A256D96C15092A43"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
             }
           },
           {
             "key": "screen_resolution",
             "value": {
-              "stringValue": "1280x720"
+              "stringValue": "1366x768"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "1ae577c279a3c9f14086246a11a6bf87",
-              "spanId": "8aecc4000ad3cf8d",
+              "traceId": "1c0a95b35ba2841f46bbce5a38c5f03e",
+              "spanId": "d06218024c30f0c9",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1782919239061000000",
-              "endTimeUnixNano": "1782919239484000000",
+              "startTimeUnixNano": "1782925534432000000",
+              "endTimeUnixNano": "1782925534774000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B20D5636CF4067336F53CBD72E3D74E3"
+                    "stringValue": "F4EE114BC7C859EB38309E308F5485EB"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B20D5636CF4067336F53CBD72E3D74E3"
+                    "stringValue": "F4EE114BC7C859EB38309E308F5485EB"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1782919239060
+                    "intValue": 1782925534430
                   }
                 },
                 {
@@ -173,7 +173,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "9D0A9E3CEC998182BA414123027C5BDB"
+                    "stringValue": "8D40887E30EC698EE9911EAA055E6C71"
                   }
                 },
                 {
@@ -197,7 +197,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 9
+                    "intValue": 13
                   }
                 },
                 {
@@ -250,13 +250,13 @@
           },
           "spans": [
             {
-              "traceId": "667f759fe88fd893990dca91ccf4e3e1",
-              "spanId": "c163f90fad7ae993",
-              "parentSpanId": "5c65b575f4cb36a3",
+              "traceId": "c8feb387fc8bb1118d4f3c812d8bb5cb",
+              "spanId": "99917beb95d64569",
+              "parentSpanId": "a9e99ec371b60b28",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782919238945000000",
-              "endTimeUnixNano": "1782919238949000000",
+              "startTimeUnixNano": "1782925534344000000",
+              "endTimeUnixNano": "1782925534352000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -288,55 +288,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919238945000000",
+                  "timeUnixNano": "1782925534344000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782919238948000000",
+                  "timeUnixNano": "1782925534351000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782919238948000000",
+                  "timeUnixNano": "1782925534351000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782919238948000000",
+                  "timeUnixNano": "1782925534351000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1782919238965000000",
+                  "timeUnixNano": "1782925534344000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782919238948000000",
+                  "timeUnixNano": "1782925534351000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782919238948000000",
+                  "timeUnixNano": "1782925534352000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782919238949000000",
+                  "timeUnixNano": "1782925534352000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782919238949000000",
+                  "timeUnixNano": "1782925534352000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -349,13 +349,13 @@
               "flags": 257
             },
             {
-              "traceId": "667f759fe88fd893990dca91ccf4e3e1",
-              "spanId": "10e0deebeb049e41",
-              "parentSpanId": "5c65b575f4cb36a3",
+              "traceId": "c8feb387fc8bb1118d4f3c812d8bb5cb",
+              "spanId": "cdeed03ddee170ee",
+              "parentSpanId": "a9e99ec371b60b28",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782919238983000000",
-              "endTimeUnixNano": "1782919239030000000",
+              "startTimeUnixNano": "1782925534381000000",
+              "endTimeUnixNano": "1782925534399000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -423,49 +423,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919238983000000",
+                  "timeUnixNano": "1782925534381000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782919238983000000",
+                  "timeUnixNano": "1782925534381000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782919238983000000",
+                  "timeUnixNano": "1782925534381000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782919238983000000",
+                  "timeUnixNano": "1782925534381000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782919238983000000",
+                  "timeUnixNano": "1782925534381000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782919239029000000",
+                  "timeUnixNano": "1782925534399000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782919239030000000",
+                  "timeUnixNano": "1782925534399000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782919239030000000",
+                  "timeUnixNano": "1782925534399000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -478,12 +478,12 @@
               "flags": 257
             },
             {
-              "traceId": "667f759fe88fd893990dca91ccf4e3e1",
-              "spanId": "5c65b575f4cb36a3",
+              "traceId": "c8feb387fc8bb1118d4f3c812d8bb5cb",
+              "spanId": "a9e99ec371b60b28",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1782919238945000000",
-              "endTimeUnixNano": "1782919239071000000",
+              "startTimeUnixNano": "1782925534344000000",
+              "endTimeUnixNano": "1782925534459000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -500,7 +500,7 @@
                 {
                   "key": "user_agent.original",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0.2) Gecko/20100101 Firefox/150.0.2"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
                   }
                 },
                 {
@@ -520,50 +520,44 @@
               "events": [
                 {
                   "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1782919238945000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1782919238984000000",
+                  "timeUnixNano": "1782925534382000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1782919239066000000",
+                  "timeUnixNano": "1782925534443000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1782919239067000000",
+                  "timeUnixNano": "1782925534449000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1782919239071000000",
+                  "timeUnixNano": "1782925534459000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1782919239071000000",
+                  "timeUnixNano": "1782925534459000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1782919239071000000",
+                  "timeUnixNano": "1782925534459000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "firstContentfulPaint",
-                  "timeUnixNano": "1782919239072000000",
+                  "timeUnixNano": "1782925534460000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "A7508E7057A6D47659FF078E2414029E"
+              "stringValue": "0AA1C308EA48BF822B352E6402F2F510"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1780486687128000000",
-              "observedTimeUnixNano": "1780486687107000000",
+              "timeUnixNano": "1782919273577000000",
+              "observedTimeUnixNano": "1782919273549000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":0}"
+                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":2}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 1
+                    "intValue": 3
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 1
+                    "intValue": 3
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1780486687105-1412407026087"
+                    "stringValue": "v5-1782919273546-2642378919799"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 0
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 1
+                    "intValue": 2
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "9DAD518649FCA92FD8287F3EE742EE15"
+                    "stringValue": "10B68CCB2C0A0209EC55E8DBB0B81141"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "400182366B84C28142F768F4D6DB14A9"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "400182366B84C28142F768F4D6DB14A9"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "163AA46F45C18B5BD58A7D104FADC47D"
+                    "stringValue": "3CB7DEE76C09F81745E2A2C64CC490FB"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1780486687134000000",
-              "observedTimeUnixNano": "1780486687114000000",
+              "timeUnixNano": "1782919273586000000",
+              "observedTimeUnixNano": "1782919273558000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":1,\"firstByteToFCP\":27,\"loadState\":\"dom-interactive\"}"
+                "stringValue": "{\"timeToFirstByte\":3,\"firstByteToFCP\":34,\"loadState\":\"dom-interactive\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -261,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 28
+                    "intValue": 37
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 28
+                    "intValue": 37
                   }
                 },
                 {
@@ -279,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1780486687105-2107150101542"
+                    "stringValue": "v5-1782919273546-5129510329188"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "DB5083A7357B22F073FA4C8DDF28BF55"
+                    "stringValue": "60A7A496627D99A93CE1C5A4919BE1E2"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "400182366B84C28142F768F4D6DB14A9"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "400182366B84C28142F768F4D6DB14A9"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
@@ -341,7 +341,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "163AA46F45C18B5BD58A7D104FADC47D"
+                    "stringValue": "3CB7DEE76C09F81745E2A2C64CC490FB"
                   }
                 },
                 {
@@ -354,11 +354,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1780486687261000000",
-              "observedTimeUnixNano": "1780486687240000000",
+              "timeUnixNano": "1782919273721000000",
+              "observedTimeUnixNano": "1782919273693000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":1,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":27,\"target\":\"#root>h1\"}"
+                "stringValue": "{\"timeToFirstByte\":3,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":34,\"target\":\"#root>h1\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -377,13 +377,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 28
+                    "intValue": 37
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 28
+                    "intValue": 37
                   }
                 },
                 {
@@ -395,7 +395,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1780486687105-1777043032439"
+                    "stringValue": "v5-1782919273546-6632317092660"
                   }
                 },
                 {
@@ -427,13 +427,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "FEA689DD7D334B1B0520C8879DCFBE51"
+                    "stringValue": "F6C265019111413FEBAFE66AC47D248B"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "400182366B84C28142F768F4D6DB14A9"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
@@ -445,7 +445,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "400182366B84C28142F768F4D6DB14A9"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
@@ -457,7 +457,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "163AA46F45C18B5BD58A7D104FADC47D"
+                    "stringValue": "3CB7DEE76C09F81745E2A2C64CC490FB"
                   }
                 },
                 {
@@ -478,8 +478,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "2582187242865000000",
-              "observedTimeUnixNano": "1780486687239000000",
+              "timeUnixNano": "2586228395320000000",
+              "observedTimeUnixNano": "1782919273692000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -509,6 +509,12 @@
                   }
                 },
                 {
+                  "key": "first_interaction.time",
+                  "value": {
+                    "doubleValue": 803309121772.0001
+                  }
+                },
+                {
                   "key": "first_interaction.x",
                   "value": {
                     "intValue": 364
@@ -523,13 +529,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "510F9666EAA36C745B4BD6F51E1EE25B"
+                    "stringValue": "D336F2E45A954773EC764E25D471F5AB"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "400182366B84C28142F768F4D6DB14A9"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
@@ -541,7 +547,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "400182366B84C28142F768F4D6DB14A9"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
@@ -553,7 +559,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "163AA46F45C18B5BD58A7D104FADC47D"
+                    "stringValue": "3CB7DEE76C09F81745E2A2C64CC490FB"
                   }
                 },
                 {
@@ -585,8 +591,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1780486687679000000",
-              "observedTimeUnixNano": "1780486687658000000",
+              "timeUnixNano": "1782919274158000000",
+              "observedTimeUnixNano": "1782919274130000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -602,13 +608,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:98892\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:38009\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:37548\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:237129\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:1:797\nag@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:8:127516\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:8:132570\ncd@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:8:128751\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:28582\niy@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:28404"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:100343\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:38009\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:37548\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242332\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:797\nlm@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127516\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:132570\nhd@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:15162\nnc@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:128751\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:28582\n_y@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:28404"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:11:126\":\"186c7210976877b22d7d13d27d4adcb4\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:126\":\"8ad5455d6272b4b18a20538605d0249b\"}"
                   }
                 },
                 {
@@ -620,13 +626,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "AF8A522808CEECE5EC86C55254FB15F0"
+                    "stringValue": "D21F22F49E7302A403360D46D15E2A6C"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "400182366B84C28142F768F4D6DB14A9"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
@@ -638,7 +644,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "400182366B84C28142F768F4D6DB14A9"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
@@ -650,7 +656,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "163AA46F45C18B5BD58A7D104FADC47D"
+                    "stringValue": "3CB7DEE76C09F81745E2A2C64CC490FB"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "0AA1C308EA48BF822B352E6402F2F510"
+              "stringValue": "4534747E87F60607984F2FA44E2D73F2"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Safari/605.1.15"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "2b0817067a0f1c8e7156cb4c6b824cfe",
-              "spanId": "0a4bfa230daffac4",
+              "traceId": "c1dd925705106f373ec7c3d51bd89a1d",
+              "spanId": "358c7a74c0d851d5",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1782919273544000000",
-              "endTimeUnixNano": "1782919274208000000",
+              "startTimeUnixNano": "1782925569802000000",
+              "endTimeUnixNano": "1782925570591000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
+                    "stringValue": "4E3CDF902890477EC19051C75A8108C5"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
+                    "stringValue": "4E3CDF902890477EC19051C75A8108C5"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1782919273544
+                    "intValue": 1782925569800
                   }
                 },
                 {
@@ -173,7 +173,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "3CB7DEE76C09F81745E2A2C64CC490FB"
+                    "stringValue": "22970E9C76F068E1B725F428FD1122D6"
                   }
                 },
                 {
@@ -197,7 +197,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 6
+                    "intValue": 20
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "2586228395320000000",
+                  "timeUnixNano": "1782925570077000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "2586228395758000000",
+                  "timeUnixNano": "1782925570516000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "6709761ad738251ad31f3f50e579bcde",
-              "spanId": "9b0d40754f4699bf",
-              "parentSpanId": "72204166e1d4dd11",
+              "traceId": "c2571604953bfd04efdc060242a71feb",
+              "spanId": "addd7235b4535874",
+              "parentSpanId": "ce3248d601d0d710",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782919273521000000",
-              "endTimeUnixNano": "1782919273523000000",
+              "startTimeUnixNano": "1782925569740000000",
+              "endTimeUnixNano": "1782925569753000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -345,55 +345,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919273521000000",
+                  "timeUnixNano": "1782925569740000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782919273521000000",
+                  "timeUnixNano": "1782925569740000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782919273521000000",
+                  "timeUnixNano": "1782925569740000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782919273521000000",
+                  "timeUnixNano": "1782925569740000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1782919273520000000",
+                  "timeUnixNano": "1782925569736000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782919273521000000",
+                  "timeUnixNano": "1782925569740000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782919273522000000",
+                  "timeUnixNano": "1782925569742000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782919273523000000",
+                  "timeUnixNano": "1782925569753000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782919273523000000",
+                  "timeUnixNano": "1782925569753000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -406,13 +406,13 @@
               "flags": 257
             },
             {
-              "traceId": "6709761ad738251ad31f3f50e579bcde",
-              "spanId": "e4aa4eab8ec448f9",
-              "parentSpanId": "72204166e1d4dd11",
+              "traceId": "c2571604953bfd04efdc060242a71feb",
+              "spanId": "3ca8b06b8681ad8e",
+              "parentSpanId": "ce3248d601d0d710",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782919273527000000",
-              "endTimeUnixNano": "1782919273529000000",
+              "startTimeUnixNano": "1782925569762000000",
+              "endTimeUnixNano": "1782925569769000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -480,49 +480,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919273527000000",
+                  "timeUnixNano": "1782925569762000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782919273527000000",
+                  "timeUnixNano": "1782925569762000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782919273527000000",
+                  "timeUnixNano": "1782925569762000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782919273527000000",
+                  "timeUnixNano": "1782925569762000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782919273527000000",
+                  "timeUnixNano": "1782925569762000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782919273528000000",
+                  "timeUnixNano": "1782925569764000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782919273528000000",
+                  "timeUnixNano": "1782925569767000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782919273529000000",
+                  "timeUnixNano": "1782925569769000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -535,12 +535,12 @@
               "flags": 257
             },
             {
-              "traceId": "6709761ad738251ad31f3f50e579bcde",
-              "spanId": "72204166e1d4dd11",
+              "traceId": "c2571604953bfd04efdc060242a71feb",
+              "spanId": "ce3248d601d0d710",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1782919273521000000",
-              "endTimeUnixNano": "1782919273548000000",
+              "startTimeUnixNano": "1782925569740000000",
+              "endTimeUnixNano": "1782925569807000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -557,7 +557,7 @@
                 {
                   "key": "user_agent.original",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Safari/605.1.15"
+                    "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15"
                   }
                 },
                 {
@@ -578,19 +578,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919273521000000",
+                  "timeUnixNano": "1782925569740000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domInteractive",
+                  "timeUnixNano": "1782925569757000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domContentLoadedEventStart",
+                  "timeUnixNano": "1782925569807000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domContentLoadedEventEnd",
+                  "timeUnixNano": "1782925569807000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domComplete",
+                  "timeUnixNano": "1782925569807000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1782919273548000000",
+                  "timeUnixNano": "1782925569807000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1782919273548000000",
+                  "timeUnixNano": "1782925569807000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -611,12 +635,12 @@
           },
           "spans": [
             {
-              "traceId": "d92c980086ce535f9d2bb37a97b73130",
-              "spanId": "6d9ebc51714dbeb2",
+              "traceId": "d0f602a01fa209c0026944907e9eb3fc",
+              "spanId": "96f6adbcd65a51f3",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1782919273693000000",
-              "endTimeUnixNano": "1782919273696000000",
+              "startTimeUnixNano": "1782925570018000000",
+              "endTimeUnixNano": "1782925570022000000",
               "attributes": [
                 {
                   "key": "component",
@@ -663,7 +687,7 @@
                 {
                   "key": "http.user_agent",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Safari/605.1.15"
+                    "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15"
                   }
                 },
                 {
@@ -724,43 +748,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782919273694000000",
+                  "timeUnixNano": "1782925570018000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782919273694000000",
+                  "timeUnixNano": "1782925570018000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782919273694000000",
+                  "timeUnixNano": "1782925570018000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782919273694000000",
+                  "timeUnixNano": "1782925570018000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782919273694000000",
+                  "timeUnixNano": "1782925570018000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782919273694000000",
+                  "timeUnixNano": "1782925570018000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782919273696000000",
+                  "timeUnixNano": "1782925570021000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "8AB50558D988265458BBA69C4D3028D0"
+              "stringValue": "0AA1C308EA48BF822B352E6402F2F510"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15"
+              "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Safari/605.1.15"
             }
           },
           {
@@ -85,23 +85,23 @@
           },
           "spans": [
             {
-              "traceId": "ebd89477eff8f83798cfb5a8d7f079f7",
-              "spanId": "545913dcd7b97fd6",
+              "traceId": "2b0817067a0f1c8e7156cb4c6b824cfe",
+              "spanId": "0a4bfa230daffac4",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1782849236438000000",
-              "endTimeUnixNano": "1782849237131000000",
+              "startTimeUnixNano": "1782919273544000000",
+              "endTimeUnixNano": "1782919274208000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "9EA7B77CBE12E85F7B293E8DD44795AE"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "9EA7B77CBE12E85F7B293E8DD44795AE"
+                    "stringValue": "7D6F18B6C461992308A9A449C6E53905"
                   }
                 },
                 {
@@ -137,7 +137,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1782849236437
+                    "intValue": 1782919273544
                   }
                 },
                 {
@@ -173,7 +173,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "1E32A0247A54D273D0E5F7D983194299"
+                    "stringValue": "3CB7DEE76C09F81745E2A2C64CC490FB"
                   }
                 },
                 {
@@ -197,7 +197,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 10
+                    "intValue": 6
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1782849236612000000",
+                  "timeUnixNano": "2586228395320000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1782849237062000000",
+                  "timeUnixNano": "2586228395758000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "5479a8f675c5e8ace5d52806340772e4",
-              "spanId": "c18e41ff145b6ec5",
-              "parentSpanId": "f4261eef26090361",
+              "traceId": "6709761ad738251ad31f3f50e579bcde",
+              "spanId": "9b0d40754f4699bf",
+              "parentSpanId": "72204166e1d4dd11",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782849236407000000",
-              "endTimeUnixNano": "1782849236409000000",
+              "startTimeUnixNano": "1782919273521000000",
+              "endTimeUnixNano": "1782919273523000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -345,55 +345,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849236407000000",
+                  "timeUnixNano": "1782919273521000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782849236407000000",
+                  "timeUnixNano": "1782919273521000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782849236407000000",
+                  "timeUnixNano": "1782919273521000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782849236407000000",
+                  "timeUnixNano": "1782919273521000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1782849236406000000",
+                  "timeUnixNano": "1782919273520000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782849236407000000",
+                  "timeUnixNano": "1782919273521000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782849236408000000",
+                  "timeUnixNano": "1782919273522000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782849236408000000",
+                  "timeUnixNano": "1782919273523000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782849236409000000",
+                  "timeUnixNano": "1782919273523000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -406,13 +406,13 @@
               "flags": 257
             },
             {
-              "traceId": "5479a8f675c5e8ace5d52806340772e4",
-              "spanId": "e37a066bff09f185",
-              "parentSpanId": "f4261eef26090361",
+              "traceId": "6709761ad738251ad31f3f50e579bcde",
+              "spanId": "e4aa4eab8ec448f9",
+              "parentSpanId": "72204166e1d4dd11",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1782849236413000000",
-              "endTimeUnixNano": "1782849236414000000",
+              "startTimeUnixNano": "1782919273527000000",
+              "endTimeUnixNano": "1782919273529000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -423,19 +423,19 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DPnyDkpy.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 400416
+                    "intValue": 400458
                   }
                 },
                 {
                   "key": "http.response_content_length_uncompressed",
                   "value": {
-                    "intValue": 400404
+                    "intValue": 400446
                   }
                 },
                 {
@@ -447,19 +447,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 400416
+                    "intValue": 400458
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 400716
+                    "intValue": 400758
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 400404
+                    "intValue": 400446
                   }
                 },
                 {
@@ -480,49 +480,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849236413000000",
+                  "timeUnixNano": "1782919273527000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782849236413000000",
+                  "timeUnixNano": "1782919273527000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782849236413000000",
+                  "timeUnixNano": "1782919273527000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782849236413000000",
+                  "timeUnixNano": "1782919273527000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782849236413000000",
+                  "timeUnixNano": "1782919273527000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782849236414000000",
+                  "timeUnixNano": "1782919273528000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1782849236414000000",
+                  "timeUnixNano": "1782919273528000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782849236414000000",
+                  "timeUnixNano": "1782919273529000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -535,12 +535,12 @@
               "flags": 257
             },
             {
-              "traceId": "5479a8f675c5e8ace5d52806340772e4",
-              "spanId": "f4261eef26090361",
+              "traceId": "6709761ad738251ad31f3f50e579bcde",
+              "spanId": "72204166e1d4dd11",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1782849236407000000",
-              "endTimeUnixNano": "1782849236444000000",
+              "startTimeUnixNano": "1782919273521000000",
+              "endTimeUnixNano": "1782919273548000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -557,7 +557,7 @@
                 {
                   "key": "user_agent.original",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15"
+                    "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Safari/605.1.15"
                   }
                 },
                 {
@@ -578,43 +578,19 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849236407000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domInteractive",
-                  "timeUnixNano": "1782849236412000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1782849236443000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1782849236443000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domComplete",
-                  "timeUnixNano": "1782849236443000000",
+                  "timeUnixNano": "1782919273521000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1782849236443000000",
+                  "timeUnixNano": "1782919273548000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1782849236444000000",
+                  "timeUnixNano": "1782919273548000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -635,12 +611,12 @@
           },
           "spans": [
             {
-              "traceId": "3b01c3441c6489b5d51978d427566df4",
-              "spanId": "2b6fa16a14019bd5",
+              "traceId": "d92c980086ce535f9d2bb37a97b73130",
+              "spanId": "6d9ebc51714dbeb2",
               "name": "HTTP GET",
               "kind": 3,
-              "startTimeUnixNano": "1782849236579000000",
-              "endTimeUnixNano": "1782849236582000000",
+              "startTimeUnixNano": "1782919273693000000",
+              "endTimeUnixNano": "1782919273696000000",
               "attributes": [
                 {
                   "key": "component",
@@ -687,7 +663,7 @@
                 {
                   "key": "http.user_agent",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15"
+                    "stringValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Safari/605.1.15"
                   }
                 },
                 {
@@ -748,43 +724,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1782849236580000000",
+                  "timeUnixNano": "1782919273694000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1782849236580000000",
+                  "timeUnixNano": "1782919273694000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1782849236580000000",
+                  "timeUnixNano": "1782919273694000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1782849236580000000",
+                  "timeUnixNano": "1782919273694000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1782849236580000000",
+                  "timeUnixNano": "1782919273694000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1782849236580000000",
+                  "timeUnixNano": "1782919273694000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1782849236581000000",
+                  "timeUnixNano": "1782919273696000000",
                   "droppedAttributesCount": 0
                 }
               ],

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "5172864E809D69B9A52F58A073406869"
+              "stringValue": "5854073E3D5EB49AFF2630E2C25B1470"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1781898518217000000",
-              "observedTimeUnixNano": "1781898518186000000",
+              "timeUnixNano": "1782919267052000000",
+              "observedTimeUnixNano": "1782919266980000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
+                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":5}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 2
+                    "intValue": 6
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 2
+                    "intValue": 6
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1781898518183-9921286551038"
+                    "stringValue": "v5-1782919266973-4378270513546"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 0
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 3
+                    "intValue": 5
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "03B06A1DC81E4087C5AC7F7EE7D2016B"
+                    "stringValue": "C077F11386779146FB51ED680D3C8A89"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5F9AE989F10D8436A854D23722B6F13C"
+                    "stringValue": "5008C6F6D0270019B3B94874E0E02FA9"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5F9AE989F10D8436A854D23722B6F13C"
+                    "stringValue": "5008C6F6D0270019B3B94874E0E02FA9"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E0AFF4EF513F116563FD52E79870515C"
+                    "stringValue": "B4D79438F0FF0F674E9B94240F9B5EAC"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1781898518224000000",
-              "observedTimeUnixNano": "1781898518192000000",
+              "timeUnixNano": "1782919267071000000",
+              "observedTimeUnixNano": "1782919266998000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":36,\"loadState\":\"dom-interactive\"}"
+                "stringValue": "{\"timeToFirstByte\":6,\"firstByteToFCP\":85,\"loadState\":\"dom-interactive\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -261,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 38
+                    "intValue": 91
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 38
+                    "intValue": 91
                   }
                 },
                 {
@@ -279,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1781898518183-4256891485903"
+                    "stringValue": "v5-1782919266973-9656205886978"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "73871441A6990A3994C8906724506DD6"
+                    "stringValue": "958E9F40D57B194267C34EEAFAC8DD1C"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5F9AE989F10D8436A854D23722B6F13C"
+                    "stringValue": "5008C6F6D0270019B3B94874E0E02FA9"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5F9AE989F10D8436A854D23722B6F13C"
+                    "stringValue": "5008C6F6D0270019B3B94874E0E02FA9"
                   }
                 },
                 {
@@ -341,7 +341,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E0AFF4EF513F116563FD52E79870515C"
+                    "stringValue": "B4D79438F0FF0F674E9B94240F9B5EAC"
                   }
                 },
                 {
@@ -362,8 +362,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "2584340792615000000",
-              "observedTimeUnixNano": "1781898518329000000",
+              "timeUnixNano": "2586228388915000000",
+              "observedTimeUnixNano": "1782919267252000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -393,6 +393,12 @@
                   }
                 },
                 {
+                  "key": "first_interaction.time",
+                  "value": {
+                    "intValue": 803309121937
+                  }
+                },
+                {
                   "key": "first_interaction.x",
                   "value": {
                     "intValue": 47
@@ -407,13 +413,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "62C5EEA9754E0E5EB07875490DC7769D"
+                    "stringValue": "5600908860DFB76E40598A0FD8DF9D06"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5F9AE989F10D8436A854D23722B6F13C"
+                    "stringValue": "5008C6F6D0270019B3B94874E0E02FA9"
                   }
                 },
                 {
@@ -425,7 +431,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5F9AE989F10D8436A854D23722B6F13C"
+                    "stringValue": "5008C6F6D0270019B3B94874E0E02FA9"
                   }
                 },
                 {
@@ -437,7 +443,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E0AFF4EF513F116563FD52E79870515C"
+                    "stringValue": "B4D79438F0FF0F674E9B94240F9B5EAC"
                   }
                 },
                 {
@@ -470,8 +476,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1781898518329000000",
-              "observedTimeUnixNano": "1781898518329000000",
+              "timeUnixNano": "1782919267253000000",
+              "observedTimeUnixNano": "1782919267253000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -509,13 +515,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0A012D3B97DEB2B8379AFB6E75522095"
+                    "stringValue": "00527AAA619EADBCC99EA0698FC4C3E1"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5F9AE989F10D8436A854D23722B6F13C"
+                    "stringValue": "5008C6F6D0270019B3B94874E0E02FA9"
                   }
                 },
                 {
@@ -527,7 +533,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5F9AE989F10D8436A854D23722B6F13C"
+                    "stringValue": "5008C6F6D0270019B3B94874E0E02FA9"
                   }
                 },
                 {
@@ -539,7 +545,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E0AFF4EF513F116563FD52E79870515C"
+                    "stringValue": "B4D79438F0FF0F674E9B94240F9B5EAC"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "566184B8ED1145B578BC8648F8D2EB15"
+              "stringValue": "48BC2F27C96019DE35B58D7B9303AEA3"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1780486684052000000",
-              "observedTimeUnixNano": "1780486684002000000",
+              "timeUnixNano": "1782919268186000000",
+              "observedTimeUnixNano": "1782919268089000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":3,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
+                "stringValue": "{\"waitingDuration\":12,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":25}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 4
+                    "intValue": 37
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 4
+                    "intValue": 37
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1780486683994-9924182255162"
+                    "stringValue": "v5-1782919268080-4539245401283"
                   }
                 },
                 {
@@ -183,25 +183,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 1
+                    "intValue": 21
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 3
+                    "intValue": 16
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "6424BCA94208F70D59C3AC8163729FA4"
+                    "stringValue": "EDF4F52514807B01EC663303B8B224B5"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "1F1606DE317C9DAF5739B1E80B7993CA"
+                    "stringValue": "4FC8339533E07AD9C49BA5C72F3FD963"
                   }
                 },
                 {
@@ -213,7 +213,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "1F1606DE317C9DAF5739B1E80B7993CA"
+                    "stringValue": "4FC8339533E07AD9C49BA5C72F3FD963"
                   }
                 },
                 {
@@ -225,7 +225,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "CC8B1D3C0CA14160E51869E4803C79CD"
+                    "stringValue": "3E9A2B9F3647B9F7E49F7FDF9B85FDAB"
                   }
                 },
                 {
@@ -238,11 +238,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1780486684062000000",
-              "observedTimeUnixNano": "1780486684012000000",
+              "timeUnixNano": "1782919268195000000",
+              "observedTimeUnixNano": "1782919268098000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":4,\"firstByteToFCP\":55.00000000000001,\"loadState\":\"dom-interactive\"}"
+                "stringValue": "{\"timeToFirstByte\":37,\"firstByteToFCP\":74,\"loadState\":\"dom-interactive\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -261,13 +261,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 59.00000000000001
+                    "intValue": 111
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 59.00000000000001
+                    "intValue": 111
                   }
                 },
                 {
@@ -279,7 +279,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v5-1780486683993-5671384261256"
+                    "stringValue": "v5-1782919268080-7502820420285"
                   }
                 },
                 {
@@ -311,13 +311,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "A78D66C9E32EE00865E4CA88BDBD47DD"
+                    "stringValue": "A519B6823DF32E7CDA58547BEEDFAB4C"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "1F1606DE317C9DAF5739B1E80B7993CA"
+                    "stringValue": "4FC8339533E07AD9C49BA5C72F3FD963"
                   }
                 },
                 {
@@ -329,7 +329,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "1F1606DE317C9DAF5739B1E80B7993CA"
+                    "stringValue": "4FC8339533E07AD9C49BA5C72F3FD963"
                   }
                 },
                 {
@@ -341,7 +341,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "CC8B1D3C0CA14160E51869E4803C79CD"
+                    "stringValue": "3E9A2B9F3647B9F7E49F7FDF9B85FDAB"
                   }
                 },
                 {
@@ -362,8 +362,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "2582187239855000000",
-              "observedTimeUnixNano": "1780486684197000000",
+              "timeUnixNano": "2586228390012000000",
+              "observedTimeUnixNano": "1782919268332000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -393,6 +393,12 @@
                   }
                 },
                 {
+                  "key": "first_interaction.time",
+                  "value": {
+                    "doubleValue": 803309121930.0001
+                  }
+                },
+                {
                   "key": "first_interaction.x",
                   "value": {
                     "intValue": 120
@@ -407,13 +413,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "B0559801DFA2137DCD317E5CB37EE204"
+                    "stringValue": "8FB05696EE7480587077DFEF98797420"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "1F1606DE317C9DAF5739B1E80B7993CA"
+                    "stringValue": "4FC8339533E07AD9C49BA5C72F3FD963"
                   }
                 },
                 {
@@ -425,7 +431,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "1F1606DE317C9DAF5739B1E80B7993CA"
+                    "stringValue": "4FC8339533E07AD9C49BA5C72F3FD963"
                   }
                 },
                 {
@@ -437,7 +443,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "CC8B1D3C0CA14160E51869E4803C79CD"
+                    "stringValue": "3E9A2B9F3647B9F7E49F7FDF9B85FDAB"
                   }
                 },
                 {
@@ -469,8 +475,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1780486684248000000",
-              "observedTimeUnixNano": "1780486684198000000",
+              "timeUnixNano": "1782919268430000000",
+              "observedTimeUnixNano": "1782919268333000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -486,13 +492,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:98892\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:38009\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:37548\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:237129\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:1:797\nag@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:8:127516\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:8:132570\ncd@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:8:15162\nec@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:8:128751\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:28582\niy@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:9:28404"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:100343\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:38009\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:37548\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:242332\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:970\nPromise@[native code]\nUt@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:1:797\nlm@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:127516\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:132570\nhd@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:15162\nnc@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:8:128751\ngc@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:28582\n_y@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:9:28404"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-CCPKbh8-.js:11:126\":\"186c7210976877b22d7d13d27d4adcb4\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-Du4u9Glu.js:11:126\":\"8ad5455d6272b4b18a20538605d0249b\"}"
                   }
                 },
                 {
@@ -504,13 +510,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0981BFA114100FC06958496737451FAA"
+                    "stringValue": "AF7859B1D6BCB1A7F1D6E27AE6EDA7CB"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "1F1606DE317C9DAF5739B1E80B7993CA"
+                    "stringValue": "4FC8339533E07AD9C49BA5C72F3FD963"
                   }
                 },
                 {
@@ -522,7 +528,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "1F1606DE317C9DAF5739B1E80B7993CA"
+                    "stringValue": "4FC8339533E07AD9C49BA5C72F3FD963"
                   }
                 },
                 {
@@ -534,7 +540,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "CC8B1D3C0CA14160E51869E4803C79CD"
+                    "stringValue": "3E9A2B9F3647B9F7E49F7FDF9B85FDAB"
                   }
                 },
                 {

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -126,6 +126,7 @@ const IGNORED_ATTRIBUTES_LIST = [
   'tap.coords',
   'first_interaction.x',
   'first_interaction.y',
+  'first_interaction.time',
 ];
 
 const testWithMockApi = base.extend<TestWithMockApi>({


### PR DESCRIPTION
## What problem does this solve?
`FirstInteractionInstrumentation` was missing an attribute to record when the first interaction occurred relative to navigation start (zero time), making it impossible to correlate the event with page load timing on the backend.

## Short description
Adds `first_interaction.time` — the raw zero-time offset (ms from navigation start) of the first interaction event — following the same convention as `emb.element_timing.start_time`. The log's existing `timestamp` field continues to hold the converted epoch value.