### PR TITLE
fix: check out tag ref on release to fix npm provenance

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -715,6 +715,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # On `release`-triggered runs, checkout otherwise lands on a detached
+          # commit with no tag ref (actions/checkout#2280), which makes
+          # `npm publish --provenance` fail with "Missing SourceRepositoryRef".
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## What problem is this solving?

\`npm publish --provenance\` was failing on release with:

\`\`\`
npm error 422 Unprocessable Entity - Missing SourceRepositoryRef in signing certificate
\`\`\`

## Short description of changes

On \`release\`-triggered workflow runs, \`actions/checkout\` without an explicit \`ref\` lands on a detached commit SHA rather than the tagged ref ([actions/checkout#2280](https://github.com/actions/checkout/issues/2280)). The sigstore signing process uses the git ref to populate \`SourceRepositoryRef\` in the Fulcio certificate — a detached HEAD has no ref, so the field is missing and the npm registry rejects the provenance bundle with a 422.

Fix: pass \`ref: \${{ github.event.release.tag_name }}\` to the checkout in the publish job. On non-release runs (PRs, pushes to main) \`github.event.release.tag_name\` is empty and \`actions/checkout\` falls back to its default behavior, so there is no change outside of release publishes.

## How has this been tested?

Will be validated on the next release publish.

## Checklist

- [ ] Tests added
- [ ] Documentation added