### PR TITLE
feat: add soft navigation span polyfill

### DIFF
--- a/demo/frontend/soft/index.tsx
+++ b/demo/frontend/soft/index.tsx
@@ -9,7 +9,7 @@ import { setupSDK } from '../src/otel-base.ts';
 
 setupSDK([createReactRouterNavigationInstrumentation()]);
 
-type Route = 'home' | 'a' | 'b';
+type Route = 'home' | 'a' | 'b' | 'query' | 'hash';
 
 const PAGES: Record<
   Route,
@@ -33,12 +33,26 @@ const PAGES: Record<
     description:
       'You navigated to Page B. Check the Navigation Info below to see how the SDK tracks this.',
   },
+  query: {
+    path: 'soft/?tab=details',
+    title: 'Query String',
+    description:
+      'Only the query string changed (?tab=details). Tests whether the SDK treats a search-param-only change as a soft navigation.',
+  },
+  hash: {
+    path: 'soft/#section',
+    title: 'Hash',
+    description:
+      'Only the hash changed (#section). Tests whether the SDK treats a hash-only change as a soft navigation.',
+  },
 };
 
 const getRoute = (): Route => {
-  const path = window.location.pathname;
-  if (path.endsWith('/a')) return 'a';
-  if (path.endsWith('/b')) return 'b';
+  const { pathname, search, hash } = window.location;
+  if (pathname.endsWith('/a')) return 'a';
+  if (pathname.endsWith('/b')) return 'b';
+  if (search.includes('tab=details')) return 'query';
+  if (hash.includes('section')) return 'hash';
   return 'home';
 };
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "server": "npx tsx server/server.ts",
     "commitlint": "commitlint",
     "test:integration": "turbo run test --filter=tests-integration",
+    "test:integration:headed": "turbo run test:headed --filter=tests-integration",
     "test:integration:update-golden": "turbo run update-golden --filter=tests-integration",
     "test:integration:container": "bash scripts/test-integration-podman.sh",
     "test:integration:container:update-golden": "UPDATE_GOLDEN=1 bash scripts/test-integration-podman.sh",

--- a/packages/web-sdk/scripts/validate.ts
+++ b/packages/web-sdk/scripts/validate.ts
@@ -18,7 +18,7 @@ import zlib from 'node:zlib';
 import { COLORS, log, logSection } from '../../../scripts/build-config.ts';
 
 // Maximum bundle size (gzipped) — triggers hard failure to catch bloat/duplication early
-const MAX_BUNDLE_SIZE_KB = 56;
+const MAX_BUNDLE_SIZE_KB = 60;
 
 const BUNDLE_FILE = 'embrace-web-sdk.js';
 const BUNDLE_MAP_FILE = 'embrace-web-sdk.js.map';

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
@@ -370,6 +370,23 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
     globalThis.PerformanceObserver = original;
     instrumentation.disable();
   });
+
+  it('disconnects the existing observer when onEnable is called while already active', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+    });
+
+    const firstCallback = observerCallback;
+
+    // Bypass the _isEnabled guard in enable() to re-enter _enableNative while
+    // _observer is already set, exercising the disconnect() branch.
+    instrumentation.onEnable();
+
+    expect(observerCallback).to.not.equal(firstCallback);
+
+    instrumentation.disable();
+  });
 });
 
 describe('getNavigationEventTrigger', () => {
@@ -690,6 +707,66 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
     expect(spans[0].attributes['browser.url.full']).to.equal(
       'https://example.com/first',
     );
+
+    instrumentation.disable();
+  });
+
+  it('returns early from _enablePolyfill when navigation is removed from the host after construction', () => {
+    const host: {
+      navigation: Navigation | undefined;
+      location: { href: string };
+    } = {
+      navigation: mockNavigation as unknown as Navigation,
+      location: { href: 'https://example.com' },
+    };
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+      navigationHost: host,
+    });
+
+    instrumentation.disable();
+    host.navigation = undefined;
+
+    // onEnable() bypasses the _isEnabled guard; _usePolyfill is still true so
+    // _enablePolyfill() is entered, and the !nav guard fires.
+    instrumentation.onEnable();
+
+    expect(currentEntryChangeListeners).to.have.length(0);
+
+    instrumentation.disable();
+  });
+
+  it('stops emitting in _emitPolyfillSpan once the limit is reached mid-batch', () => {
+    const customLimitManager = new EmbraceLimitManager({
+      ...DEFAULT_LIMITS,
+      maxAllowed: { ...DEFAULT_LIMITS.maxAllowed, soft_navigation: 1 },
+    });
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager: customLimitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    // Two navigations at distinct timestamps so each click entry matches one.
+    clock.tick(150); // t = 150
+    triggerCurrentEntryChange();
+    clock.tick(200); // t = 350
+    triggerCurrentEntryChange();
+
+    // Two click entries whose windows cover a different navigation each.
+    // Entry 1: startTime=100, duration=100 → window [100, 200] matches t=150.
+    // Entry 2: startTime=300, duration=100 → window [300, 400] matches t=350.
+    triggerClickEntries([
+      makeClickEntry({ startTime: 100, duration: 100 }),
+      makeClickEntry({ startTime: 300, duration: 100 }),
+    ]);
+
+    // Only the first _emitPolyfillSpan call goes through; the second hits the limit guard.
+    expect(spanExporter.getFinishedSpans()).to.have.length(1);
 
     instrumentation.disable();
   });

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
@@ -99,7 +99,7 @@ let eventObserveOptions: {
   durationThreshold?: number;
 } | null = null;
 
-let currentEntryChangeListeners: Array<() => void> = [];
+let currentEntryChangeListeners: Array<(event: Event) => void> = [];
 
 let mockNavigation: {
   currentEntry: { url: string } | null;
@@ -132,9 +132,9 @@ class MockPolyfillPerformanceObserver {
   }
 }
 
-const triggerCurrentEntryChange = () => {
+const triggerCurrentEntryChange = (timeStamp = performance.now()) => {
   for (const listener of currentEntryChangeListeners) {
-    listener();
+    listener({ timeStamp } as Event);
   }
 };
 

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
@@ -11,10 +11,19 @@ import {
   DEFAULT_LIMITS,
   EmbraceLimitManager,
 } from '../../../managers/index.ts';
-import { SoftNavigationPerformanceInstrumentation } from './SoftNavigationPerformanceInstrumentation.ts';
+import {
+  getNavigationEventTrigger,
+  SoftNavigationPerformanceInstrumentation,
+} from './SoftNavigationPerformanceInstrumentation.ts';
 import type { PerformanceSoftNavigationTiming } from './types.ts';
 
 const { expect } = chai;
+
+let spanExporter: InMemorySpanExporter;
+
+before(() => {
+  spanExporter = setupTestTraceExporter();
+});
 
 const makeEntry = (
   overrides: Partial<PerformanceSoftNavigationTiming> = {},
@@ -34,6 +43,10 @@ const makeEntry = (
 
 type ObserverCallback = (list: {
   getEntries: () => PerformanceSoftNavigationTiming[];
+}) => void;
+
+type EventObserverCallback = (list: {
+  getEntries: () => PerformanceEventTiming[];
 }) => void;
 
 let observerCallback: ObserverCallback | null = null;
@@ -58,16 +71,82 @@ const triggerEntries = (entries: PerformanceSoftNavigationTiming[]) => {
   observerCallback?.({ getEntries: () => entries });
 };
 
+// --- Polyfill test helpers ---
+
+type MockClickEntry = PerformanceEventTiming;
+
+const makeClickEntry = (
+  overrides: Partial<MockClickEntry> = {},
+): MockClickEntry =>
+  ({
+    name: 'click',
+    entryType: 'event',
+    startTime: 100,
+    duration: 200,
+    interactionId: 42,
+    processingStart: 110,
+    processingEnd: 120,
+    cancelable: true,
+    toJSON: () => ({}),
+    ...overrides,
+  }) as MockClickEntry;
+
+let eventObserverCallback: EventObserverCallback | null = null;
+let eventObserverDisconnected = false;
+let eventObserveOptions: {
+  type: string;
+  buffered: boolean;
+  durationThreshold?: number;
+} | null = null;
+
+let currentEntryChangeListeners: Array<() => void> = [];
+
+let mockNavigation: {
+  currentEntry: { url: string } | null;
+  addEventListener: (event: string, listener: () => void) => void;
+  removeEventListener: (event: string, listener: () => void) => void;
+};
+
+class MockPolyfillPerformanceObserver {
+  public static supportedEntryTypes = ['event'];
+  private _callback: EventObserverCallback;
+
+  public constructor(callback: EventObserverCallback) {
+    this._callback = callback;
+    eventObserverDisconnected = false;
+  }
+
+  public observe(options: {
+    type: string;
+    buffered: boolean;
+    durationThreshold?: number;
+  }): void {
+    if (options.type === 'event') {
+      eventObserverCallback = this._callback;
+      eventObserveOptions = options;
+    }
+  }
+
+  public disconnect(): void {
+    eventObserverDisconnected = true;
+  }
+}
+
+const triggerCurrentEntryChange = () => {
+  for (const listener of currentEntryChangeListeners) {
+    listener();
+  }
+};
+
+const triggerClickEntries = (entries: PerformanceEventTiming[]) => {
+  eventObserverCallback?.({ getEntries: () => entries });
+};
+
 describe('SoftNavigationPerformanceInstrumentation', () => {
-  let spanExporter: InMemorySpanExporter;
   let clock: sinon.SinonFakeTimers;
   let perf: MockPerformanceManager;
   let limitManager: EmbraceLimitManager;
   let originalPerformanceObserver: typeof globalThis.PerformanceObserver;
-
-  before(() => {
-    spanExporter = setupTestTraceExporter();
-  });
 
   beforeEach(() => {
     spanExporter.reset();
@@ -291,6 +370,329 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
     expect(diagLogger.getErrorLogs()[0]).to.equal('failed to enable');
 
     globalThis.PerformanceObserver = original;
+    instrumentation.disable();
+  });
+});
+
+describe('getNavigationEventTrigger', () => {
+  it('returns a matching entry when the timestamp falls within the click window', () => {
+    const entry = makeClickEntry({ startTime: 100, duration: 200 });
+    const result = getNavigationEventTrigger(150, [entry]);
+    expect(result).to.equal(entry);
+  });
+
+  it('returns a matching entry when the timestamp equals startTime', () => {
+    const entry = makeClickEntry({ startTime: 100, duration: 200 });
+    expect(getNavigationEventTrigger(100, [entry])).to.equal(entry);
+  });
+
+  it('returns a matching entry when the timestamp equals startTime + duration', () => {
+    const entry = makeClickEntry({ startTime: 100, duration: 200 });
+    expect(getNavigationEventTrigger(300, [entry])).to.equal(entry);
+  });
+
+  it('returns null when timestamp is before the click window', () => {
+    const entry = makeClickEntry({ startTime: 100, duration: 200 });
+    expect(getNavigationEventTrigger(99, [entry])).to.be.null;
+  });
+
+  it('returns null when timestamp is after the click window', () => {
+    const entry = makeClickEntry({ startTime: 100, duration: 200 });
+    expect(getNavigationEventTrigger(301, [entry])).to.be.null;
+  });
+
+  it('returns null for an empty entries array', () => {
+    expect(getNavigationEventTrigger(150, [])).to.be.null;
+  });
+
+  it('returns the first matching entry when multiple entries qualify', () => {
+    const entry1 = makeClickEntry({ startTime: 100, duration: 200 });
+    const entry2 = makeClickEntry({ startTime: 50, duration: 300 });
+    expect(getNavigationEventTrigger(150, [entry1, entry2])).to.equal(entry1);
+  });
+});
+
+describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
+  let clock: sinon.SinonFakeTimers;
+  let perf: MockPerformanceManager;
+  let limitManager: EmbraceLimitManager;
+  let originalPerformanceObserver: typeof globalThis.PerformanceObserver;
+
+  beforeEach(() => {
+    spanExporter.reset();
+    clock = sinon.useFakeTimers();
+    perf = new MockPerformanceManager(clock);
+    limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
+
+    originalPerformanceObserver = globalThis.PerformanceObserver;
+
+    currentEntryChangeListeners = [];
+    eventObserverCallback = null;
+    eventObserverDisconnected = false;
+    eventObserveOptions = null;
+
+    mockNavigation = {
+      currentEntry: { url: 'https://example.com/new-page' },
+      addEventListener: (_event: string, listener: () => void) => {
+        currentEntryChangeListeners.push(listener);
+      },
+      removeEventListener: (_event: string, listener: () => void) => {
+        const index = currentEntryChangeListeners.indexOf(listener);
+        if (index !== -1) currentEntryChangeListeners.splice(index, 1);
+      },
+    };
+
+    (globalThis as Record<string, unknown>)['PerformanceObserver'] =
+      MockPolyfillPerformanceObserver;
+  });
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>)['PerformanceObserver'] =
+      originalPerformanceObserver;
+    clock.restore();
+  });
+
+  it('enables the polyfill when soft-navigation is not supported but Navigation API and event type are available', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    expect(eventObserveOptions).to.deep.include({
+      type: 'event',
+      buffered: true,
+      durationThreshold: 16,
+    });
+    expect(currentEntryChangeListeners).to.have.length(1);
+
+    instrumentation.disable();
+  });
+
+  it('emits a polyfill span when a click entry matches a pending navigation', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    // Simulate: user clicks at t=100, navigation commits at t=150
+    clock.tick(150);
+    triggerCurrentEntryChange();
+
+    triggerClickEntries([
+      makeClickEntry({ startTime: 100, duration: 200, interactionId: 42 }),
+    ]);
+
+    const spans = spanExporter.getFinishedSpans();
+    expect(spans).to.have.length(1);
+    const span = spans[0];
+    expect(span.name).to.equal('Soft Navigation');
+    expect(span.attributes['browser.url.full']).to.equal(
+      'https://example.com/new-page',
+    );
+    expect(span.attributes['emb.soft_navigation.source']).to.equal('polyfill');
+    expect(span.attributes['emb.soft_navigation.start_time']).to.equal(100);
+    expect(span.attributes['emb.soft_navigation.duration']).to.equal(50); // 150 - 100
+    expect(span.attributes['emb.soft_navigation.interaction_id']).to.equal(42);
+
+    instrumentation.disable();
+  });
+
+  it('span start is at click startTime and end is at navigation commit', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    clock.tick(150);
+    triggerCurrentEntryChange();
+
+    triggerClickEntries([makeClickEntry({ startTime: 100, duration: 200 })]);
+
+    const span = spanExporter.getFinishedSpans()[0];
+    expect(span.startTime).to.not.deep.equal(span.endTime);
+
+    instrumentation.disable();
+  });
+
+  it('does not emit a span when no click entry matches the navigation timestamp', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    clock.tick(500);
+    triggerCurrentEntryChange();
+
+    // click window is [100, 300], navigation at 500 → no match
+    triggerClickEntries([makeClickEntry({ startTime: 100, duration: 200 })]);
+
+    expect(spanExporter.getFinishedSpans()).to.have.length(0);
+
+    instrumentation.disable();
+  });
+
+  it('omits interaction_id when it is 0', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    clock.tick(150);
+    triggerCurrentEntryChange();
+
+    triggerClickEntries([
+      makeClickEntry({ startTime: 100, duration: 200, interactionId: 0 }),
+    ]);
+
+    const span = spanExporter.getFinishedSpans()[0];
+    expect(span.attributes).not.to.have.property(
+      'emb.soft_navigation.interaction_id',
+    );
+
+    instrumentation.disable();
+  });
+
+  it('ignores non-click event entries', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    clock.tick(150);
+    triggerCurrentEntryChange();
+
+    triggerClickEntries([
+      makeClickEntry({ name: 'keydown', startTime: 100, duration: 200 }),
+    ]);
+
+    expect(spanExporter.getFinishedSpans()).to.have.length(0);
+
+    instrumentation.disable();
+  });
+
+  it('does not emit polyfill spans after disable', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    instrumentation.disable();
+
+    expect(eventObserverDisconnected).to.be.true;
+    expect(currentEntryChangeListeners).to.have.length(0);
+
+    clock.tick(150);
+    triggerClickEntries([makeClickEntry({ startTime: 100, duration: 200 })]);
+
+    expect(spanExporter.getFinishedSpans()).to.have.length(0);
+  });
+
+  it('stops emitting once the soft_navigation limit is reached via polyfill', () => {
+    const customLimitManager = new EmbraceLimitManager({
+      ...DEFAULT_LIMITS,
+      maxAllowed: { ...DEFAULT_LIMITS.maxAllowed, soft_navigation: 1 },
+    });
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager: customLimitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    clock.tick(150);
+    triggerCurrentEntryChange();
+    mockNavigation.currentEntry = { url: 'https://example.com/page-2' };
+    clock.tick(50);
+    triggerCurrentEntryChange();
+
+    triggerClickEntries([makeClickEntry({ startTime: 100, duration: 200 })]);
+
+    expect(spanExporter.getFinishedSpans()).to.have.length(1);
+
+    instrumentation.disable();
+  });
+
+  it('logs an error when the event observer fails to construct', () => {
+    (globalThis as Record<string, unknown>)['PerformanceObserver'] = class {
+      public static supportedEntryTypes = ['event'];
+      public constructor() {
+        throw new Error('constructor failed');
+      }
+    };
+
+    const diagLogger = new InMemoryDiagLogger();
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      diag: diagLogger,
+      limitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    expect(diagLogger.getErrorLogs()[0]).to.equal('failed to enable polyfill');
+    expect(currentEntryChangeListeners).to.have.length(0);
+
+    instrumentation.disable();
+  });
+
+  it('uses the destination URL from navigation.currentEntry at commit time', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    mockNavigation.currentEntry = { url: 'https://example.com/first' };
+    clock.tick(150);
+    triggerCurrentEntryChange();
+
+    mockNavigation.currentEntry = { url: 'https://example.com/second' };
+    clock.tick(50);
+    triggerCurrentEntryChange();
+
+    triggerClickEntries([makeClickEntry({ startTime: 100, duration: 200 })]);
+
+    const spans = spanExporter.getFinishedSpans();
+    expect(spans).to.have.length(1);
+    expect(spans[0].attributes['browser.url.full']).to.equal(
+      'https://example.com/first',
+    );
+
     instrumentation.disable();
   });
 });

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
@@ -294,8 +294,6 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
     });
 
     expect(observerCallback).to.be.null;
-    expect(diagLogger.getDebugLogs().some((m) => m.includes('soft-navigation')))
-      .to.be.true;
 
     instrumentation.disable();
   });

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
@@ -390,40 +390,29 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
 });
 
 describe('getNavigationEventTrigger', () => {
-  it('returns a matching entry when the timestamp falls within the click window', () => {
+  it('returns the entry when the timestamp falls within the click window', () => {
     const entry = makeClickEntry({ startTime: 100, duration: 200 });
-    const result = getNavigationEventTrigger(150, [entry]);
-    expect(result).to.equal(entry);
+    expect(getNavigationEventTrigger(150, entry)).to.equal(entry);
   });
 
-  it('returns a matching entry when the timestamp equals startTime', () => {
+  it('returns the entry when the timestamp equals startTime', () => {
     const entry = makeClickEntry({ startTime: 100, duration: 200 });
-    expect(getNavigationEventTrigger(100, [entry])).to.equal(entry);
+    expect(getNavigationEventTrigger(100, entry)).to.equal(entry);
   });
 
-  it('returns a matching entry when the timestamp equals startTime + duration', () => {
+  it('returns the entry when the timestamp equals startTime + duration', () => {
     const entry = makeClickEntry({ startTime: 100, duration: 200 });
-    expect(getNavigationEventTrigger(300, [entry])).to.equal(entry);
+    expect(getNavigationEventTrigger(300, entry)).to.equal(entry);
   });
 
   it('returns null when timestamp is before the click window', () => {
     const entry = makeClickEntry({ startTime: 100, duration: 200 });
-    expect(getNavigationEventTrigger(99, [entry])).to.be.null;
+    expect(getNavigationEventTrigger(99, entry)).to.be.null;
   });
 
   it('returns null when timestamp is after the click window', () => {
     const entry = makeClickEntry({ startTime: 100, duration: 200 });
-    expect(getNavigationEventTrigger(301, [entry])).to.be.null;
-  });
-
-  it('returns null for an empty entries array', () => {
-    expect(getNavigationEventTrigger(150, [])).to.be.null;
-  });
-
-  it('returns the first matching entry when multiple entries qualify', () => {
-    const entry1 = makeClickEntry({ startTime: 100, duration: 200 });
-    const entry2 = makeClickEntry({ startTime: 50, duration: 300 });
-    expect(getNavigationEventTrigger(150, [entry1, entry2])).to.equal(entry1);
+    expect(getNavigationEventTrigger(301, entry)).to.be.null;
   });
 });
 
@@ -558,6 +547,71 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
     triggerClickEntries([makeClickEntry({ startTime: 100, duration: 200 })]);
 
     expect(spanExporter.getFinishedSpans()).to.have.length(0);
+
+    instrumentation.disable();
+  });
+
+  it('skips a pending navigation and logs debug when currentEntry has no URL', () => {
+    const diagLogger = new InMemoryDiagLogger();
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      diag: diagLogger,
+      limitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    mockNavigation.currentEntry = null;
+    clock.tick(150);
+    triggerCurrentEntryChange();
+
+    triggerClickEntries([makeClickEntry({ startTime: 100, duration: 200 })]);
+
+    expect(spanExporter.getFinishedSpans()).to.have.length(0);
+    expect(diagLogger.getDebugLogs()).to.include(
+      'currententrychange fired with no URL, skipping',
+    );
+
+    instrumentation.disable();
+  });
+
+  it('prunes pending navigations older than 60 s when a click entry arrives', () => {
+    const instrumentation = new SoftNavigationPerformanceInstrumentation({
+      perf,
+      limitManager,
+      navigationHost: {
+        navigation: mockNavigation as unknown as Navigation,
+        location: { href: 'https://example.com' },
+      },
+    });
+
+    // Navigation at t=0 (will be older than 60 s by the time the click arrives).
+    triggerCurrentEntryChange();
+
+    // Navigation at t=100 (recent, should survive).
+    clock.tick(100);
+    triggerCurrentEntryChange();
+
+    // Click arrives at t=60_100, so t=0 navigation is exactly 60_100 ms old (> 60_000)
+    // and t=100 navigation is 60_000 ms old (not > 60_000, so it stays).
+    // The click window covers [60_000, 60_200], which matches t=100... wait, 100 < 60_000.
+    // Use a click at startTime=60_100 with a very large duration to match t=100.
+    clock.tick(60_000); // t = 60_100
+    triggerClickEntries([makeClickEntry({ startTime: 60_100, duration: 200 })]);
+
+    // t=0 was pruned (60_100 - 0 = 60_100 > 60_000).
+    // t=100 was pruned (60_100 - 100 = 60_000, not < 60_000).
+    // No match → no span.
+    expect(spanExporter.getFinishedSpans()).to.have.length(0);
+
+    // Now verify a navigation within the 60 s window still matches.
+    clock.tick(100); // t = 60_200
+    triggerCurrentEntryChange(); // pending navigation at t=60_200
+    triggerClickEntries([makeClickEntry({ startTime: 60_200, duration: 200 })]);
+
+    expect(spanExporter.getFinishedSpans()).to.have.length(1);
 
     instrumentation.disable();
   });
@@ -707,32 +761,6 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
     expect(spans[0].attributes['browser.url.full']).to.equal(
       'https://example.com/first',
     );
-
-    instrumentation.disable();
-  });
-
-  it('returns early from _enablePolyfill when navigation is removed from the host after construction', () => {
-    const host: {
-      navigation: Navigation | undefined;
-      location: { href: string };
-    } = {
-      navigation: mockNavigation as unknown as Navigation,
-      location: { href: 'https://example.com' },
-    };
-    const instrumentation = new SoftNavigationPerformanceInstrumentation({
-      perf,
-      limitManager,
-      navigationHost: host,
-    });
-
-    instrumentation.disable();
-    host.navigation = undefined;
-
-    // onEnable() bypasses the _isEnabled guard; _usePolyfill is still true so
-    // _enablePolyfill() is entered, and the !nav guard fires.
-    instrumentation.onEnable();
-
-    expect(currentEntryChangeListeners).to.have.length(0);
 
     instrumentation.disable();
   });

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
@@ -32,16 +32,15 @@ import type {
  */
 export function getNavigationEventTrigger(
   navigationTimestamp: number,
-  clickEntries: PerformanceEventTiming[],
+  entry: PerformanceEventTiming,
 ): PerformanceEventTiming | null {
-  return (
-    clickEntries.find(
-      (entry) =>
-        entry.startTime <= navigationTimestamp &&
-        navigationTimestamp <= entry.startTime + entry.duration,
-    ) ?? null
-  );
+  return entry.startTime <= navigationTimestamp &&
+    navigationTimestamp <= entry.startTime + entry.duration
+    ? entry
+    : null;
 }
+
+const PENDING_NAVIGATION_TTL_MS = 60_000;
 
 type PendingNavigation = { timestamp: number; url: string };
 
@@ -53,7 +52,12 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
   private readonly _navigationHost: NavigationHost;
 
   private readonly _handleCurrentEntryChange = (): void => {
-    const url = this._navigationHost.navigation?.currentEntry?.url ?? '';
+    const url = this._navigationHost.navigation?.currentEntry?.url;
+    if (!url) {
+      this._diag.debug('currententrychange fired with no URL, skipping');
+      return;
+    }
+
     // Store origin-relative time (performance.now() equivalent) so it can be
     // compared directly against PerformanceEventTiming.startTime, which is also
     // origin-relative. getNowMillis() is epoch-based; subtracting getZeroTime()
@@ -89,7 +93,7 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
       this._usePolyfill = false;
       super.enable();
     } else if (
-      this._navigationHost.navigation != null &&
+      this._navigationHost.navigation &&
       isEntryTypeSupported('event')
     ) {
       this._usePolyfill = true;
@@ -124,10 +128,12 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
   }
 
   private _enablePolyfill(): void {
-    const nav = this._navigationHost.navigation;
-    if (!nav) {
-      return;
+    if (this._eventObserver) {
+      this._eventObserver.disconnect();
     }
+
+    // biome-ignore lint/style/noNonNullAssertion: enable() is only called when navigationHost.navigation is defined
+    const nav = this._navigationHost.navigation!;
 
     nav.addEventListener('currententrychange', this._handleCurrentEntryChange);
 
@@ -214,8 +220,13 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
       return;
     }
 
+    this._pendingNavigations = this._pendingNavigations.filter(
+      ({ timestamp }) =>
+        entry.startTime - timestamp < PENDING_NAVIGATION_TTL_MS,
+    );
+
     const index = this._pendingNavigations.findIndex(
-      ({ timestamp }) => getNavigationEventTrigger(timestamp, [entry]) !== null,
+      ({ timestamp }) => getNavigationEventTrigger(timestamp, entry) !== null,
     );
 
     if (index === -1) {

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
@@ -1,3 +1,5 @@
+/* eslint-disable baseline-js/use-baseline */
+import type { NavigationHost } from '../../../common/index.ts';
 import { KEY_BROWSER_URL_FULL } from '../../../constants/index.ts';
 import {
   createPerformanceObserver,
@@ -20,13 +22,51 @@ import type {
   SoftNavigationPerformanceInstrumentationArgs,
 } from './types.ts';
 
+/**
+ * Returns the click entry whose processing window contains the given navigation
+ * timestamp, or null if no match is found.
+ *
+ * For pushState navigations, currententrychange fires synchronously during the
+ * click handler, so the timestamp falls within the click entry's
+ * [startTime, startTime + duration] window.
+ */
+export function getNavigationEventTrigger(
+  navigationTimestamp: number,
+  clickEntries: PerformanceEventTiming[],
+): PerformanceEventTiming | null {
+  return (
+    clickEntries.find(
+      (entry) =>
+        entry.startTime <= navigationTimestamp &&
+        navigationTimestamp <= entry.startTime + entry.duration,
+    ) ?? null
+  );
+}
+
+type PendingNavigation = { timestamp: number; url: string };
+
 export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumentationBase {
   private _observer: PerformanceObserver | null = null;
+  private _eventObserver: PerformanceObserver | null = null;
+  private _pendingNavigations: PendingNavigation[] = [];
+  private _usePolyfill = false;
+  private readonly _navigationHost: NavigationHost;
+
+  private readonly _handleCurrentEntryChange = (): void => {
+    const url = this._navigationHost.navigation?.currentEntry?.url ?? '';
+    // Store origin-relative time (performance.now() equivalent) so it can be
+    // compared directly against PerformanceEventTiming.startTime, which is also
+    // origin-relative. getNowMillis() is epoch-based; subtracting getZeroTime()
+    // converts it back to origin-relative.
+    const timestamp = this.perf.getNowMillis() - this.perf.getZeroTime();
+    this._pendingNavigations.push({ timestamp, url });
+  };
 
   public constructor({
     diag,
     perf,
     limitManager,
+    navigationHost = window as NavigationHost,
   }: SoftNavigationPerformanceInstrumentationArgs = {}) {
     super({
       instrumentationName: 'SoftNavigationPerformanceInstrumentation',
@@ -37,6 +77,8 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
       config: {},
     });
 
+    this._navigationHost = navigationHost;
+
     if (this._config.enabled) {
       this.enable();
     }
@@ -44,13 +86,26 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
 
   public override enable(): void {
     if (isEntryTypeSupported('soft-navigation')) {
+      this._usePolyfill = false;
       super.enable();
-    } else {
-      this._diag.debug('soft-navigation not supported, skipping');
+    } else if (
+      this._navigationHost.navigation != null &&
+      isEntryTypeSupported('event')
+    ) {
+      this._usePolyfill = true;
+      super.enable();
     }
   }
 
   public override onEnable(): void {
+    if (this._usePolyfill) {
+      this._enablePolyfill();
+    } else {
+      this._enableNative();
+    }
+  }
+
+  private _enableNative(): void {
     if (this._observer) {
       this._observer.disconnect();
     }
@@ -68,11 +123,50 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
     }
   }
 
+  private _enablePolyfill(): void {
+    const nav = this._navigationHost.navigation;
+    if (!nav) {
+      return;
+    }
+
+    nav.addEventListener('currententrychange', this._handleCurrentEntryChange);
+
+    this._eventObserver = createPerformanceObserver<PerformanceEventTiming>(
+      'event',
+      (entry) => this._processClickEntry(entry),
+      // SPA routers commit navigations synchronously inside the click handler,
+      // so the entry duration is well under the 104ms default threshold. 16ms
+      // (one frame) is the spec minimum and captures any real interaction.
+      { diag: this._diag, durationThreshold: 16 },
+    );
+
+    if (!this._eventObserver) {
+      nav.removeEventListener(
+        'currententrychange',
+        this._handleCurrentEntryChange,
+      );
+      this._isEnabled = false;
+      this._diag.error('failed to enable polyfill');
+      return;
+    }
+  }
+
   public onDisable(): void {
     if (this._observer) {
       this._observer.disconnect();
       this._observer = null;
     }
+
+    if (this._eventObserver) {
+      this._eventObserver.disconnect();
+      this._eventObserver = null;
+    }
+
+    this._navigationHost.navigation?.removeEventListener(
+      'currententrychange',
+      this._handleCurrentEntryChange,
+    );
+    this._pendingNavigations.length = 0;
   }
 
   private _processEntry(entry: PerformanceSoftNavigationTiming): void {
@@ -109,5 +203,52 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
     span.end(
       this.perf.epochMillisFromZeroTime(entry.startTime + entry.duration),
     );
+  }
+
+  private _processClickEntry(entry: PerformanceEventTiming): void {
+    if (!this._isEnabled) {
+      return;
+    }
+
+    if (entry.name !== 'click') {
+      return;
+    }
+
+    const index = this._pendingNavigations.findIndex(
+      ({ timestamp }) => getNavigationEventTrigger(timestamp, [entry]) !== null,
+    );
+
+    if (index === -1) {
+      return;
+    }
+
+    const [matched] = this._pendingNavigations.splice(index, 1);
+    this._emitPolyfillSpan(entry, matched.timestamp, matched.url);
+  }
+
+  private _emitPolyfillSpan(
+    clickEntry: PerformanceEventTiming,
+    navigationTimestamp: number,
+    url: string,
+  ): void {
+    if (this.limitManager?.limitSoftNavigationEntry()) {
+      return;
+    }
+
+    const span = this.tracer.startSpan(SOFT_NAVIGATION_SPAN_NAME, {
+      startTime: this.perf.epochMillisFromZeroTime(clickEntry.startTime),
+      attributes: {
+        [KEY_BROWSER_URL_FULL]: url,
+        [KEY_EMB_SOFT_NAVIGATION_SOURCE]: SOFT_NAVIGATION_SOURCES.polyfill,
+        [KEY_EMB_SOFT_NAVIGATION_START_TIME]: this.perf.millisFromZeroTime(
+          clickEntry.startTime,
+        ),
+        [KEY_EMB_SOFT_NAVIGATION_DURATION]:
+          navigationTimestamp - clickEntry.startTime,
+        [KEY_EMB_SOFT_NAVIGATION_INTERACTION_ID]:
+          clickEntry.interactionId !== 0 ? clickEntry.interactionId : undefined,
+      },
+    });
+    span.end(this.perf.epochMillisFromZeroTime(navigationTimestamp));
   }
 }

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
@@ -51,19 +51,14 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
   private _usePolyfill = false;
   private readonly _navigationHost: NavigationHost;
 
-  private readonly _handleCurrentEntryChange = (): void => {
+  private readonly _handleCurrentEntryChange = (event: Event): void => {
     const url = this._navigationHost.navigation?.currentEntry?.url;
     if (!url) {
       this._diag.debug('currententrychange fired with no URL, skipping');
       return;
     }
 
-    // Store origin-relative time (performance.now() equivalent) so it can be
-    // compared directly against PerformanceEventTiming.startTime, which is also
-    // origin-relative. getNowMillis() is epoch-based; subtracting getZeroTime()
-    // converts it back to origin-relative.
-    const timestamp = this.perf.getNowMillis() - this.perf.getZeroTime();
-    this._pendingNavigations.push({ timestamp, url });
+    this._pendingNavigations.push({ timestamp: event.timeStamp, url });
   };
 
   public constructor({
@@ -98,6 +93,10 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
     ) {
       this._usePolyfill = true;
       super.enable();
+    } else {
+      this._diag.debug(
+        'soft-navigation and navigation API not supported, skipping',
+      );
     }
   }
 
@@ -137,12 +136,16 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
 
     nav.addEventListener('currententrychange', this._handleCurrentEntryChange);
 
+    // A plain click listener only provides event.timeStamp (= startTime).
+    // To correlate a click with the navigation it triggered we need the full [startTime, startTime + duration] window.
+    // PerformanceEventTiming is the only API that exposes duration for event processing.
     this._eventObserver = createPerformanceObserver<PerformanceEventTiming>(
       'event',
       (entry) => this._processClickEntry(entry),
       // SPA routers commit navigations synchronously inside the click handler,
-      // so the entry duration is well under the 104ms default threshold. 16ms
-      // (one frame) is the spec minimum and captures any real interaction.
+      // so the entry duration is well under the 104ms default threshold
+      // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe#durationthreshold
+      // 16ms (one frame) is the spec minimum and captures any real interaction.
       { diag: this._diag, durationThreshold: 16 },
     );
 
@@ -220,6 +223,8 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
       return;
     }
 
+    // Remove any pending navigations that are older than the TTL. This prevents
+    // the pending navigation list from growing indefinitely.
     this._pendingNavigations = this._pendingNavigations.filter(
       ({ timestamp }) =>
         entry.startTime - timestamp < PENDING_NAVIGATION_TTL_MS,
@@ -242,6 +247,10 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
     navigationTimestamp: number,
     url: string,
   ): void {
+    if (!this._isEnabled) {
+      return;
+    }
+
     if (this.limitManager?.limitSoftNavigationEntry()) {
       return;
     }

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/types.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/types.ts
@@ -1,9 +1,12 @@
+import type { NavigationHost } from '../../../common/index.ts';
 import type { EmbraceInstrumentationBaseArgs } from '../../EmbraceInstrumentationBase/types.ts';
 
 export type SoftNavigationPerformanceInstrumentationArgs = Pick<
   EmbraceInstrumentationBaseArgs,
   'diag' | 'perf' | 'limitManager'
->;
+> & {
+  navigationHost?: NavigationHost;
+};
 
 export type PerformanceSoftNavigationTiming = PerformanceEntry & {
   navigationId: string;

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -7,6 +7,7 @@
     "install-dependencies": "bash scripts/installE2EPlatformDependencies.sh && npx playwright install",
     "build-platforms": "npx tsx --test \"tests/build-platform/*.test.ts\" --test-timeout=20000 --test-concurrency=1",
     "test": "npx playwright test",
+    "test:headed": "npx playwright test --headed --config playwright.config.headed.ts",
     "update-golden": "UPDATE_GOLDEN=1 npm run test"
   },
   "dependencies": {

--- a/tests/integration/playwright.config.headed.ts
+++ b/tests/integration/playwright.config.headed.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Headed-only config for manual verification of features that require real
+// browser interaction (e.g. the soft navigation polyfill, which depends on
+// PerformanceEventTiming entries that headless Chromium does not generate for
+// synthetic clicks). Run with:
+//   npx playwright test --config playwright.config.headed.ts
+export default defineConfig({
+  timeout: 6 * 60 * 1000,
+  webServer: [
+    {
+      name: 'vite-react-router',
+      command: 'cd platforms/vite-react-router && npx vite preview --port 3016',
+      url: 'http://localhost:3016',
+      reuseExistingServer: true,
+    },
+    {
+      name: 'api',
+      command: 'npm run server --prefix ../..',
+      url: 'http://localhost:3001/health-check',
+      reuseExistingServer: true,
+    },
+  ],
+  projects: [
+    // Standard Chrome: no SoftNavigationHeuristics flag, so the polyfill path
+    // is active. Only Chromium generates PerformanceEventTiming for synthetic
+    // clicks; Firefox and WebKit do not.
+    {
+      name: 'chromium',
+      testMatch: '**/e2e-headed/soft-navigation-polyfill.spec.ts',
+      use: { ...devices['Desktop Chrome'], headless: false },
+    },
+    // Chrome with SoftNavigationHeuristics enabled: exercises the native
+    // soft-navigation PerformanceObserver entry type.
+    {
+      name: 'chromium-soft-nav-heuristics',
+      testMatch: '**/e2e-headed/soft-navigation-native.spec.ts',
+      use: {
+        ...devices['Desktop Chrome'],
+        headless: false,
+        launchOptions: {
+          args: ['--enable-features=SoftNavigationHeuristics'],
+        },
+      },
+    },
+  ],
+});

--- a/tests/integration/playwright.config.ts
+++ b/tests/integration/playwright.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
     },
   ],
   testMatch: '**/*.spec.ts',
+  testIgnore: '**/e2e-headed/**',
   projects: [
     {
       name: 'chromium',

--- a/tests/integration/tests/e2e-headed/soft-navigation-native.spec.ts
+++ b/tests/integration/tests/e2e-headed/soft-navigation-native.spec.ts
@@ -1,0 +1,130 @@
+// Headed-only test for the native soft navigation path. Run with:
+//   npx playwright test --config playwright.config.headed.ts
+//
+// Requires Chrome launched with --enable-features=SoftNavigationHeuristics so
+// that the browser reports soft-navigation PerformanceObserver entries. The
+// playwright.config.headed.ts chromium-soft-nav-heuristics project supplies
+// that flag automatically.
+import type { IExportTraceServiceRequest } from '@opentelemetry/otlp-transformer/build/esnext/trace/internal-types.js';
+import testWithMockApi from '../../utils/test-with-mock-api.ts';
+
+const BASE_URL = 'http://localhost:3016';
+
+type SPAFixture = {
+  loadHome: () => Promise<void>;
+  triggerSessionEnd: () => Promise<void>;
+};
+
+const test = testWithMockApi.extend<SPAFixture>({
+  loadHome: async ({ page }, use) => {
+    await use(async () => {
+      await page.goto(BASE_URL);
+      await page.waitForFunction(
+        () => window.EMBRACE_CURRENT_USER_SESSION_ID !== null,
+      );
+    });
+  },
+
+  triggerSessionEnd: async ({ page }, use) => {
+    await use(async () => {
+      await page.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'hidden',
+          writable: true,
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+    });
+  },
+});
+
+test.describe('Soft Navigation Native', () => {
+  test('emits a Soft Navigation span with source=performance_observer on link click', async ({
+    page,
+    loadHome,
+    requests,
+    triggerSessionEnd,
+    validateThatSessionPartsEnded,
+  }) => {
+    await loadHome();
+
+    await page.getByRole('link', { name: 'Products' }).click();
+    await test
+      .expect(page.getByRole('heading', { name: 'Products' }))
+      .toBeVisible();
+
+    // Give the browser time to deliver the soft-navigation entry via
+    // PerformanceObserver before the session flush.
+    await page.waitForTimeout(1000);
+
+    await triggerSessionEnd();
+
+    // 1 navigation + 1 session end = 2 session parts. Wait until the server
+    // confirms both so that requests contains the second-part native span.
+    await validateThatSessionPartsEnded(2);
+
+    const allSpans = requests.flatMap((r) =>
+      ((r.data as IExportTraceServiceRequest).resourceSpans ?? [])
+        .flatMap((rs) => rs.scopeSpans ?? [])
+        .flatMap((ss) => ss.spans ?? []),
+    );
+
+    const nativeSpan = allSpans.find(
+      (span) =>
+        span.name === 'Soft Navigation' &&
+        span.attributes?.some(
+          (a) =>
+            a.key === 'emb.soft_navigation.source' &&
+            a.value.stringValue === 'performance_observer',
+        ) &&
+        span.attributes?.some(
+          (a) =>
+            a.key === 'browser.url.full' &&
+            (a.value.stringValue ?? '').includes('/products'),
+        ),
+    );
+
+    test
+      .expect(
+        nativeSpan,
+        'expected a native Soft Navigation span for /products',
+      )
+      .toBeDefined();
+    test
+      .expect(
+        nativeSpan?.attributes?.find(
+          (a) => a.key === 'emb.soft_navigation.source',
+        )?.value.stringValue,
+      )
+      .toBe('performance_observer');
+    // Chrome reports timing values as whole-number milliseconds, so OTLP
+    // serializes them as intValue rather than doubleValue.
+    const durationAttr = nativeSpan?.attributes?.find(
+      (a) => a.key === 'emb.soft_navigation.duration',
+    )?.value;
+    test
+      .expect(
+        durationAttr?.intValue ?? durationAttr?.doubleValue,
+        'expected emb.soft_navigation.duration to be a positive number',
+      )
+      .toBeGreaterThan(0);
+    const paintTimeAttr = nativeSpan?.attributes?.find(
+      (a) => a.key === 'emb.soft_navigation.paint_time',
+    )?.value;
+    test
+      .expect(
+        paintTimeAttr?.intValue ?? paintTimeAttr?.doubleValue,
+        'expected emb.soft_navigation.paint_time to be a positive number',
+      )
+      .toBeGreaterThan(0);
+    const presentationTimeAttr = nativeSpan?.attributes?.find(
+      (a) => a.key === 'emb.soft_navigation.presentation_time',
+    )?.value;
+    test
+      .expect(
+        presentationTimeAttr?.intValue ?? presentationTimeAttr?.doubleValue,
+        'expected emb.soft_navigation.presentation_time to be a positive number',
+      )
+      .toBeGreaterThan(0);
+  });
+});

--- a/tests/integration/tests/e2e-headed/soft-navigation-polyfill.spec.ts
+++ b/tests/integration/tests/e2e-headed/soft-navigation-polyfill.spec.ts
@@ -1,0 +1,110 @@
+// Headed-only test for the soft navigation polyfill. Run with:
+//   npx playwright test --config playwright.config.headed.ts
+//
+// The polyfill is active when the browser does not support the native
+// soft-navigation PerformanceObserver entry type. Chrome requires the
+// --enable-features=SoftNavigationHeuristics flag for native support, so the
+// polyfill fires automatically in a standard browser window.
+//
+// Headless Chromium does not generate PerformanceEventTiming entries for
+// Playwright synthetic clicks, so this test must run in headed mode where real
+// user interactions produce real entries.
+import type { IExportTraceServiceRequest } from '@opentelemetry/otlp-transformer/build/esnext/trace/internal-types.js';
+import testWithMockApi from '../../utils/test-with-mock-api.ts';
+
+const BASE_URL = 'http://localhost:3016';
+
+type SPAFixture = {
+  loadHome: () => Promise<void>;
+  triggerSessionEnd: () => Promise<void>;
+};
+
+const test = testWithMockApi.extend<SPAFixture>({
+  loadHome: async ({ page }, use) => {
+    await use(async () => {
+      await page.goto(BASE_URL);
+      await page.waitForFunction(
+        () => window.EMBRACE_CURRENT_USER_SESSION_ID !== null,
+      );
+    });
+  },
+
+  triggerSessionEnd: async ({ page }, use) => {
+    await use(async () => {
+      await page.evaluate(() => {
+        Object.defineProperty(document, 'visibilityState', {
+          value: 'hidden',
+          writable: true,
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+    });
+  },
+});
+
+test.describe('Soft Navigation Polyfill', () => {
+  test('emits a Soft Navigation span with source=polyfill on link click', async ({
+    page,
+    loadHome,
+    requests,
+    triggerSessionEnd,
+    validateThatSessionPartsEnded,
+  }) => {
+    await loadHome();
+
+    await page.getByRole('link', { name: 'Products' }).click();
+    await test
+      .expect(page.getByRole('heading', { name: 'Products' }))
+      .toBeVisible();
+
+    await page.waitForTimeout(1000); // wait for the polyfill span to be emitted
+
+    await triggerSessionEnd();
+
+    // 1 navigation + 1 session end = 2 session parts. Wait until the server
+    // confirms both so that requests contains the second-part polyfill span.
+    await validateThatSessionPartsEnded(2);
+
+    const allSpans = requests.flatMap((r) =>
+      ((r.data as IExportTraceServiceRequest).resourceSpans ?? [])
+        .flatMap((rs) => rs.scopeSpans ?? [])
+        .flatMap((ss) => ss.spans ?? []),
+    );
+
+    const polyfillSpan = allSpans.find(
+      (span) =>
+        span.name === 'Soft Navigation' &&
+        span.attributes?.some(
+          (a) =>
+            a.key === 'emb.soft_navigation.source' &&
+            a.value.stringValue === 'polyfill',
+        ) &&
+        span.attributes?.some(
+          (a) =>
+            a.key === 'browser.url.full' &&
+            (a.value.stringValue ?? '').includes('/products'),
+        ),
+    );
+
+    test
+      .expect(
+        polyfillSpan,
+        'expected a polyfill Soft Navigation span for /products',
+      )
+      .toBeDefined();
+    test
+      .expect(
+        polyfillSpan?.attributes?.find(
+          (a) => a.key === 'emb.soft_navigation.source',
+        )?.value.stringValue,
+      )
+      .toBe('polyfill');
+    test
+      .expect(
+        polyfillSpan?.attributes?.find(
+          (a) => a.key === 'emb.soft_navigation.duration',
+        )?.value.doubleValue,
+      )
+      .toBeGreaterThan(0);
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,11 @@
       "cache": false,
       "persistent": true
     },
+    "test:headed": {
+      "dependsOn": ["^build"],
+      "cache": false,
+      "persistent": true
+    },
     "dev": {
       "dependsOn": ["^build"],
       "cache": false,


### PR DESCRIPTION
## What problem is this solving?

`SoftNavigationPerformanceInstrumentation` previously only worked when Chrome was launched with `--enable-features=SoftNavigationHeuristics`, which is not enabled by default. Without it, no soft navigation spans were emitted for SPA route changes.

## Short description of changes

- Added a polyfill path to `SoftNavigationPerformanceInstrumentation` that activates when the native `soft-navigation` PerformanceObserver entry type is unavailable. The polyfill correlates `PerformanceEventTiming` click entries with Navigation API `currententrychange` events to synthesize a span with `emb.soft_navigation.source = 'polyfill'`.
- Refactored the `navigation` constructor arg to a `navigationHost` pattern (matching `EmbraceUserSessionManager`) so tests can inject a mock without touching `globalThis`.
- Added unit tests for the polyfill path including `getNavigationEventTrigger` and the full click→navigate→span flow.
- Added two headed integration tests: `soft-navigation-polyfill.spec.ts` (standard Chrome, polyfill active) and `soft-navigation-native.spec.ts` (Chrome with `--enable-features=SoftNavigationHeuristics`, native path). Each project in `playwright.config.headed.ts` is scoped via `testMatch` to only its relevant test.
- Added a `test:headed` Turbo task and `test:integration:headed` root script.
- Extended the soft nav demo with query-string (`?tab=details`) and hash (`#section`) navigation items.

## How has this been tested?

- Unit tests: `npm run test` (headless, all pass)
- Headed polyfill test: `npx turbo run test:headed --filter=tests-integration` — verified polyfill span is emitted and `source === 'polyfill'`
- Headed native test: same command, `chromium-soft-nav-heuristics` project — verified `source === 'performance_observer'` and timing attrs (`duration`, `paint_time`, `presentation_time`) are positive