### PR TITLE
test(document-load): align OTel test setup with current sdk-trace API

### DIFF
--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -9,12 +9,12 @@ import {
   TRACE_PARENT_HEADER,
   W3CTraceContextPropagator,
 } from '@opentelemetry/core';
-import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace';
 import {
-  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
-} from '@opentelemetry/sdk-trace-base';
+  TracerProvider,
+} from '@opentelemetry/sdk-trace';
 import {
   PerformanceTimingNames as PTN,
   StackContextManager,
@@ -27,8 +27,8 @@ import { DocumentLoadInstrumentation } from '../index.ts';
 import { EventNames } from './enums/EventNames.ts';
 
 const exporter = new InMemorySpanExporter();
-const spanProcessor = new SimpleSpanProcessor(exporter);
-const provider = new BasicTracerProvider({
+const spanProcessor = new SimpleSpanProcessor({ exporter });
+const provider = new TracerProvider({
   spanProcessors: [spanProcessor],
 });
 trace.setGlobalTracerProvider(provider);


### PR DESCRIPTION
## What problem is this solving?

The `DocumentLoadInstrumentation` test used APIs from `@opentelemetry/sdk-trace-base` that no longer match the current OpenTelemetry SDK surface after the recent dependency bump. `BasicTracerProvider`, the positional `SimpleSpanProcessor(exporter)` constructor, and the `sdk-trace-base` import path have been superseded.

## Short description of changes

- Import `ReadableSpan`, `InMemorySpanExporter`, `SimpleSpanProcessor`, and `TracerProvider` from `@opentelemetry/sdk-trace` instead of `@opentelemetry/sdk-trace-base`.
- Replace `BasicTracerProvider` with `TracerProvider`.
- Use the object-form constructor `new SimpleSpanProcessor({ exporter })`.

## How has this been tested?

Ran the document-load instrumentation unit tests locally.

## Checklist

- [ ] Documentation added
- [x] Tests added
