### PR TITLE
docs: add todo for licenses patch

### DIFF
--- a/patches/generate-license-file+4.2.1.patch
+++ b/patches/generate-license-file+4.2.1.patch
@@ -1,3 +1,4 @@
+# TODO remove once https://github.com/TobyAndToby/generate-license-file/pull/743 is merged and released
 diff --git a/node_modules/generate-license-file/src/lib/internal/resolveLicenseContent/licenseFile.js b/node_modules/generate-license-file/src/lib/internal/resolveLicenseContent/licenseFile.js
 index b3efcd0..2d3f83a 100644
 --- a/node_modules/generate-license-file/src/lib/internal/resolveLicenseContent/licenseFile.js


### PR DESCRIPTION
## What problem is this solving?

The `generate-license-file+4.2.1.patch` sorts discovered license files for deterministic cross-platform notices, but it's a local patch waiting on an upstream fix. Without a marker, it's easy to forget to drop the patch once upstream lands the change.

## Short description of the changes

Adds a `# TODO` comment at the top of the patch pointing at the upstream PR (TobyAndToby/generate-license-file#743) so the patch can be removed once that PR is merged and released.

## How was this tested?

Docs/comment-only change to a patch header; no behavior change. The patch still applies cleanly.

## Checklist

- [x] Change is documentation only
- [x] No functional/runtime impact