### PR TITLE
chore: add Navigation API to baseline ignore features

### DIFF
--- a/packages/web-sdk/eslint.dist.config.ts
+++ b/packages/web-sdk/eslint.dist.config.ts
@@ -34,6 +34,9 @@ export default defineConfig([
             'proto',
             // AbortSignal.timeout is guarded in FetchTransport
             'abortsignal-timeout',
+            // Navigation API (newly available) is used intentionally to
+            // track soft navigations. It is guarded by using a proxy interface named NavigationHost
+            'navigation',
           ],
         },
       ],


### PR DESCRIPTION
## What problem is this solving?

The baseline validation (`npm run check:dist`) runs `eslint-plugin-baseline-js` on compiled output and rejects any API that is not widely available. The Navigation API (`window.navigation`) is newly available (not yet widely available) and is used intentionally by the soft navigation polyfill in `SoftNavigationPerformanceInstrumentation`.

## Short description of changes

- Added `'navigation'` to `ignoreFeatures` in `eslint.dist.config.ts` so the baseline check does not flag Navigation API usage in compiled output.