### PR TITLE
fix(web-vitals): use `PerformanceEntry.startTime` for web vitals log timestamps where possible

### DIFF
--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -23,6 +23,10 @@ import {
   KEY_EMB_TYPE,
 } from '../../../constants/index.ts';
 import { EmbracePageManager } from '../../../managers/index.ts';
+import {
+  _resetZeroTimeMillisForTesting,
+  updateZeroTimeMillis,
+} from '../../../utils/PerformanceManager/index.ts';
 import type { WebVitalListeners, WebVitalOnReport } from './types.ts';
 import { WebVitalsInstrumentation } from './WebVitalsInstrumentation.ts';
 
@@ -66,6 +70,7 @@ describe('WebVitalsInstrumentation', () => {
   afterEach(() => {
     clock.restore();
     instrumentation.disable();
+    _resetZeroTimeMillisForTesting();
   });
 
   it('should report CLS metrics as a log record', () => {
@@ -157,6 +162,69 @@ describe('WebVitalsInstrumentation', () => {
     expect(body['largestShiftValue']).to.equal(3.0);
     expect(body['largestShiftTarget']).to.equal('some-target');
     expect(body['loadState']).to.equal('complete');
+  });
+
+  it('should use the layout shift window start as the timestamp for CLS', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+
+    clock.tick(5000);
+
+    metricReportFunc({
+      name: 'CLS',
+      value: 0.1,
+      rating: 'good',
+      delta: 0.1,
+      id: 'm1',
+      // The window spans two shifts; the timestamp must mark the first, not the
+      // largest shift (2000) or the report time (5000).
+      entries: [{ startTime: 1000 }, { startTime: 2000 }] as LayoutShift[],
+      navigationType: 'navigate',
+      navigationId: 1,
+      attribution: { largestShiftTime: 2000 },
+    } as MetricWithAttribution);
+
+    const record = memoryExporter.getFinishedLogRecords()[0];
+    expect(record.hrTime).to.deep.equal([1, 0]);
+  });
+
+  it('should use the metric entry start time as the timestamp for LCP', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const metricReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
+
+    // Tick the clock forward so the event startTime and report time are different.
+    clock.tick(5000);
+
+    metricReportFunc({
+      name: 'LCP',
+      value: 22,
+      rating: 'good',
+      delta: 0,
+      id: 'm1',
+      entries: [{ startTime: 3000 } as PerformanceEntry],
+      navigationType: 'navigate',
+      attribution: {
+        timeToFirstByte: 0,
+        resourceLoadDelay: 0,
+        resourceLoadDuration: 0,
+        elementRenderDelay: 0,
+      },
+    } as MetricWithAttribution);
+
+    const record = memoryExporter.getFinishedLogRecords()[0];
+    expect(record.hrTime).to.deep.equal([3, 0]);
   });
 
   it('should report FCP metrics as a log record', () => {
@@ -484,6 +552,9 @@ describe('WebVitalsInstrumentation', () => {
     const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
     clock.tick(5000);
+    // Distinct from both the time origin (0) and the report time (5000) so the
+    // assertion below can only match the session part's zero time.
+    updateZeroTimeMillis(2000);
 
     metricReportFunc({
       name: 'TTFB',
@@ -535,7 +606,7 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.serverResponse': 20,
       'emb.web_vital.attribution.unattributed': 20,
     });
-    expect(record.hrTime).to.deep.equal([5, 0]);
+    expect(record.hrTime).to.deep.equal([2, 0]);
     const ttfbBody = JSON.parse(record.body as string) as Record<
       string,
       unknown
@@ -1612,6 +1683,9 @@ describe('WebVitalsInstrumentation', () => {
     const emitFunc = ttfbStub.getCall(1).args[0] as WebVitalOnReport;
 
     clock.tick(5000);
+    // Distinct from both the time origin (0) and the report time (5000) so the
+    // assertion below can only match the session part's zero time.
+    updateZeroTimeMillis(2000);
 
     const metric = {
       name: 'TTFB',
@@ -1666,7 +1740,7 @@ describe('WebVitalsInstrumentation', () => {
       'emb.web_vital.attribution.serverResponse': 20,
       'emb.web_vital.attribution.unattributed': 20,
     });
-    expect(record.hrTime).to.deep.equal([5, 0]);
+    expect(record.hrTime).to.deep.equal([2, 0]);
     const body = JSON.parse(record.body as string) as Record<string, unknown>;
     expect(body['waitingDuration']).to.equal(20);
     expect(body['cacheDuration']).to.equal(40);

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -312,18 +312,43 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
   }
 
   private _getTimeForMetric(metric: MetricWithAttribution): number {
-    if (metric.name === 'CLS' && metric.attribution.largestShiftTime) {
-      return this.perf.epochMillisFromOrigin(
-        metric.attribution.largestShiftTime,
-      );
-    }
-
-    if (metric.name === 'INP' && metric.attribution.interactionTime) {
+    // For INP use interactionTime, which is the start time of the user's interaction
+    if (metric.name === 'INP') {
       return this.perf.epochMillisFromOrigin(
         metric.attribution.interactionTime,
       );
     }
 
+    // For CLS use the first layout shift's startTime, which is the beginning of
+    // the  session window. Fall back to largestShiftTime if the entries aren't
+    // available for some reason.
+    if (metric.name === 'CLS') {
+      const windowStart =
+        metric.entries.length > 0
+          ? Math.min(...metric.entries.map((entry) => entry.startTime))
+          : metric.attribution.largestShiftTime;
+
+      if (windowStart !== undefined) {
+        return this.perf.epochMillisFromOrigin(windowStart);
+      }
+    }
+
+    // For TTFB use the "zero" time of the current session part
+    if (metric.name === 'TTFB') {
+      return this.perf.getZeroTime();
+    }
+
+    // For other metrics, use the startTime of the last entry. Note: in practice, web-vitals does
+    // not emit multiple entries for metrics other than CLS. However to future-proof this code,
+    // we are assuming that the last entry is the most relevant one.
+    const metricStartTime =
+      metric.entries[metric.entries.length - 1]?.startTime;
+
+    if (metricStartTime !== undefined) {
+      return this.perf.epochMillisFromOrigin(metricStartTime);
+    }
+
+    // Fall back to when the metric was reported
     return this.perf.getNowMillis();
   }
 

--- a/packages/web-sdk/src/utils/PerformanceManager/README.md
+++ b/packages/web-sdk/src/utils/PerformanceManager/README.md
@@ -170,9 +170,11 @@ One log per web-vital report.
 
 | Telemetry field | Source | Method |
 | --- | --- | --- |
-| log timestamp (CLS) | `attribution.largestShiftTime` | `epochMillisFromOrigin` |
 | log timestamp (INP) | `attribution.interactionTime` | `epochMillisFromOrigin` |
-| log timestamp (LCP / FCP / TTFB) | — (no per-event offset in attribution) | `getNowMillis()` at emission |
+| log timestamp (CLS) | earliest `entries[].startTime` — the layout shift window's start (fallback: `attribution.largestShiftTime`) | `epochMillisFromOrigin` |
+| log timestamp (TTFB) | — (the moment the user started viewing the current view) | `getZeroTime()` |
+| log timestamp (LCP / FCP) | last `entries[].startTime` | `epochMillisFromOrigin` |
+| log timestamp (no entries) | — | `getNowMillis()` at emission |
 | `browser.web_vital.value` / `.delta` | computed by the `web-vitals` library | none — see below |
 | TTFB sub-part attributes (`redirect`, `domainLookup`, `tcpConnection`, `tlsNegotiation`, `serverResponse`, `unattributed`) | differences of `PerformanceNavigationTiming` fields | none — pure durations |
 | raw attribution body (`includeRawAttribution`) | `metric.attribution` primitives, verbatim | none — intentionally a raw debug dump |


### PR DESCRIPTION
## What problem is this solving?

We have an inconsistency with how the log timestamps are set:

- CLS uses `metric.attribution.largestShiftTime`
- INP uses `metric.attribution.interactionTime`
- Everything else uses the time that web-vitals emitted the metric (`this.perf.getNowMillis()`)

Metrics can be emitted very long after they occur, so we are not capturing the correct timestamp for other metrics.

## Short description of changes

I believe the log timestamp should be the time when the metric actually started. For INP this is still `interactionTime`. For CLS it's the start of the first layout shift (which is also the start of the session window). For everything else it's the `PerformanceEntry.startTime` for the most recent entry*.

*<sup>in practice, most metrics only have one entry</sup>

⚠️ I have also bumped the bundle size limit from 56 -> 60 KB.

## How has this been tested?

Unit tests

## Checklist

- [ ] Documentation added
- [x] Tests added
