### PR TITLE
fix(web-vitals): update `PerformanceSoftNavigationTiming.navigationId` to match the spec

### DIFF
--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
@@ -33,7 +33,7 @@ const makeEntry = (
     entryType: 'soft-navigation',
     startTime: 200,
     duration: 50,
-    navigationId: 'nav-1',
+    navigationId: 1,
     interactionId: 7,
     paintTime: 230,
     presentationTime: 240,
@@ -194,7 +194,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
         name: 'https://example.com/next-page',
         startTime: 200,
         duration: 50,
-        navigationId: 'nav-1',
+        navigationId: 1,
         interactionId: 7,
         paintTime: 230,
         presentationTime: 240,
@@ -211,9 +211,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
     expect(span.attributes['emb.soft_navigation.source']).to.equal(
       'performance_observer',
     );
-    expect(span.attributes['emb.soft_navigation.navigation_id']).to.equal(
-      'nav-1',
-    );
+    expect(span.attributes['emb.soft_navigation.navigation_id']).to.equal(1);
     expect(span.attributes['emb.soft_navigation.interaction_id']).to.equal(7);
     expect(span.attributes['emb.soft_navigation.start_time']).to.equal(200);
     expect(span.attributes['emb.soft_navigation.duration']).to.equal(50);
@@ -324,9 +322,9 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
     });
 
     triggerEntries([
-      makeEntry({ navigationId: 'nav-0' }),
-      makeEntry({ navigationId: 'nav-1' }),
-      makeEntry({ navigationId: 'nav-2' }),
+      makeEntry({ navigationId: 0 }),
+      makeEntry({ navigationId: 1 }),
+      makeEntry({ navigationId: 2 }),
     ]);
 
     expect(spanExporter.getFinishedSpans()).to.have.length(2);

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/types.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/types.ts
@@ -9,7 +9,7 @@ export type SoftNavigationPerformanceInstrumentationArgs = Pick<
 };
 
 export type PerformanceSoftNavigationTiming = PerformanceEntry & {
-  navigationId: string;
+  navigationId: number;
   interactionId?: number;
   paintTime?: number | null;
   presentationTime?: number | null;


### PR DESCRIPTION
## What problem is this solving?

Using `number` to [match the spec](https://wicg.github.io/soft-navigations/#sec-pe-extension) means we have to do less type-juggling when we implement soft navigation support for web vitals.

<img width="493" height="187" alt="Screenshot 2026-07-09 at 6 55 43 PM" src="https://github.com/user-attachments/assets/3cd69686-4537-4b8e-9c58-a7b6d2ed4754" />

## Short description of changes

- Changed the type of `PerformanceSoftNavigationTiming.navigationId` from `string` to `number`

## How has this been tested?

Type checks

## Checklist

- [ ] Documentation added
- [ ] Tests added
