### PR TITLE
chore(demo): add watch-build to demo preview task

### DIFF
--- a/demo/frontend/package.json
+++ b/demo/frontend/package.json
@@ -9,6 +9,7 @@
     "dev": "vite --port 4847 --open",
     "build": "vite build",
     "preview": "vite preview --port 4847 --open",
+    "build:watch": "vite build --watch",
     "demo": "bash ./scripts/runDemo.sh",
     "upload-sourcemaps": "embrace-web-cli upload --app-version 0.0.1",
     "upload-sourcemaps:dry": "embrace-web-cli upload -d --app-version 0.0.1"

--- a/demo/frontend/turbo.json
+++ b/demo/frontend/turbo.json
@@ -6,8 +6,13 @@
       "dependsOn": ["clean", "^build"],
       "cache": false
     },
+    "build:watch": {
+      "dependsOn": ["^build"],
+      "cache": false,
+      "persistent": true
+    },
     "preview": {
-      "with": ["//#server"],
+      "with": ["//#server", "@embrace-io/web-sdk#dev", "build:watch"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## What problem is this solving?

When running the demo `preview`, changes to the SDK source and the demo frontend weren't picked up automatically, requiring manual rebuilds to see updates.

## Short description of changes

- Add a `build:watch` script (`vite build --watch`) to `demo/frontend`
- Define a persistent `build:watch` turbo task
- Wire `@embrace-io/web-sdk#dev` and `build:watch` into the `preview` task's `with` alongside the existing `//#server`, so the SDK and demo rebuild live while previewing

## How has this been tested?

Ran the demo `preview` task locally and confirmed source changes trigger rebuilds.

## Checklist

- [ ] Documentation added
- [ ] Tests added