### PR TITLE
EMBR-12978 refactor(processors): stamp span attributes in onEnding

### DIFF
--- a/packages/web-sdk/src/processors/BrowserSpanProcessor/BrowserSpanProcessor.ts
+++ b/packages/web-sdk/src/processors/BrowserSpanProcessor/BrowserSpanProcessor.ts
@@ -1,4 +1,4 @@
-import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace';
+import type { Span, SpanProcessor } from '@opentelemetry/sdk-trace';
 import type { URLDocument } from '../../common/index.ts';
 import { KEY_BROWSER_URL_FULL } from '../../constants/index.ts';
 import type { BrowserSpanProcessorArgs } from './types.ts';
@@ -19,13 +19,17 @@ export class BrowserSpanProcessor implements SpanProcessor {
     return Promise.resolve(undefined);
   }
 
-  public onEnd(span: ReadableSpan): void {
+  public onEnding(span: Span): void {
     if (!span.attributes[KEY_BROWSER_URL_FULL]) {
       span.attributes[KEY_BROWSER_URL_FULL] = this._urlDocument.URL;
     }
   }
 
   public onStart(this: void): void {
+    // do nothing.
+  }
+
+  public onEnd(this: void): void {
     // do nothing.
   }
 

--- a/packages/web-sdk/src/processors/EmbraceNetworkSpanProcessor/EmbraceNetworkSpanProcessor.ts
+++ b/packages/web-sdk/src/processors/EmbraceNetworkSpanProcessor/EmbraceNetworkSpanProcessor.ts
@@ -1,4 +1,4 @@
-import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace';
+import type { Span, SpanProcessor } from '@opentelemetry/sdk-trace';
 import {
   ATTR_HTTP_REQUEST_METHOD,
   ATTR_HTTP_RESPONSE_STATUS_CODE,
@@ -26,10 +26,8 @@ export class EmbraceNetworkSpanProcessor implements SpanProcessor {
     return Promise.resolve(undefined);
   }
 
-  // TODO `onEnd` is not supposed to modify the span. There is a new experimental onEnding api that allows modifying
-
-  //  the span before it is sent to the exporter. This processor should be updated to use that api once that is available
-  public onEnd(span: ReadableSpan): void {
+  // Read in onEnding because isNetworkSpan depends on the HTTP response status, which is only set at span end.
+  public onEnding(span: Span): void {
     if (isNetworkSpan(span)) {
       span.attributes[KEY_EMB_TYPE] = EMB_TYPES.Network;
 
@@ -53,6 +51,10 @@ export class EmbraceNetworkSpanProcessor implements SpanProcessor {
   }
 
   public onStart(this: void): void {
+    // do nothing.
+  }
+
+  public onEnd(this: void): void {
     // do nothing.
   }
 

--- a/packages/web-sdk/src/processors/PageSpanProcessor/PageSpanProcessor.ts
+++ b/packages/web-sdk/src/processors/PageSpanProcessor/PageSpanProcessor.ts
@@ -1,4 +1,4 @@
-import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace';
+import type { Span, SpanProcessor } from '@opentelemetry/sdk-trace';
 import type { PageManager } from '../../api-page/index.ts';
 import {
   KEY_APP_SURFACE_LABEL,
@@ -19,7 +19,7 @@ export class PageSpanProcessor implements SpanProcessor {
   }
 
   // Attach page attributes at span end to capture the page where the span completed
-  public onEnd(span: ReadableSpan): void {
+  public onEnding(span: Span): void {
     // If the span already has page attributes, do not override them
     if (
       !span.attributes[KEY_EMB_PAGE_PATH] ||
@@ -41,6 +41,10 @@ export class PageSpanProcessor implements SpanProcessor {
   }
 
   public onStart(this: void): void {
+    // do nothing.
+  }
+
+  public onEnd(this: void): void {
     // do nothing.
   }
 

--- a/packages/web-sdk/src/processors/SpanScrubProcessor/SpanScrubProcessor.ts
+++ b/packages/web-sdk/src/processors/SpanScrubProcessor/SpanScrubProcessor.ts
@@ -1,4 +1,4 @@
-import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace';
+import type { Span, SpanProcessor } from '@opentelemetry/sdk-trace';
 import type { AttributeScrubber } from '../../common/index.ts';
 import type { SpanScrubProcessorArgs } from './types.ts';
 
@@ -13,8 +13,7 @@ export class SpanScrubProcessor implements SpanProcessor {
     return Promise.resolve(undefined);
   }
 
-  // TODO `onEnd` is not supposed to modify the span. There is a new experimental onEnding api that allows modifying
-  public onEnd(span: ReadableSpan): void {
+  public onEnding(span: Span): void {
     this._attributeScrubbers.forEach((scrubber) => {
       const value = span.attributes[scrubber.key];
       if (value && typeof value === 'string') {
@@ -24,6 +23,10 @@ export class SpanScrubProcessor implements SpanProcessor {
   }
 
   public onStart(this: void): void {
+    // do nothing.
+  }
+
+  public onEnd(this: void): void {
     // do nothing.
   }
 

--- a/packages/web-sdk/src/processors/UserSpanProcessor/UserSpanProcessor.ts
+++ b/packages/web-sdk/src/processors/UserSpanProcessor/UserSpanProcessor.ts
@@ -1,4 +1,4 @@
-import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace';
+import type { Span, SpanProcessor } from '@opentelemetry/sdk-trace';
 import { ATTR_USER_ID } from '@opentelemetry/semantic-conventions/incubating';
 import type { UserManager } from '../../api-users/index.ts';
 import type { UserSpanProcessorArgs } from './types.ts';
@@ -17,9 +17,8 @@ export class UserSpanProcessor implements SpanProcessor {
     return Promise.resolve(undefined);
   }
 
-  // TODO `onEnd` is not supposed to modify the span. There is a new experimental onEnding api that allows modifying
-  // using onEnd to make sure we get the userId at the last possible moment in case it was set up after the span was started.
-  public onEnd(span: ReadableSpan): void {
+  // Read the userId in onEnding to catch an identity set after the span started.
+  public onEnding(span: Span): void {
     const userId = this._userManager.getUserId();
 
     if (userId) {
@@ -28,6 +27,10 @@ export class UserSpanProcessor implements SpanProcessor {
   }
 
   public onStart(this: void): void {
+    // do nothing.
+  }
+
+  public onEnd(this: void): void {
     // do nothing.
   }
 


### PR DESCRIPTION
## What problem is this solving?

Span processors mutate spans in `onEnd`, which receives a finalized `ReadableSpan` and is out of spec for mutation (three of them carried a TODO noting this). This moves all five stamping processors to the experimental `onEnding` hook, which receives a mutable `Span`. This is deliberately non-breaking: attributes are still stamped at the same point in the span lifecycle (span end), just via the correct hook.

First PR of the soft-navigation signal correlation work. Moving browser-URL / page attributes from span end to span start (start-context attribution) is a separate follow-up branch, kept out of scope here to avoid a behavior change.

## Short description of changes

- Move attribute stamping from `onEnd` to `onEnding` in `BrowserSpanProcessor`, `PageSpanProcessor`, `EmbraceNetworkSpanProcessor`, `UserSpanProcessor`, and `SpanScrubProcessor`.
- Keep the interface-required `onEnd` as a no-op in each.
- Drop the stale "migrate to onEnding" TODO comments; add a one-line WHY note on the network processor.
- `EmbraceSessionPartBatchedSpanProcessor` is unchanged: it batches and exports rather than mutates, so it correctly stays on `onEnd`.

## How has this been tested?

- Full web-sdk unit suite: 929 passing, 1 skipped, 0 failing.
- `npm run check` (tsc + eslint `--max-warnings 0`): 11/11 workspaces clean.
- Behavior is unchanged, so the existing per-processor tests are the regression guard and pass as-is under the new hook.

## Checklist

- [ ] Documentation added <!-- N/A: internal refactor, no user-facing API or docs change -->
- [ ] Tests added <!-- N/A: no behavior change; existing tests guard the refactor -->
