### PR TITLE
fix: cross-browser test determinism and missing FetchTransport coverage

### DIFF
--- a/packages/web-sdk/src/managers/EmbracePageManager/EmbracePageManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbracePageManager/EmbracePageManager.test.ts
@@ -11,35 +11,16 @@ import { EmbracePageManager } from './EmbracePageManager.ts';
 chai.use(sinonChai);
 const { expect } = chai;
 
-class FakeNavigation {
-  private readonly _listeners: Array<
-    (event: NavigationCurrentEntryChangeEvent) => void
-  > = [];
-
-  public addEventListener(
-    _type: 'currententrychange',
-    listener: (event: NavigationCurrentEntryChangeEvent) => void,
-  ): void {
-    this._listeners.push(listener);
-  }
-
-  public removeEventListener(
-    _type: 'currententrychange',
-    listener: (event: NavigationCurrentEntryChangeEvent) => void,
-  ): void {
-    const i = this._listeners.indexOf(listener);
-    if (i !== -1) {
-      this._listeners.splice(i, 1);
-    }
-  }
-
-  public fire(from: string): void {
+class FakeNavigation extends EventTarget {
+  public fire(from: string, timeStamp = performance.now()): void {
     const event = Object.assign(new Event('currententrychange'), {
       from: { url: from },
     }) as NavigationCurrentEntryChangeEvent;
-    for (const listener of [...this._listeners]) {
-      listener(event);
-    }
+    Object.defineProperty(event, 'timeStamp', {
+      value: timeStamp,
+      configurable: true,
+    });
+    this.dispatchEvent(event);
   }
 }
 
@@ -268,7 +249,7 @@ describe('EmbracePageManager', () => {
       const perf = new OTelPerformanceManager();
       const zeroTimeBefore = perf.getZeroTime();
 
-      navigation.fire('http://previous.example.com/');
+      navigation.fire('http://previous.example.com/', performance.now() + 1000);
 
       expect(perf.getZeroTime()).to.be.greaterThan(zeroTimeBefore);
     });

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
@@ -1,5 +1,6 @@
 import { DiagLogLevel, diag } from '@opentelemetry/api';
 import * as chai from 'chai';
+import * as sinon from 'sinon';
 import {
   fakeFetchGetKeepalive,
   fakeFetchInstall,
@@ -386,6 +387,45 @@ describe('FetchTransport', () => {
 
       expect(result.status).to.equal('retryable');
     });
+
+    it('should return failure when fetch throws a non-retryable error', async () => {
+      reinstallFetch().rejects(new Error('Some other network error'));
+
+      const transport = makeTransport();
+      const result = await transport.send(smallPayload, 1000);
+
+      expect(result.status).to.equal('failure');
+    });
+  });
+
+  describe('AbortSignal.timeout fallback', () => {
+    let originalTimeout: typeof AbortSignal.timeout | undefined;
+
+    beforeEach(() => {
+      // Simulates a browser without AbortSignal.timeout, forcing the
+      // AbortController + setTimeout fallback path.
+      originalTimeout = AbortSignal.timeout;
+      // @ts-expect-error deleting a normally-present static method
+      delete AbortSignal.timeout;
+    });
+
+    afterEach(() => {
+      AbortSignal.timeout = originalTimeout as typeof AbortSignal.timeout;
+    });
+
+    it('should clear the fallback timer once the request completes', async () => {
+      fakeFetchRespondWith('ok', { status: 200 });
+      const clearTimeoutSpy = sinon.spy(globalThis, 'clearTimeout');
+
+      try {
+        const transport = makeTransport();
+        await transport.send(smallPayload, 1000);
+
+        void expect(clearTimeoutSpy.calledOnce).to.be.true;
+      } finally {
+        clearTimeoutSpy.restore();
+      }
+    });
   });
 
   describe('HTTP status classification', () => {
@@ -463,6 +503,17 @@ describe('FetchTransport', () => {
       const match = debugs.find((msg) =>
         msg.includes('Fetch transport failed'),
       );
+      expect(match).to.be.a('string');
+    });
+
+    it('should warn via diag when fetch throws a non-retryable error', async () => {
+      reinstallFetch().rejects(new Error('Some other network error'));
+
+      const transport = makeTransport();
+      await transport.send(smallPayload, 1000);
+
+      const warns = diagLogger.getWarnLogs();
+      const match = warns.find((msg) => msg.includes('Fetch transport failed'));
       expect(match).to.be.a('string');
     });
 


### PR DESCRIPTION
## What problem is this solving?

Two unrelated test gaps found while working in this area:

1. `EmbracePageManager.test.ts`'s soft-navigation zero-time tests were flaky on Firefox and WebKit:
   - `FakeNavigation.fire()` constructed a `currententrychange` `Event` and invoked listeners directly instead of dispatching it through a real `EventTarget`. Some engines only populate `Event.timeStamp` on actual dispatch, leaving it at `0` otherwise.
   - The "advances the SDK zero time on soft navigation" test compared `getZeroTime()` before/after with no time gap in between, which could land in the same rounded timestamp bucket under WebKit's coarser timer resolution.