### PR TITLE
fix(deps): override fast-uri to ^3.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6645,9 +6645,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,9 @@
     "typescript-eslint": "8.64.0",
     "vite": "8.1.5"
   },
+  "overrides": {
+    "fast-uri": "^3.1.4"
+  },
   "packageManager": "npm@11.16.0",
   "devEngines": {
     "packageManager": {


### PR DESCRIPTION
## What is the problem this PR is solving?

`fast-uri` was resolving to `3.1.3` in the dependency tree (pulled in transitively via `@commitlint/cli` → `ajv@8.20.0`, which requests `fast-uri@^3.0.1`). This version is flagged by [Dependabot advisory #119](https://github.com/embrace-io/embrace-web-sdk/security/dependabot/119).

## Short description of the changes

Add a top-level npm `overrides` entry forcing `fast-uri` to `^3.1.4`, and regenerate `package-lock.json` accordingly. `fast-uri` now resolves at `3.1.4`. A general (unscoped) override was chosen so any future path that pulls in `fast-uri` also gets the patched version. The range stays within ajv's requested `^3.0.1`, so nothing downstream breaks. This is a dev-only dependency (commitlint tooling).

## How was this change tested?

- `npm install` regenerates the lockfile cleanly and reports `found 0 vulnerabilities`.
- `npm ls fast-uri` confirms resolution at `3.1.4`.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation if needed