### PR TITLE
EMBR-13168 fix(integration): graceful shutdown for playwright web servers

### DIFF
--- a/tests/integration/constants/test.ts
+++ b/tests/integration/constants/test.ts
@@ -2,4 +2,14 @@ const EMBRACE_API_REGEX =
   /^https:\/\/[a-z]-[a-z0-9]{5}\.data\.emb-api\.com\/v2\/(spans|logs)$/;
 const BASE_URL = 'http://localhost:3000';
 
-export { BASE_URL, EMBRACE_API_REGEX };
+// npm-wrapped webServer commands (npm run / npx) place their grandchildren in
+// separate process groups, so Playwright's default process-group SIGKILL never
+// reaches them. The survivors hold the command's stdio pipes open and teardown
+// waits on those pipes forever, hanging the runner after the last test. npm
+// relays SIGTERM down the whole chain, so ask Playwright to try that first.
+const GRACEFUL_SHUTDOWN = {
+  signal: 'SIGTERM',
+  timeout: 3000,
+} as const;
+
+export { BASE_URL, EMBRACE_API_REGEX, GRACEFUL_SHUTDOWN };

--- a/tests/integration/playwright.config.headed.ts
+++ b/tests/integration/playwright.config.headed.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { GRACEFUL_SHUTDOWN } from './constants/test.ts';
 
 // Headed-only config for manual verification of features that require real
 // browser interaction (e.g. the soft navigation polyfill, which depends on
@@ -13,12 +14,14 @@ export default defineConfig({
       command: 'cd platforms/vite-react-router && npx vite preview --port 3016',
       url: 'http://localhost:3016',
       reuseExistingServer: true,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'api',
       command: 'npm run server --prefix ../..',
       url: 'http://localhost:3001/health-check',
       reuseExistingServer: true,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
   ],
   projects: [

--- a/tests/integration/playwright.config.prebuilt.ts
+++ b/tests/integration/playwright.config.prebuilt.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { GRACEFUL_SHUTDOWN } from './constants/test.ts';
 
 // Config for fast iteration: assumes all platforms are already built and servers are already running.
 // Use with the --serve / --test modes of scripts/test-integration-podman.sh.
@@ -12,6 +13,7 @@ export default defineConfig({
       url: 'http://localhost:3010',
       reuseExistingServer: true,
       timeout: 30 * 1000,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'next-15-turbopack-pages',
@@ -19,6 +21,7 @@ export default defineConfig({
       url: 'http://localhost:3011',
       reuseExistingServer: true,
       timeout: 30 * 1000,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'next-15-webpack-app',
@@ -26,6 +29,7 @@ export default defineConfig({
       url: 'http://localhost:3012',
       reuseExistingServer: true,
       timeout: 30 * 1000,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'next-15-webpack-pages',
@@ -33,6 +37,7 @@ export default defineConfig({
       url: 'http://localhost:3013',
       reuseExistingServer: true,
       timeout: 30 * 1000,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'next-16-app',
@@ -40,6 +45,7 @@ export default defineConfig({
       url: 'http://localhost:3014',
       reuseExistingServer: true,
       timeout: 30 * 1000,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'next-16-pages',
@@ -47,6 +53,7 @@ export default defineConfig({
       url: 'http://localhost:3015',
       reuseExistingServer: true,
       timeout: 30 * 1000,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'vite-react-router',
@@ -54,6 +61,7 @@ export default defineConfig({
       url: 'http://localhost:3016',
       reuseExistingServer: true,
       timeout: 30 * 1000,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'api',
@@ -61,6 +69,7 @@ export default defineConfig({
       url: 'http://localhost:3001/health-check',
       reuseExistingServer: true,
       timeout: 30 * 1000,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
   ],
   testMatch: '**/*.spec.ts',

--- a/tests/integration/playwright.config.spa.ts
+++ b/tests/integration/playwright.config.spa.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { GRACEFUL_SHUTDOWN } from './constants/test.ts';
 
 export default defineConfig({
   timeout: 10 * 1000, // 10 seconds
@@ -9,12 +10,14 @@ export default defineConfig({
         'cd platforms/vite-react-router && npm run build && npx vite preview --port 3016',
       url: 'http://localhost:3016',
       reuseExistingServer: false,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'api',
       command: 'npm run server --prefix ../..',
       url: 'http://localhost:3001/health-check',
       reuseExistingServer: true,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
   ],
   testMatch: '**/vite-react-router-tests.spec.ts',

--- a/tests/integration/playwright.config.ts
+++ b/tests/integration/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { GRACEFUL_SHUTDOWN } from './constants/test.ts';
 
 export default defineConfig({
   timeout: 10 * 1000, // 10 seconds
@@ -9,6 +10,7 @@ export default defineConfig({
         'cd platforms/next-15-turbopack-app && npm run build && npx next start -p 3010',
       url: 'http://localhost:3010',
       reuseExistingServer: false,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'next-15-turbopack-pages',
@@ -16,6 +18,7 @@ export default defineConfig({
         'cd platforms/next-15-turbopack-pages && npm run build && npx next start -p 3011',
       url: 'http://localhost:3011',
       reuseExistingServer: false,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'next-15-webpack-app',
@@ -23,6 +26,7 @@ export default defineConfig({
         'cd platforms/next-15-webpack-app && npm run build && npx next start -p 3012',
       url: 'http://localhost:3012',
       reuseExistingServer: false,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'next-15-webpack-pages',
@@ -30,6 +34,7 @@ export default defineConfig({
         'cd platforms/next-15-webpack-pages && npm run build && npx next start -p 3013',
       url: 'http://localhost:3013',
       reuseExistingServer: false,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'next-16-app',
@@ -37,6 +42,7 @@ export default defineConfig({
         'cd platforms/next-16-app && npm run build && npx next start -p 3014',
       url: 'http://localhost:3014',
       reuseExistingServer: false,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'next-16-pages',
@@ -44,6 +50,7 @@ export default defineConfig({
         'cd platforms/next-16-pages && npm run build && npx next start -p 3015',
       url: 'http://localhost:3015',
       reuseExistingServer: false,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'vite-react-router',
@@ -51,12 +58,14 @@ export default defineConfig({
         'cd platforms/vite-react-router && npm run build && npx vite preview --port 3016',
       url: 'http://localhost:3016',
       reuseExistingServer: false,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
     {
       name: 'api',
       command: 'npm run server --prefix ../..',
       url: 'http://localhost:3001/health-check',
       reuseExistingServer: true,
+      gracefulShutdown: GRACEFUL_SHUTDOWN,
     },
   ],
   testMatch: '**/*.spec.ts',


### PR DESCRIPTION
## What problem are you trying to solve?

Running `npm run test:integration` natively (outside the podman container) hangs forever after the last test, with no summary printed. Playwright's default webServer teardown SIGKILLs each command's process group, but npm 11 (`npm run` / `npx`) places its subtree in a separate process group. The surviving orphans keep the command's stdio pipes open, and Playwright waits on pipe EOF for each webServer before exiting. Broken locally since the node 26.3.0 / npm 11.16.0 requirement (#1365); container CI is unaffected.

## Short description of the changes

Add `gracefulShutdown: { signal: 'SIGTERM', timeout: 3000 }` (shared `GRACEFUL_SHUTDOWN` constant in `tests/integration/constants/test.ts`) to every webServer entry in all four Playwright configs. npm relays SIGTERM down the whole child chain, so every descendant exits and teardown completes; SIGKILL remains the fallback after the timeout.

## How was this tested?

Full native `npm run test:integration` run: previously hung indefinitely after the last test; now exits on its own with code 0 (300 passed, 72 skipped), summary printed, and all 8 server ports released. Verified the mechanism directly: SIGTERM to a webServer process group takes down the whole npm chain, while the default group SIGKILL leaves `npm exec` subtrees orphaned and holding pipes.