### PR TITLE
EMBR-13244 fix: web vital session_part_id attribution race

### DIFF
--- a/packages/web-sdk/src/api-sessions/api/SessionAPI/SessionAPI.test.ts
+++ b/packages/web-sdk/src/api-sessions/api/SessionAPI/SessionAPI.test.ts
@@ -17,6 +17,7 @@ afterEach(() => {
 const createMockUserSessionManager = (): UserSessionManagerInternal => ({
   // Part identity
   getSessionPartId: sinon.stub().returns('partId'),
+  getSessionPartIdAt: sinon.stub().returns('partId'),
   getSessionPartSpan: sinon.stub().returns({} as Span),
   // Part lifecycle
   startSessionPartInternal: sinon.stub(),

--- a/packages/web-sdk/src/api-sessions/manager/NoOpUserSessionManager/NoOpUserSessionManager.ts
+++ b/packages/web-sdk/src/api-sessions/manager/NoOpUserSessionManager/NoOpUserSessionManager.ts
@@ -83,6 +83,10 @@ export class NoOpUserSessionManager implements UserSessionManagerInternal {
     return null;
   }
 
+  public getSessionPartIdAt(_timestampEpochMillis: number): string | null {
+    return null;
+  }
+
   public getSessionPartSpan(): ExtendedSpan | null {
     return null;
   }

--- a/packages/web-sdk/src/api-sessions/manager/ProxyUserSessionManager/ProxyUserSessionManager.test.ts
+++ b/packages/web-sdk/src/api-sessions/manager/ProxyUserSessionManager/ProxyUserSessionManager.test.ts
@@ -17,6 +17,7 @@ describe('ProxyUserSessionManager', () => {
     mockDelegate = {
       // Part identity
       getSessionPartId: sinon.stub().returns('part-id'),
+      getSessionPartIdAt: sinon.stub().returns('part-id'),
       getSessionPartSpan: sinon.stub().returns({} as Span),
       // Part lifecycle
       startSessionPartInternal: sinon.stub(),

--- a/packages/web-sdk/src/api-sessions/manager/ProxyUserSessionManager/ProxyUserSessionManager.ts
+++ b/packages/web-sdk/src/api-sessions/manager/ProxyUserSessionManager/ProxyUserSessionManager.ts
@@ -114,6 +114,10 @@ export class ProxyUserSessionManager implements UserSessionManagerInternal {
     return this.getDelegate().getSessionPartId();
   }
 
+  public getSessionPartIdAt(timestampEpochMillis: number): string | null {
+    return this.getDelegate().getSessionPartIdAt(timestampEpochMillis);
+  }
+
   public getSessionPartSpan(): ExtendedSpan | null {
     return this.getDelegate().getSessionPartSpan();
   }

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -12,7 +12,9 @@ import {
   InMemoryDiagLogger,
   MockPerformanceManager,
   setupTestLogExporter,
+  setupTestStorage,
   setupTestWebVitalListeners,
+  TEST_DYNAMIC_CONFIG_MANAGER,
 } from '../../../../tests/utils/index.ts';
 import {
   EMB_TYPES,
@@ -22,7 +24,12 @@ import {
   KEY_EMB_PAGE_PATH,
   KEY_EMB_TYPE,
 } from '../../../constants/index.ts';
-import { EmbracePageManager } from '../../../managers/index.ts';
+import {
+  DEFAULT_LIMITS,
+  EmbraceLimitManager,
+  EmbracePageManager,
+  EmbraceUserSessionManager,
+} from '../../../managers/index.ts';
 import {
   _resetZeroTimeMillisForTesting,
   updateZeroTimeMillis,
@@ -3730,6 +3737,136 @@ describe('WebVitalsInstrumentation', () => {
         [KEY_EMB_PAGE_PATH]: '/second/:id',
         [KEY_EMB_PAGE_ID]: attributedPageID,
       });
+    });
+  });
+
+  describe('session part attribution', () => {
+    let userSessionManager: EmbraceUserSessionManager;
+
+    beforeEach(() => {
+      const limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
+      const storage = setupTestStorage();
+      userSessionManager = new EmbraceUserSessionManager({
+        dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,
+        limitManager,
+        perf,
+        storage,
+        visibilityDoc: window.document,
+      });
+    });
+
+    it('should stamp the session part id active when the metric occurred, not the one active when the log is finally emitted', () => {
+      userSessionManager.startSessionPartInternal({ reason: 'init' });
+      const partAId = userSessionManager.getSessionPartId();
+      expect(partAId).to.not.be.null;
+
+      // Roll over to a second part before the metric is ever reported —
+      // web-vitals can defer CLS's report well past when the underlying
+      // shift occurred (e.g. until the tab backgrounds).
+      clock.tick(1000);
+      userSessionManager.endSessionPartInternal({ reason: 'background' });
+      userSessionManager.startSessionPartInternal({ reason: 'foreground' });
+      const partBId = userSessionManager.getSessionPartId();
+      expect(partBId).to.not.equal(partAId);
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlAttribution: false,
+      });
+      instrumentation.setUserSessionManager(userSessionManager);
+
+      const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+
+      // The underlying shift happened at time 0, during part A, even though
+      // the log is only emitted now, well into part B.
+      emitFunc({
+        name: 'CLS',
+        value: 0.1,
+        rating: 'good',
+        delta: 0.1,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        navigationId: 1,
+        attribution: { largestShiftTime: 0 },
+      } as MetricWithAttribution);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes['emb.session_part_id']).to.equal(partAId);
+    });
+
+    it('should stamp the new part id for a metric whose event happened after the rollover', () => {
+      userSessionManager.startSessionPartInternal({ reason: 'init' });
+      const partAId = userSessionManager.getSessionPartId();
+
+      clock.tick(1000);
+      userSessionManager.endSessionPartInternal({ reason: 'background' });
+      userSessionManager.startSessionPartInternal({ reason: 'foreground' });
+      const partBId = userSessionManager.getSessionPartId();
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlAttribution: false,
+      });
+      instrumentation.setUserSessionManager(userSessionManager);
+
+      const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+
+      // Shift happened at time 1500, after part B started at 1000.
+      emitFunc({
+        name: 'CLS',
+        value: 0.1,
+        rating: 'good',
+        delta: 0.1,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        navigationId: 1,
+        attribution: { largestShiftTime: 1500 },
+      } as MetricWithAttribution);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes['emb.session_part_id']).to.equal(partBId);
+      expect(records[0].attributes['emb.session_part_id']).to.not.equal(
+        partAId,
+      );
+    });
+
+    it('should stamp session_part_id even when urlAttribution is disabled', () => {
+      userSessionManager.startSessionPartInternal({ reason: 'init' });
+      const partId = userSessionManager.getSessionPartId();
+
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlAttribution: false,
+      });
+      instrumentation.setUserSessionManager(userSessionManager);
+
+      const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+
+      emitFunc({
+        name: 'CLS',
+        value: 0.1,
+        rating: 'good',
+        delta: 0.1,
+        id: 'm1',
+        entries: [],
+        navigationType: 'navigate',
+        navigationId: 1,
+        attribution: { largestShiftTime: 0 },
+      } as MetricWithAttribution);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records).to.have.lengthOf(1);
+      expect(records[0].attributes['emb.session_part_id']).to.equal(partId);
     });
   });
 });

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -20,6 +20,7 @@ import {
   KEY_BROWSER_URL_FULL,
   KEY_EMB_PAGE_ID,
   KEY_EMB_PAGE_PATH,
+  KEY_EMB_SESSION_PART_ID,
   KEY_EMB_TYPE,
 } from '../../../constants/index.ts';
 import { getSelector } from '../../../utils/index.ts';
@@ -477,6 +478,14 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
 
   private _emitWebVital(metric: MetricWithAttribution): void {
     const attributedPage = this._attributedPage[metric.name];
+    // Resolve by the metric's own event time rather than reading the
+    // currently active part: web-vitals can defer a metric's report well
+    // past when its underlying entry occurred (e.g. INP/CLS finalize on
+    // visibilitychange), by which point the part active at report time may
+    // not be the one the entry actually happened in.
+    const metricTimeMillis = this._getTimeForMetric(metric);
+    const sessionPartId =
+      this.userSessionManager.getSessionPartIdAt(metricTimeMillis);
     const logRecord: LogRecord = {
       eventName: WEB_VITAL_EVENT_NAME,
       severityNumber: SeverityNumber.INFO,
@@ -496,6 +505,9 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
               [KEY_BROWSER_WEB_VITAL_INTERACTION_ID]:
                 metric.navigationInteractionId,
             }
+          : {}),
+        ...(sessionPartId !== null
+          ? { [KEY_EMB_SESSION_PART_ID]: sessionPartId }
           : {}),
         ...(attributedPage
           ? {
@@ -537,7 +549,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
               ),
             )
           : undefined,
-      timestamp: millisToHrTime(this._getTimeForMetric(metric)),
+      timestamp: millisToHrTime(metricTimeMillis),
     };
 
     if (this._applyCustomLogRecordData) {

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -9,6 +9,7 @@ import {
   InMemoryStorage,
   MockPerformanceManager,
 } from '../../../tests/utils/index.ts';
+import type { VisibilityStateDocument } from '../../common/index.ts';
 import type { DynamicSDKConfig } from '../../sdk/index.ts';
 import { NamespacedStorage } from '../../utils/NamespacedStorage/NamespacedStorage.ts';
 import {
@@ -33,6 +34,17 @@ const lastEndCall = (
   }
   return spy.lastCall.args[0] as EndSessionPartOptions;
 };
+
+// Backed by a real EventTarget so tests can dispatch an actual
+// `visibilitychange` event and exercise the manager's real listener wiring,
+// rather than reaching into private handlers.
+class FakeVisibilityDocument
+  extends EventTarget
+  implements VisibilityStateDocument
+{
+  public visibilityState: DocumentVisibilityState = 'visible';
+  public hasFocus = (): boolean => true;
+}
 
 describe('EmbraceUserSessionManager', () => {
   let inMemoryStorage: InMemoryStorage;
@@ -340,6 +352,100 @@ describe('EmbraceUserSessionManager', () => {
         }),
       ).to.not.throw();
       void expect(manager.getSessionPartId()).to.be.null;
+    });
+  });
+
+  describe('getSessionPartIdAt', () => {
+    it('resolves the part active at a given timestamp across multiple rollovers', () => {
+      const manager = createManager();
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const partAId = manager.getSessionPartId();
+
+      clock.tick(1000);
+      manager.rolloverSessionPartInternal({
+        endReason: 'web_soft_navigation',
+        startReason: 'web_soft_navigation',
+      });
+      const partBId = manager.getSessionPartId();
+
+      clock.tick(1000);
+      manager.rolloverSessionPartInternal({
+        endReason: 'web_soft_navigation',
+        startReason: 'web_soft_navigation',
+      });
+      const partCId = manager.getSessionPartId();
+
+      expect(manager.getSessionPartIdAt(500)).to.equal(partAId);
+      expect(manager.getSessionPartIdAt(1500)).to.equal(partBId);
+      expect(manager.getSessionPartIdAt(2500)).to.equal(partCId);
+    });
+
+    it('falls back to the currently active part when the timestamp predates any recorded rollover', () => {
+      const manager = createManager();
+
+      clock.tick(1000);
+      manager.startSessionPartInternal({ reason: 'init' });
+      const partId = manager.getSessionPartId();
+
+      expect(manager.getSessionPartIdAt(0)).to.equal(partId);
+    });
+
+    it('falls back to null when no part has ever started', () => {
+      const manager = createManager();
+
+      void expect(manager.getSessionPartIdAt(0)).to.be.null;
+    });
+
+    it('resolves to the most recently created part even after it has closed, when nothing new has started since', () => {
+      const manager = createManager();
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const partId = manager.getSessionPartId();
+
+      clock.tick(1000);
+      manager.endSessionPartInternal({ reason: 'background' });
+      // A genuine gap: nothing is active, and nothing new has started yet
+      // (e.g. inactivity closed the part while a background script kept
+      // producing layout shifts with no real user activity to restart one).
+      void expect(manager.getSessionPartId()).to.be.null;
+
+      // The history only tracks start times, not end times, so a query for
+      // any time at/after the closed part's start — including one past its
+      // actual end — still resolves to it, since it remains the most
+      // recently created part as of that timestamp.
+      expect(manager.getSessionPartIdAt(1500)).to.equal(partId);
+    });
+
+    it('clears the rollover history once the tab becomes visible again, so a stale query falls back to the live part', () => {
+      const visibilityDoc = new FakeVisibilityDocument();
+      const manager = new EmbraceUserSessionManager({
+        diag,
+        perf: new MockPerformanceManager(clock),
+        storage,
+        limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
+        visibilityDoc,
+        dynamicConfigManager: createTestDynamicConfigManager(),
+      });
+      manager.setTracerProvider(new TracerProvider());
+
+      manager.startSessionPartInternal({ reason: 'init' });
+      const partAId = manager.getSessionPartId();
+
+      clock.tick(1000);
+      manager.endSessionPartInternal({ reason: 'background' });
+      manager.startSessionPartInternal({ reason: 'foreground' });
+      const partBId = manager.getSessionPartId();
+
+      // Before any visibility event, the history still resolves the
+      // pre-rollover timestamp to part A.
+      expect(manager.getSessionPartIdAt(0)).to.equal(partAId);
+
+      // Tab becomes visible again — anything pending from before this point
+      // is guaranteed to have already flushed, so the history clears.
+      visibilityDoc.dispatchEvent(new Event('visibilitychange'));
+
+      expect(manager.getSessionPartIdAt(0)).to.equal(partBId);
     });
   });
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.test.ts
@@ -9,7 +9,6 @@ import {
   InMemoryStorage,
   MockPerformanceManager,
 } from '../../../tests/utils/index.ts';
-import type { VisibilityStateDocument } from '../../common/index.ts';
 import type { DynamicSDKConfig } from '../../sdk/index.ts';
 import { NamespacedStorage } from '../../utils/NamespacedStorage/NamespacedStorage.ts';
 import {
@@ -34,17 +33,6 @@ const lastEndCall = (
   }
   return spy.lastCall.args[0] as EndSessionPartOptions;
 };
-
-// Backed by a real EventTarget so tests can dispatch an actual
-// `visibilitychange` event and exercise the manager's real listener wiring,
-// rather than reaching into private handlers.
-class FakeVisibilityDocument
-  extends EventTarget
-  implements VisibilityStateDocument
-{
-  public visibilityState: DocumentVisibilityState = 'visible';
-  public hasFocus = (): boolean => true;
-}
 
 describe('EmbraceUserSessionManager', () => {
   let inMemoryStorage: InMemoryStorage;
@@ -417,34 +405,20 @@ describe('EmbraceUserSessionManager', () => {
       expect(manager.getSessionPartIdAt(1500)).to.equal(partId);
     });
 
-    it('clears the rollover history once the tab becomes visible again, so a stale query falls back to the live part', () => {
-      const visibilityDoc = new FakeVisibilityDocument();
-      const manager = new EmbraceUserSessionManager({
-        diag,
-        perf: new MockPerformanceManager(clock),
-        storage,
-        limitManager: new EmbraceLimitManager(DEFAULT_LIMITS),
-        visibilityDoc,
-        dynamicConfigManager: createTestDynamicConfigManager(),
-      });
-      manager.setTracerProvider(new TracerProvider());
+    it('clears the rollover history once the user session ends', () => {
+      const manager = createManager();
 
       manager.startSessionPartInternal({ reason: 'init' });
       const partAId = manager.getSessionPartId();
 
       clock.tick(1000);
-      manager.endSessionPartInternal({ reason: 'background' });
-      manager.startSessionPartInternal({ reason: 'foreground' });
+      manager.endUserSession();
       const partBId = manager.getSessionPartId();
+      expect(partBId).to.not.equal(partAId);
 
-      // Before any visibility event, the history still resolves the
-      // pre-rollover timestamp to part A.
-      expect(manager.getSessionPartIdAt(0)).to.equal(partAId);
-
-      // Tab becomes visible again — anything pending from before this point
-      // is guaranteed to have already flushed, so the history clears.
-      visibilityDoc.dispatchEvent(new Event('visibilitychange'));
-
+      // The user session part A belonged to has ended, so nothing will
+      // ever need to resolve a timestamp against it again — the history
+      // clears and a stale query falls back to the new user session's part.
       expect(manager.getSessionPartIdAt(0)).to.equal(partBId);
     });
   });

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -112,6 +112,12 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   private _hasStoredState = false;
 
   private _activeSessionPartId: string | null = null;
+  // Rollover history backing getSessionPartIdAt, cleared once the tab
+  // becomes visible again
+  private _sessionPartHistory: Array<{
+    id: string;
+    startTimeEpochMillis: number;
+  }> = [];
   // Held for the part's lifetime so getUserSessionAttributes() reads
   // during the part return its starting value, even if another tab bumps
   // the shared counter while this tab is mid-disengagement.
@@ -340,6 +346,17 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     return this._activeSessionPartId;
   }
 
+  public getSessionPartIdAt(timestampEpochMillis: number): string | null {
+    for (let i = this._sessionPartHistory.length - 1; i >= 0; i--) {
+      if (
+        this._sessionPartHistory[i].startTimeEpochMillis <= timestampEpochMillis
+      ) {
+        return this._sessionPartHistory[i].id;
+      }
+    }
+    return this.getSessionPartId();
+  }
+
   public getSessionPartSpan(): ExtendedSpan | null {
     return this._sessionPartSpan;
   }
@@ -400,6 +417,10 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
     this._activeSessionPartCounts = {};
     this._nextSessionPartCounts = {};
     this._sessionPartSpan = span;
+    this._sessionPartHistory.push({
+      id: activeSessionPartId,
+      startTimeEpochMillis: timestamp ?? this._perf.getNowMillis(),
+    });
 
     this._startSessionPartInactivityTimer();
 
@@ -907,6 +928,9 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   // Tab visibility flipped (switch tabs, minimize, OS app switch). Drives
   // the engagement transition off the current visibilityState/hasFocus pair.
   private readonly _onVisibilityChange = (): void => {
+    if (getVisibilityState(this._visibilityDoc) !== EMB_STATES.Background) {
+      this._sessionPartHistory = [];
+    }
     this._handleEngagementTransition('visibilitychange');
   };
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/EmbraceUserSessionManager.ts
@@ -112,8 +112,9 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   private _hasStoredState = false;
 
   private _activeSessionPartId: string | null = null;
-  // Rollover history backing getSessionPartIdAt, cleared once the tab
-  // becomes visible again
+  // Rollover history backing getSessionPartIdAt, cleared once the user
+  // session ends, so it covers as much ground as possible before eviction
+  // rather than resetting on every visibility cycle.
   private _sessionPartHistory: Array<{
     id: string;
     startTimeEpochMillis: number;
@@ -512,6 +513,7 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
       this._state = null;
       this._storage.removeItem(EMBRACE_USER_SESSION_STATE_KEY);
       this._clearMaxDurationTimer();
+      this._sessionPartHistory = [];
     } else {
       this._continueUserSessionAfterPartEnd(now);
     }
@@ -928,9 +930,6 @@ export class EmbraceUserSessionManager implements UserSessionManagerInternal {
   // Tab visibility flipped (switch tabs, minimize, OS app switch). Drives
   // the engagement transition off the current visibilityState/hasFocus pair.
   private readonly _onVisibilityChange = (): void => {
-    if (getVisibilityState(this._visibilityDoc) !== EMB_STATES.Background) {
-      this._sessionPartHistory = [];
-    }
     this._handleEngagementTransition('visibilitychange');
   };
 

--- a/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
+++ b/packages/web-sdk/src/managers/EmbraceUserSessionManager/types.ts
@@ -130,6 +130,17 @@ export interface UserSessionManagerInternal extends UserSessionManager {
 
   getSessionPartId: () => string | null;
 
+  /**
+   * Resolves the session part active at a given timestamp, based on a
+   * rollover history rather than live state. This lets a caller that only
+   * learns of an event well after it happened (e.g. a metric library that
+   * defers its own reporting) attribute it to the part it actually
+   * occurred in, instead of whichever part happens to be active by the
+   * time it asks. Falls back to the currently active part (or null) when
+   * the timestamp predates any part recorded in the retained history.
+   */
+  getSessionPartIdAt: (timestampEpochMillis: number) => string | null;
+
   startSessionPartInternal: (options: StartSessionPartOptions) => void;
   endSessionPartInternal: (options: EndSessionPartOptions) => void;
   /**

--- a/packages/web-sdk/src/processors/UserSessionLogRecordProcessor/UserSessionLogRecordProcessor.test.ts
+++ b/packages/web-sdk/src/processors/UserSessionLogRecordProcessor/UserSessionLogRecordProcessor.test.ts
@@ -132,6 +132,25 @@ describe('UserSessionLogRecordProcessor', () => {
     ).to.be.undefined;
   });
 
+  it('should honor a session_part_id already stamped by an earlier processor instead of overwriting it with the live value', () => {
+    ({ memoryExporter, logger } = setup(
+      createMockUserSessionManager(mockAttributes, {
+        getSessionPartId: () => null,
+      }),
+    ));
+
+    logger.emit({
+      body: 'test log',
+      attributes: { 'emb.session_part_id': 'PART_SNAPSHOT' },
+    });
+
+    const finishedLogs = memoryExporter.getFinishedLogRecords();
+    expect(finishedLogs).to.have.lengthOf(1);
+    expect(finishedLogs[0].attributes['emb.session_part_id']).to.equal(
+      'PART_SNAPSHOT',
+    );
+  });
+
   it('should emit the previous user session id on emb.user_session_previous_id when available', () => {
     ({ memoryExporter, logger } = setup(
       createMockUserSessionManager(mockAttributes, {

--- a/packages/web-sdk/src/processors/UserSessionLogRecordProcessor/UserSessionLogRecordProcessor.ts
+++ b/packages/web-sdk/src/processors/UserSessionLogRecordProcessor/UserSessionLogRecordProcessor.ts
@@ -31,6 +31,11 @@ export class UserSessionLogRecordProcessor implements LogRecordProcessor {
     const userSessionId = this._userSessionManager.getUserSessionId() ?? '';
     const previousUserSessionId =
       this._userSessionManager.getPreviousUserSessionId() ?? '';
+    // If the log record already has a session part id, we use that
+    const sessionPartId =
+      logRecord.attributes[KEY_EMB_SESSION_PART_ID] ??
+      this._userSessionManager.getSessionPartId() ??
+      '';
 
     logRecord.setAttributes({
       [ATTR_LOG_RECORD_UID]: generateUUID(),
@@ -38,8 +43,7 @@ export class UserSessionLogRecordProcessor implements LogRecordProcessor {
       [ATTR_SESSION_PREVIOUS_ID]: previousUserSessionId,
       [KEY_EMB_USER_SESSION_ID]: userSessionId,
       [KEY_EMB_USER_SESSION_PREVIOUS_ID]: previousUserSessionId,
-      [KEY_EMB_SESSION_PART_ID]:
-        this._userSessionManager.getSessionPartId() ?? '',
+      [KEY_EMB_SESSION_PART_ID]: sessionPartId,
     });
   }
 


### PR DESCRIPTION
## What problem is this solving?

`emb.session_part_id` on `browser.web_vital` log records (INP, CLS) could be stamped incorrectly — empty, or attributed to the wrong session part — because it was resolved from whichever session part happened to be live at the moment the log was emitted, not at the time the metric's underlying event actually occurred. `web-vitals` backdates INP/CLS timestamps to the real interaction/shift time but defers the actual report to its own internal listener, which can fire well after the fact, once the session part has already ended.

## Short description of changes

- `EmbraceUserSessionManager` now keeps a rollover history (part id + start time), cleared once the enclosing user session ends, and exposes `getSessionPartIdAt(timestampEpochMillis)` to resolve the part active at an arbitrary past timestamp. Eviction is tied to user-session end rather than tab visibility so the history covers as much ground as possible before being reset.
- `WebVitalsInstrumentation` resolves `emb.session_part_id` from the metric's own event timestamp via that new method, instead of relying on the currently active session part.
- `UserSessionLogRecordProcessor` honors a pre-stamped `emb.session_part_id` when present, falling back to the live read otherwise.

## How has this been tested?

- Added unit tests on `EmbraceUserSessionManager` covering: multi-rollover resolution, falling back when a timestamp predates any recorded rollover, falling back when no part has ever started, resolving to the most-recently-created part even after it has closed, history persisting across a mere visibility restore, and history clearing once the user session ends.
- Added `WebVitalsInstrumentation` tests reproducing the original race (metric event time before a rollover, log emitted after) and confirming the fix, independent of `urlAttribution`.
- `npm run check` and the full `npm run test` suite pass.

## Checklist

- [ ] Documentation added (not applicable — internal SDK behavior only)
- [x] Tests added