### PR TITLE
EMBR-13077 feat(web-vitals): capture LCP element type and bounding rect attribution

### DIFF
--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -376,8 +376,8 @@ describe('WebVitalsInstrumentation', () => {
     const records = memoryExporter.getFinishedLogRecords();
     expect(records).to.have.lengthOf(1);
     const attrs = records[0].attributes;
-    expect(attrs['emb.web_vital.attribution.lcpElementType']).to.equal('img');
-    expect(attrs['emb.web_vital.attribution.lcpElementBoundingRect']).to.equal(
+    expect(attrs['emb.web_vital.attribution.elementType']).to.equal('img');
+    expect(attrs['emb.web_vital.attribution.elementBoundingRect']).to.equal(
       JSON.stringify({ x: -12, y: 101, width: 300, height: 151 }),
     );
   });
@@ -413,8 +413,8 @@ describe('WebVitalsInstrumentation', () => {
     const records = memoryExporter.getFinishedLogRecords();
     expect(records).to.have.lengthOf(1);
     expect(records[0].attributes).to.not.have.any.keys([
-      'emb.web_vital.attribution.lcpElementType',
-      'emb.web_vital.attribution.lcpElementBoundingRect',
+      'emb.web_vital.attribution.elementType',
+      'emb.web_vital.attribution.elementBoundingRect',
     ]);
   });
 
@@ -457,8 +457,8 @@ describe('WebVitalsInstrumentation', () => {
     const records = memoryExporter.getFinishedLogRecords();
     expect(records).to.have.lengthOf(1);
     expect(records[0].attributes).to.not.have.any.keys([
-      'emb.web_vital.attribution.lcpElementType',
-      'emb.web_vital.attribution.lcpElementBoundingRect',
+      'emb.web_vital.attribution.elementType',
+      'emb.web_vital.attribution.elementBoundingRect',
     ]);
     expect(diag.getErrorLogs()).to.include(
       'error building LCP element attribution',

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -376,8 +376,8 @@ describe('WebVitalsInstrumentation', () => {
     const records = memoryExporter.getFinishedLogRecords();
     expect(records).to.have.lengthOf(1);
     const attrs = records[0].attributes;
-    expect(attrs['emb.web_vital.attribution.LCPElementType']).to.equal('img');
-    expect(attrs['emb.web_vital.attribution.LCPElementBoundingRect']).to.equal(
+    expect(attrs['emb.web_vital.attribution.lcpElementType']).to.equal('img');
+    expect(attrs['emb.web_vital.attribution.lcpElementBoundingRect']).to.equal(
       JSON.stringify({ x: -12, y: 101, width: 300, height: 151 }),
     );
   });
@@ -413,8 +413,8 @@ describe('WebVitalsInstrumentation', () => {
     const records = memoryExporter.getFinishedLogRecords();
     expect(records).to.have.lengthOf(1);
     expect(records[0].attributes).to.not.have.any.keys([
-      'emb.web_vital.attribution.LCPElementType',
-      'emb.web_vital.attribution.LCPElementBoundingRect',
+      'emb.web_vital.attribution.lcpElementType',
+      'emb.web_vital.attribution.lcpElementBoundingRect',
     ]);
   });
 
@@ -457,8 +457,8 @@ describe('WebVitalsInstrumentation', () => {
     const records = memoryExporter.getFinishedLogRecords();
     expect(records).to.have.lengthOf(1);
     expect(records[0].attributes).to.not.have.any.keys([
-      'emb.web_vital.attribution.LCPElementType',
-      'emb.web_vital.attribution.LCPElementBoundingRect',
+      'emb.web_vital.attribution.lcpElementType',
+      'emb.web_vital.attribution.lcpElementBoundingRect',
     ]);
     expect(diag.getErrorLogs()).to.include(
       'error building LCP element attribution',

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -334,6 +334,137 @@ describe('WebVitalsInstrumentation', () => {
     expect(body['elementRenderDelay']).to.equal(3000);
   });
 
+  it('should include LCP element type and bounding rect when the element is available', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const metricReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
+    clock.tick(5000);
+
+    metricReportFunc({
+      name: 'LCP',
+      value: 22,
+      rating: 'poor',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      navigationId: 1,
+      attribution: {
+        timeToFirstByte: 999,
+        resourceLoadDelay: 1000,
+        resourceLoadDuration: 2000,
+        elementRenderDelay: 3000,
+        lcpEntry: {
+          element: {
+            tagName: 'IMG',
+            getBoundingClientRect: () => ({
+              x: -12.4,
+              y: 100.6,
+              width: 300.2,
+              height: 150.8,
+            }),
+          },
+        },
+      },
+    } as unknown as MetricWithAttribution);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const attrs = records[0].attributes;
+    expect(attrs['emb.web_vital.attribution.LCPElementType']).to.equal('img');
+    expect(attrs['emb.web_vital.attribution.LCPElementBoundingRect']).to.equal(
+      JSON.stringify({ x: -12, y: 101, width: 300, height: 151 }),
+    );
+  });
+
+  it('should omit LCP element attributes when the element is unavailable', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const metricReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
+    clock.tick(5000);
+
+    metricReportFunc({
+      name: 'LCP',
+      value: 22,
+      rating: 'poor',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      navigationId: 1,
+      attribution: {
+        timeToFirstByte: 999,
+        resourceLoadDelay: 1000,
+        resourceLoadDuration: 2000,
+        elementRenderDelay: 3000,
+      },
+    } as MetricWithAttribution);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    expect(records[0].attributes).to.not.have.any.keys([
+      'emb.web_vital.attribution.LCPElementType',
+      'emb.web_vital.attribution.LCPElementBoundingRect',
+    ]);
+  });
+
+  it('should still emit the LCP record and log when reading the element throws', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const metricReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
+    clock.tick(5000);
+
+    metricReportFunc({
+      name: 'LCP',
+      value: 22,
+      rating: 'poor',
+      delta: 0,
+      id: 'm1',
+      entries: [],
+      navigationType: 'navigate',
+      navigationId: 1,
+      attribution: {
+        timeToFirstByte: 999,
+        resourceLoadDelay: 1000,
+        resourceLoadDuration: 2000,
+        elementRenderDelay: 3000,
+        lcpEntry: {
+          element: {
+            tagName: 'IMG',
+            getBoundingClientRect: () => {
+              throw new Error('boom');
+            },
+          },
+        },
+      },
+    } as unknown as MetricWithAttribution);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    expect(records[0].attributes).to.not.have.any.keys([
+      'emb.web_vital.attribution.LCPElementType',
+      'emb.web_vital.attribution.LCPElementBoundingRect',
+    ]);
+    expect(diag.getErrorLogs()).to.include(
+      'error building LCP element attribution',
+    );
+  });
+
   it('should report INP metrics as a log record', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -206,10 +206,10 @@ const lcpElementAttribution = (
     if (element) {
       const prefix = KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX;
       const rect = element.getBoundingClientRect();
-      attributes[`${prefix}LCPElementType`] = element.tagName.toLowerCase();
+      attributes[`${prefix}lcpElementType`] = element.tagName.toLowerCase();
       // x/y are intentionally not clamped: an element scrolled above the
       // viewport legitimately has a negative position.
-      attributes[`${prefix}LCPElementBoundingRect`] = JSON.stringify({
+      attributes[`${prefix}lcpElementBoundingRect`] = JSON.stringify({
         x: Math.round(rect.x),
         y: Math.round(rect.y),
         width: Math.round(rect.width),

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -6,6 +6,7 @@ import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
 import type {
   CLSMetricWithAttribution,
   INPAttribution,
+  LCPAttribution,
   Metric,
   MetricWithAttribution,
   TTFBAttribution,
@@ -187,6 +188,36 @@ const ttfbSubPartsAttribution = (
     }
   } else {
     diag.debug('TTFB navigationEntry unavailable, skipping timing breakdown');
+  }
+
+  return attributes;
+};
+
+const lcpElementAttribution = (
+  metric: MetricWithAttribution,
+  diag: DiagLogger,
+): Attributes => {
+  const attributes: Attributes = {};
+
+  try {
+    const attribution = metric.attribution as LCPAttribution;
+    const element = attribution.lcpEntry?.element;
+
+    if (element) {
+      const prefix = KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX;
+      const rect = element.getBoundingClientRect();
+      attributes[`${prefix}LCPElementType`] = element.tagName.toLowerCase();
+      // x/y are intentionally not clamped: an element scrolled above the
+      // viewport legitimately has a negative position.
+      attributes[`${prefix}LCPElementBoundingRect`] = JSON.stringify({
+        x: Math.round(rect.x),
+        y: Math.round(rect.y),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+      });
+    }
+  } catch (e) {
+    diag.error('error building LCP element attribution', e);
   }
 
   return attributes;
@@ -416,6 +447,9 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
           : {}),
         ...(metric.name === 'TTFB'
           ? ttfbSubPartsAttribution(metric, this._diag)
+          : {}),
+        ...(metric.name === 'LCP'
+          ? lcpElementAttribution(metric, this._diag)
           : {}),
       },
       body:

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -206,10 +206,10 @@ const lcpElementAttribution = (
     if (element) {
       const prefix = KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX;
       const rect = element.getBoundingClientRect();
-      attributes[`${prefix}lcpElementType`] = element.tagName.toLowerCase();
+      attributes[`${prefix}elementType`] = element.tagName.toLowerCase();
       // x/y are intentionally not clamped: an element scrolled above the
       // viewport legitimately has a negative position.
-      attributes[`${prefix}lcpElementBoundingRect`] = JSON.stringify({
+      attributes[`${prefix}elementBoundingRect`] = JSON.stringify({
         x: Math.round(rect.x),
         y: Math.round(rect.y),
         width: Math.round(rect.width),

--- a/tests/integration/platforms/vite-6/src/main.tsx
+++ b/tests/integration/platforms/vite-6/src/main.tsx
@@ -5,7 +5,12 @@ import SDKTest from './SDKTest.tsx';
 const App = () => {
   return (
     <>
-      <h1>Hello from React + TypeScript + Vite!</h1>
+      {/* Fixed-size block so the LCP element's bounding rect is identical
+          across browsers; a text heading's box height drifts with the
+          browser's default font, making the golden nondeterministic. */}
+      <div style={{ width: '600px', height: '400px' }}>
+        Hello from React + TypeScript + Vite!
+      </div>
       <SDKTest />
     </>
   );

--- a/tests/integration/platforms/vite-7/src/main.tsx
+++ b/tests/integration/platforms/vite-7/src/main.tsx
@@ -5,7 +5,12 @@ import SDKTest from './SDKTest.tsx';
 const App = () => {
   return (
     <>
-      <h1>Hello from React + TypeScript + Vite!</h1>
+      {/* Fixed-size block so the LCP element's bounding rect is identical
+          across browsers; a text heading's box height drifts with the
+          browser's default font, making the golden nondeterministic. */}
+      <div style={{ width: '600px', height: '400px' }}>
+        Hello from React + TypeScript + Vite!
+      </div>
       <SDKTest />
     </>
   );

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "58C65E6606801A73344CD5B3FD0DD08B"
+              "stringValue": "CE6007E0A177B0E52C3073F123B33D5D"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784844301701800049",
-              "observedTimeUnixNano": "1784844301703000000",
+              "timeUnixNano": "1784907393854100098",
+              "observedTimeUnixNano": "1784907393857000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":0.6999999992549419,\"dnsDuration\":0,\"connectionDuration\":0.09999999776482582,\"requestDuration\":0.4000000022351742}"
+                "stringValue": "{\"waitingDuration\":0.09999999986030161,\"cacheDuration\":1.4000000001396984,\"dnsDuration\":0.2999999998137355,\"connectionDuration\":0.10000000009313226,\"requestDuration\":0.8999999999068677}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 1.199999999254942
+                    "doubleValue": 2.7999999998137355
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 1.199999999254942
+                    "doubleValue": 2.7999999998137355
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784844301700-1452086545007"
+                    "stringValue": "v6-1784907393851-6808487769283"
                   }
                 },
                 {
@@ -157,7 +157,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "B489E1EC714D09B0A28041FBB503B344"
+                    "stringValue": "7EC3C48311AEFD2EE099ED0B7F47286C"
                   }
                 },
                 {
@@ -193,25 +193,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 0
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 1
+                    "intValue": 2
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "8687FE38CA88178183C04224139CF676"
+                    "stringValue": "90267456A220B58132B74ED2148A9D24"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
+                    "stringValue": "D0C9BEC7CE6067E3A775290C3208BC07"
                   }
                 },
                 {
@@ -223,7 +223,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
+                    "stringValue": "D0C9BEC7CE6067E3A775290C3208BC07"
                   }
                 },
                 {
@@ -235,7 +235,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "63B63813B54284E95CD0D025ACE02997"
+                    "stringValue": "D2EC2963BC1145EFD55FA6E92B6B29BB"
                   }
                 },
                 {
@@ -248,11 +248,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1784844301714600098",
-              "observedTimeUnixNano": "1784844301718000000",
+              "timeUnixNano": "1784907393868000000",
+              "observedTimeUnixNano": "1784907393870000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":1.199999999254942,\"firstByteToFCP\":46.80000000074506,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":2.7999999998137355,\"firstByteToFCP\":77.20000000018626,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -271,13 +271,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 48
+                    "intValue": 80
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 48
+                    "intValue": 80
                   }
                 },
                 {
@@ -289,7 +289,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784844301700-2075791342585"
+                    "stringValue": "v6-1784907393851-1550583745443"
                   }
                 },
                 {
@@ -319,7 +319,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "B489E1EC714D09B0A28041FBB503B344"
+                    "stringValue": "7EC3C48311AEFD2EE099ED0B7F47286C"
                   }
                 },
                 {
@@ -331,13 +331,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "D35A8204002532571753BFBF262B9CF3"
+                    "stringValue": "1664895CBDAA0611842842E59C9F408E"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
+                    "stringValue": "D0C9BEC7CE6067E3A775290C3208BC07"
                   }
                 },
                 {
@@ -349,7 +349,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
+                    "stringValue": "D0C9BEC7CE6067E3A775290C3208BC07"
                   }
                 },
                 {
@@ -361,7 +361,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "63B63813B54284E95CD0D025ACE02997"
+                    "stringValue": "D2EC2963BC1145EFD55FA6E92B6B29BB"
                   }
                 },
                 {
@@ -374,11 +374,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1784844301714600098",
-              "observedTimeUnixNano": "1784844301826000000",
+              "timeUnixNano": "1784907393868000000",
+              "observedTimeUnixNano": "1784907393987000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":1.199999999254942,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":46.80000000074506,\"target\":\"#root>div\"}"
+                "stringValue": "{\"timeToFirstByte\":2.7999999998137355,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":77.20000000018626,\"target\":\"#root>div\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -397,13 +397,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 48
+                    "intValue": 80
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 48
+                    "intValue": 80
                   }
                 },
                 {
@@ -415,7 +415,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784844301699-9718107434606"
+                    "stringValue": "v6-1784907393850-8575040447188"
                   }
                 },
                 {
@@ -445,7 +445,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "B489E1EC714D09B0A28041FBB503B344"
+                    "stringValue": "7EC3C48311AEFD2EE099ED0B7F47286C"
                   }
                 },
                 {
@@ -455,13 +455,13 @@
                   }
                 },
                 {
-                  "key": "emb.web_vital.attribution.lcpElementType",
+                  "key": "emb.web_vital.attribution.elementType",
                   "value": {
                     "stringValue": "div"
                   }
                 },
                 {
-                  "key": "emb.web_vital.attribution.lcpElementBoundingRect",
+                  "key": "emb.web_vital.attribution.elementBoundingRect",
                   "value": {
                     "stringValue": "{\"x\":8,\"y\":8,\"width\":600,\"height\":400}"
                   }
@@ -469,13 +469,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "A3CEC2E96B43E2970F3AEEC79581772E"
+                    "stringValue": "EDDB326354F48CAC8B7CFC3251F9B4B1"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
+                    "stringValue": "D0C9BEC7CE6067E3A775290C3208BC07"
                   }
                 },
                 {
@@ -487,7 +487,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
+                    "stringValue": "D0C9BEC7CE6067E3A775290C3208BC07"
                   }
                 },
                 {
@@ -499,7 +499,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "63B63813B54284E95CD0D025ACE02997"
+                    "stringValue": "D2EC2963BC1145EFD55FA6E92B6B29BB"
                   }
                 },
                 {
@@ -520,8 +520,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784844301819500000",
-              "observedTimeUnixNano": "1784844301820000000",
+              "timeUnixNano": "1784907393980000000",
+              "observedTimeUnixNano": "1784907393982000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -553,7 +553,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "doubleValue": 117.70004882663488
+                    "doubleValue": 125.89990234375
                   }
                 },
                 {
@@ -571,13 +571,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "5C817155E51D611544DE3D38D8BD10B1"
+                    "stringValue": "84FF888387B0E8638E1AFCB391C54B47"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
+                    "stringValue": "D0C9BEC7CE6067E3A775290C3208BC07"
                   }
                 },
                 {
@@ -589,7 +589,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
+                    "stringValue": "D0C9BEC7CE6067E3A775290C3208BC07"
                   }
                 },
                 {
@@ -601,7 +601,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "63B63813B54284E95CD0D025ACE02997"
+                    "stringValue": "D2EC2963BC1145EFD55FA6E92B6B29BB"
                   }
                 },
                 {
@@ -625,7 +625,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "B489E1EC714D09B0A28041FBB503B344"
+                    "stringValue": "7EC3C48311AEFD2EE099ED0B7F47286C"
                   }
                 },
                 {
@@ -645,8 +645,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784844302237000000",
-              "observedTimeUnixNano": "1784844302237000000",
+              "timeUnixNano": "1784907394406600098",
+              "observedTimeUnixNano": "1784907394406000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -662,13 +662,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at of.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:100162)\n    at Xb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263325\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:999\n    at new Promise (<anonymous>)\n    at Pt (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:819)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263297)\n    at cg (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127507)"
+                    "stringValue": "Error\n    at lf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:99838)\n    at kb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:262208\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:1:999\n    at new Promise (<anonymous>)\n    at Pt (http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:1:819)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:262180)\n    at ug (http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:127507)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:126\":\"25761f013d0aefdb0aeb1de60c3c3b51\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:11:126\":\"20f3b7a0ebcb6792188dfd8be7538be9\"}"
                   }
                 },
                 {
@@ -680,13 +680,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "C39190A9B6DA940A9BCC25E3C2ADA290"
+                    "stringValue": "21764EBDE9BD263ABB410B174E23D90D"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
+                    "stringValue": "D0C9BEC7CE6067E3A775290C3208BC07"
                   }
                 },
                 {
@@ -698,7 +698,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
+                    "stringValue": "D0C9BEC7CE6067E3A775290C3208BC07"
                   }
                 },
                 {
@@ -710,7 +710,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "63B63813B54284E95CD0D025ACE02997"
+                    "stringValue": "D2EC2963BC1145EFD55FA6E92B6B29BB"
                   }
                 },
                 {
@@ -734,7 +734,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "B489E1EC714D09B0A28041FBB503B344"
+                    "stringValue": "7EC3C48311AEFD2EE099ED0B7F47286C"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "8B50B378C163D9F6923C79B85AED5124"
+              "stringValue": "58C65E6606801A73344CD5B3FD0DD08B"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784708683009500000",
-              "observedTimeUnixNano": "1784708683011000000",
+              "timeUnixNano": "1784844301701800049",
+              "observedTimeUnixNano": "1784844301703000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":0.699999988079071,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":0.30000001192092896}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":0.6999999992549419,\"dnsDuration\":0,\"connectionDuration\":0.09999999776482582,\"requestDuration\":0.4000000022351742}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 1
+                    "doubleValue": 1.199999999254942
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 1
+                    "doubleValue": 1.199999999254942
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784708683007-3817971312861"
+                    "stringValue": "v6-1784844301700-1452086545007"
                   }
                 },
                 {
@@ -157,7 +157,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "959EC6E6E9879F03FFA99262F7DA57A6"
+                    "stringValue": "B489E1EC714D09B0A28041FBB503B344"
                   }
                 },
                 {
@@ -205,13 +205,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "98FB0E883BC64F6ADD2EB50C8C856AF7"
+                    "stringValue": "8687FE38CA88178183C04224139CF676"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5FA64F60CF96ECEAA7E847AA48BDD6E8"
+                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
                   }
                 },
                 {
@@ -223,7 +223,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5FA64F60CF96ECEAA7E847AA48BDD6E8"
+                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
                   }
                 },
                 {
@@ -235,7 +235,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "132173267D3750008662F83F0B4A8748"
+                    "stringValue": "63B63813B54284E95CD0D025ACE02997"
                   }
                 },
                 {
@@ -248,11 +248,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1784708683018899902",
-              "observedTimeUnixNano": "1784708683021000000",
+              "timeUnixNano": "1784844301714600098",
+              "observedTimeUnixNano": "1784844301718000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":1,\"firstByteToFCP\":39,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":1.199999999254942,\"firstByteToFCP\":46.80000000074506,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -271,13 +271,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 40
+                    "intValue": 48
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 40
+                    "intValue": 48
                   }
                 },
                 {
@@ -289,7 +289,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784708683007-6181649062619"
+                    "stringValue": "v6-1784844301700-2075791342585"
                   }
                 },
                 {
@@ -319,7 +319,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "959EC6E6E9879F03FFA99262F7DA57A6"
+                    "stringValue": "B489E1EC714D09B0A28041FBB503B344"
                   }
                 },
                 {
@@ -331,13 +331,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0021E8C97E6FACBB30636D014250E9EA"
+                    "stringValue": "D35A8204002532571753BFBF262B9CF3"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5FA64F60CF96ECEAA7E847AA48BDD6E8"
+                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
                   }
                 },
                 {
@@ -349,7 +349,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5FA64F60CF96ECEAA7E847AA48BDD6E8"
+                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
                   }
                 },
                 {
@@ -361,7 +361,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "132173267D3750008662F83F0B4A8748"
+                    "stringValue": "63B63813B54284E95CD0D025ACE02997"
                   }
                 },
                 {
@@ -374,11 +374,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1784708683018899902",
-              "observedTimeUnixNano": "1784708683139000000",
+              "timeUnixNano": "1784844301714600098",
+              "observedTimeUnixNano": "1784844301826000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":1,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":39,\"target\":\"#root>h1\"}"
+                "stringValue": "{\"timeToFirstByte\":1.199999999254942,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":46.80000000074506,\"target\":\"#root>div\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -397,13 +397,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 40
+                    "intValue": 48
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 40
+                    "intValue": 48
                   }
                 },
                 {
@@ -415,7 +415,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784708683007-5603772207710"
+                    "stringValue": "v6-1784844301699-9718107434606"
                   }
                 },
                 {
@@ -445,7 +445,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "959EC6E6E9879F03FFA99262F7DA57A6"
+                    "stringValue": "B489E1EC714D09B0A28041FBB503B344"
                   }
                 },
                 {
@@ -455,15 +455,27 @@
                   }
                 },
                 {
+                  "key": "emb.web_vital.attribution.lcpElementType",
+                  "value": {
+                    "stringValue": "div"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.lcpElementBoundingRect",
+                  "value": {
+                    "stringValue": "{\"x\":8,\"y\":8,\"width\":600,\"height\":400}"
+                  }
+                },
+                {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "BD80016FFEC992A1DB3AE4D431797262"
+                    "stringValue": "A3CEC2E96B43E2970F3AEEC79581772E"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5FA64F60CF96ECEAA7E847AA48BDD6E8"
+                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
                   }
                 },
                 {
@@ -475,7 +487,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5FA64F60CF96ECEAA7E847AA48BDD6E8"
+                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
                   }
                 },
                 {
@@ -487,7 +499,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "132173267D3750008662F83F0B4A8748"
+                    "stringValue": "63B63813B54284E95CD0D025ACE02997"
                   }
                 },
                 {
@@ -508,8 +520,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784708683131000000",
-              "observedTimeUnixNano": "1784708683132000000",
+              "timeUnixNano": "1784844301819500000",
+              "observedTimeUnixNano": "1784844301820000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -541,7 +553,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "doubleValue": 121.49990230798721
+                    "doubleValue": 117.70004882663488
                   }
                 },
                 {
@@ -553,19 +565,19 @@
                 {
                   "key": "first_interaction.y",
                   "value": {
-                    "intValue": 90
+                    "intValue": 418
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "2EC4153E2E82B1FA293F6F69E95E6CAF"
+                    "stringValue": "5C817155E51D611544DE3D38D8BD10B1"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5FA64F60CF96ECEAA7E847AA48BDD6E8"
+                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
                   }
                 },
                 {
@@ -577,7 +589,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5FA64F60CF96ECEAA7E847AA48BDD6E8"
+                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
                   }
                 },
                 {
@@ -589,7 +601,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "132173267D3750008662F83F0B4A8748"
+                    "stringValue": "63B63813B54284E95CD0D025ACE02997"
                   }
                 },
                 {
@@ -613,7 +625,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "959EC6E6E9879F03FFA99262F7DA57A6"
+                    "stringValue": "B489E1EC714D09B0A28041FBB503B344"
                   }
                 },
                 {
@@ -633,8 +645,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784708683547399902",
-              "observedTimeUnixNano": "1784708683547000000",
+              "timeUnixNano": "1784844302237000000",
+              "observedTimeUnixNano": "1784844302237000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -650,13 +662,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at ff.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:97579)\n    at Xb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:257992\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:1:966\n    at new Promise (<anonymous>)\n    at Bt (http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:1:786)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:257964)\n    at dg (http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:127505)"
+                    "stringValue": "Error\n    at of.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:100162)\n    at Xb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263325\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:999\n    at new Promise (<anonymous>)\n    at Pt (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:819)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263297)\n    at cg (http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127507)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:11:126\":\"c4efd0af853a574128f8e142112e49a8\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:126\":\"25761f013d0aefdb0aeb1de60c3c3b51\"}"
                   }
                 },
                 {
@@ -668,13 +680,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "0B2E2FE0EFFC0AE25EC636FF3521936F"
+                    "stringValue": "C39190A9B6DA940A9BCC25E3C2ADA290"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "5FA64F60CF96ECEAA7E847AA48BDD6E8"
+                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
                   }
                 },
                 {
@@ -686,7 +698,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5FA64F60CF96ECEAA7E847AA48BDD6E8"
+                    "stringValue": "8F54C91FCFA8D3315DAAF667AEDA7EC8"
                   }
                 },
                 {
@@ -698,7 +710,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "132173267D3750008662F83F0B4A8748"
+                    "stringValue": "63B63813B54284E95CD0D025ACE02997"
                   }
                 },
                 {
@@ -722,7 +734,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "959EC6E6E9879F03FFA99262F7DA57A6"
+                    "stringValue": "B489E1EC714D09B0A28041FBB503B344"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "3AC5B8799CAAE74763E99F63B85D7BC6"
+              "stringValue": "ABE432D3B076197D5C6E6CEC3308E1F8"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784844316820000000",
-              "observedTimeUnixNano": "1784844316824000000",
+              "timeUnixNano": "1784907413524000000",
+              "observedTimeUnixNano": "1784907413527000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":7,\"dnsDuration\":1,\"connectionDuration\":0,\"requestDuration\":0}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":3,\"dnsDuration\":1,\"connectionDuration\":1,\"requestDuration\":1}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 8
+                    "intValue": 6
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 8
+                    "intValue": 6
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784844316809-1348638362015"
+                    "stringValue": "v6-1784907413516-9083917357905"
                   }
                 },
                 {
@@ -157,7 +157,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "F19D542E849875A65B7DA20B7CA859AA"
+                    "stringValue": "E91F2CE536441605CFD37D5B9F62E7FF"
                   }
                 },
                 {
@@ -175,13 +175,13 @@
                 {
                   "key": "emb.web_vital.attribution.domainLookup",
                   "value": {
-                    "intValue": 0
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.tcpConnection",
                   "value": {
-                    "intValue": 0
+                    "intValue": 1
                   }
                 },
                 {
@@ -193,25 +193,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 0
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 8
+                    "intValue": 3
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "FE60E4E04B1E2954C5BE45F1F84512F6"
+                    "stringValue": "35E8123D1D2173164EBFC3C0A953BB16"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                    "stringValue": "8B3D76180B9940499C3CF69C47105095"
                   }
                 },
                 {
@@ -223,7 +223,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                    "stringValue": "8B3D76180B9940499C3CF69C47105095"
                   }
                 },
                 {
@@ -235,7 +235,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EDB2BFAEE514BD4C612488E51AD984CC"
+                    "stringValue": "697B0D87F92E5B9CD640D2717727E9C3"
                   }
                 },
                 {
@@ -248,11 +248,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1784844316821000000",
-              "observedTimeUnixNano": "1784844316827000000",
+              "timeUnixNano": "1784907413524000000",
+              "observedTimeUnixNano": "1784907413530000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":8,\"firstByteToFCP\":78,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":6,\"firstByteToFCP\":65,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -271,13 +271,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 86
+                    "intValue": 71
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 86
+                    "intValue": 71
                   }
                 },
                 {
@@ -289,7 +289,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784844316809-5445230062288"
+                    "stringValue": "v6-1784907413516-2596004422452"
                   }
                 },
                 {
@@ -319,7 +319,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "F19D542E849875A65B7DA20B7CA859AA"
+                    "stringValue": "E91F2CE536441605CFD37D5B9F62E7FF"
                   }
                 },
                 {
@@ -331,13 +331,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "C5A03BB4A0ADFC80ED25AA02D2585B42"
+                    "stringValue": "B94A137EEB85615016B448F812141027"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                    "stringValue": "8B3D76180B9940499C3CF69C47105095"
                   }
                 },
                 {
@@ -349,7 +349,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                    "stringValue": "8B3D76180B9940499C3CF69C47105095"
                   }
                 },
                 {
@@ -361,7 +361,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EDB2BFAEE514BD4C612488E51AD984CC"
+                    "stringValue": "697B0D87F92E5B9CD640D2717727E9C3"
                   }
                 },
                 {
@@ -374,11 +374,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1784844316821000000",
-              "observedTimeUnixNano": "1784844316973000000",
+              "timeUnixNano": "1784907413524000000",
+              "observedTimeUnixNano": "1784907413690000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":8,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":78,\"target\":\"#root>div\"}"
+                "stringValue": "{\"timeToFirstByte\":6,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":65,\"target\":\"#root>div\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -397,13 +397,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 86
+                    "intValue": 71
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 86
+                    "intValue": 71
                   }
                 },
                 {
@@ -415,7 +415,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784844316809-4718129506595"
+                    "stringValue": "v6-1784907413516-7132387576699"
                   }
                 },
                 {
@@ -445,7 +445,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "F19D542E849875A65B7DA20B7CA859AA"
+                    "stringValue": "E91F2CE536441605CFD37D5B9F62E7FF"
                   }
                 },
                 {
@@ -455,13 +455,13 @@
                   }
                 },
                 {
-                  "key": "emb.web_vital.attribution.lcpElementType",
+                  "key": "emb.web_vital.attribution.elementType",
                   "value": {
                     "stringValue": "div"
                   }
                 },
                 {
-                  "key": "emb.web_vital.attribution.lcpElementBoundingRect",
+                  "key": "emb.web_vital.attribution.elementBoundingRect",
                   "value": {
                     "stringValue": "{\"x\":8,\"y\":8,\"width\":600,\"height\":400}"
                   }
@@ -469,13 +469,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "AD2437EA95FF2B73FC7EFE1EA6E1CA19"
+                    "stringValue": "0F47CE0E35745F2ED3110F942EC1F79F"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                    "stringValue": "8B3D76180B9940499C3CF69C47105095"
                   }
                 },
                 {
@@ -487,7 +487,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                    "stringValue": "8B3D76180B9940499C3CF69C47105095"
                   }
                 },
                 {
@@ -499,7 +499,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EDB2BFAEE514BD4C612488E51AD984CC"
+                    "stringValue": "697B0D87F92E5B9CD640D2717727E9C3"
                   }
                 },
                 {
@@ -520,8 +520,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784844316968000000",
-              "observedTimeUnixNano": "1784844316970000000",
+              "timeUnixNano": "1784907413681000000",
+              "observedTimeUnixNano": "1784907413684000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -553,7 +553,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 148
+                    "intValue": 157
                   }
                 },
                 {
@@ -571,13 +571,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "A58BC21B3ADF25280E980D68CE4B3486"
+                    "stringValue": "E2862564D7369F8C6C359F0EAEDE96DB"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                    "stringValue": "8B3D76180B9940499C3CF69C47105095"
                   }
                 },
                 {
@@ -589,7 +589,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                    "stringValue": "8B3D76180B9940499C3CF69C47105095"
                   }
                 },
                 {
@@ -601,7 +601,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EDB2BFAEE514BD4C612488E51AD984CC"
+                    "stringValue": "697B0D87F92E5B9CD640D2717727E9C3"
                   }
                 },
                 {
@@ -625,7 +625,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "F19D542E849875A65B7DA20B7CA859AA"
+                    "stringValue": "E91F2CE536441605CFD37D5B9F62E7FF"
                   }
                 },
                 {
@@ -645,8 +645,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784844317400000000",
-              "observedTimeUnixNano": "1784844317400000000",
+              "timeUnixNano": "1784907414114000000",
+              "observedTimeUnixNano": "1784907414116000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -662,13 +662,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:100162\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:38001\noN</as/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:37542\noN</sN/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263325\nPt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:999\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:819\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263299\ncg@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127508\noN</Vb/ac/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:132562\nmd@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:15162\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:128743\nSc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:28401\nEventListener.handleEvent*fg@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:128304\nnc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127704\noN</Vb/ic/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127870\nic@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127815\noN</Vb/zr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:36448\noN<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263948\nxb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:264002\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:99838\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:38001\nJM</is/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:37542\nJM</ZM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:262208\nPt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:1:999\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:1:819\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:262182\nug@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:127508\nJM</Gb/ac/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:132562\ngd@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:15162\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:128743\nSc@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:28581\nbb@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:28401\nEventListener.handleEvent*cg@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:128304\nnc@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:127704\nJM</Gb/ic/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:127870\nic@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:127815\nJM</Gb/zr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:36448\nJM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:262831\nLb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:262885\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:126\\n\":\"25761f013d0aefdb0aeb1de60c3c3b51\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:11:126\\n\":\"20f3b7a0ebcb6792188dfd8be7538be9\"}"
                   }
                 },
                 {
@@ -680,13 +680,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "6D4300A2A90644D3AABED26634D76928"
+                    "stringValue": "D32CC4CC723D74329C6084446F7CC0E9"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                    "stringValue": "8B3D76180B9940499C3CF69C47105095"
                   }
                 },
                 {
@@ -698,7 +698,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                    "stringValue": "8B3D76180B9940499C3CF69C47105095"
                   }
                 },
                 {
@@ -710,7 +710,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "EDB2BFAEE514BD4C612488E51AD984CC"
+                    "stringValue": "697B0D87F92E5B9CD640D2717727E9C3"
                   }
                 },
                 {
@@ -734,7 +734,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "F19D542E849875A65B7DA20B7CA859AA"
+                    "stringValue": "E91F2CE536441605CFD37D5B9F62E7FF"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "F38962AD289A31A39E2B2DE14B8B4FA8"
+              "stringValue": "3AC5B8799CAAE74763E99F63B85D7BC6"
             }
           },
           {
@@ -86,137 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784708698124000000",
-              "observedTimeUnixNano": "1784708698127000000",
+              "timeUnixNano": "1784844316820000000",
+              "observedTimeUnixNano": "1784844316824000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":3,\"firstByteToFCP\":39,\"loadState\":\"dom-interactive\"}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "fcp"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 42
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 42
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1784708698119-3398134663542"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "F21B8112CB418111858B19F8366C9EC2"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "A55A6FEE4C67FE6FC6458690C294F6D9"
-                  }
-                },
-                {
-                  "key": "session.id",
-                  "value": {
-                    "stringValue": "B2F83EF7B702468AE52C20F1723B6EBD"
-                  }
-                },
-                {
-                  "key": "session.previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "B2F83EF7B702468AE52C20F1723B6EBD"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "0A1704789C5C7C4267C014EA48886E62"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            },
-            {
-              "timeUnixNano": "1784708698125000000",
-              "observedTimeUnixNano": "1784708698127000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":2,\"dnsDuration\":1,\"connectionDuration\":0,\"requestDuration\":0}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":7,\"dnsDuration\":1,\"connectionDuration\":0,\"requestDuration\":0}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -235,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 3
+                    "intValue": 8
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 3
+                    "intValue": 8
                   }
                 },
                 {
@@ -253,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784708698119-9835145536864"
+                    "stringValue": "v6-1784844316809-1348638362015"
                   }
                 },
                 {
@@ -283,7 +157,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "F21B8112CB418111858B19F8366C9EC2"
+                    "stringValue": "F19D542E849875A65B7DA20B7CA859AA"
                   }
                 },
                 {
@@ -325,19 +199,19 @@
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 3
+                    "intValue": 8
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "499858056CD86B8D2BC21B3CC4E264E3"
+                    "stringValue": "FE60E4E04B1E2954C5BE45F1F84512F6"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B2F83EF7B702468AE52C20F1723B6EBD"
+                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
                   }
                 },
                 {
@@ -349,7 +223,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B2F83EF7B702468AE52C20F1723B6EBD"
+                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
                   }
                 },
                 {
@@ -361,7 +235,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0A1704789C5C7C4267C014EA48886E62"
+                    "stringValue": "EDB2BFAEE514BD4C612488E51AD984CC"
                   }
                 },
                 {
@@ -374,11 +248,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1784708698124000000",
-              "observedTimeUnixNano": "1784708698284000000",
+              "timeUnixNano": "1784844316821000000",
+              "observedTimeUnixNano": "1784844316827000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":3,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":39,\"target\":\"#root>h1\"}"
+                "stringValue": "{\"timeToFirstByte\":8,\"firstByteToFCP\":78,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -391,19 +265,19 @@
                 {
                   "key": "browser.web_vital.name",
                   "value": {
-                    "stringValue": "lcp"
+                    "stringValue": "fcp"
                   }
                 },
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 42
+                    "intValue": 86
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 42
+                    "intValue": 86
                   }
                 },
                 {
@@ -415,7 +289,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784708698119-6400588136559"
+                    "stringValue": "v6-1784844316809-5445230062288"
                   }
                 },
                 {
@@ -445,7 +319,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "F21B8112CB418111858B19F8366C9EC2"
+                    "stringValue": "F19D542E849875A65B7DA20B7CA859AA"
                   }
                 },
                 {
@@ -457,13 +331,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "B7F4B330FB6ECD5D98D0E3A6D287C6C8"
+                    "stringValue": "C5A03BB4A0ADFC80ED25AA02D2585B42"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B2F83EF7B702468AE52C20F1723B6EBD"
+                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
                   }
                 },
                 {
@@ -475,7 +349,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B2F83EF7B702468AE52C20F1723B6EBD"
+                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
                   }
                 },
                 {
@@ -487,7 +361,145 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0A1704789C5C7C4267C014EA48886E62"
+                    "stringValue": "EDB2BFAEE514BD4C612488E51AD984CC"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            },
+            {
+              "timeUnixNano": "1784844316821000000",
+              "observedTimeUnixNano": "1784844316973000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":8,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":78,\"target\":\"#root>div\"}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "lcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 86
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 86
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v6-1784844316809-4718129506595"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_id",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {
+                    "stringValue": "/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {
+                    "stringValue": "F19D542E849875A65B7DA20B7CA859AA"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.lcpElementType",
+                  "value": {
+                    "stringValue": "div"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.lcpElementBoundingRect",
+                  "value": {
+                    "stringValue": "{\"x\":8,\"y\":8,\"width\":600,\"height\":400}"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "AD2437EA95FF2B73FC7EFE1EA6E1CA19"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                  }
+                },
+                {
+                  "key": "session.previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "EDB2BFAEE514BD4C612488E51AD984CC"
                   }
                 },
                 {
@@ -508,8 +520,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784708698281000000",
-              "observedTimeUnixNano": "1784708698282000000",
+              "timeUnixNano": "1784844316968000000",
+              "observedTimeUnixNano": "1784844316970000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -541,7 +553,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 156
+                    "intValue": 148
                   }
                 },
                 {
@@ -553,19 +565,19 @@
                 {
                   "key": "first_interaction.y",
                   "value": {
-                    "intValue": 92
+                    "intValue": 419
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "225A684466CD4AF3BE93F83E8CC9F869"
+                    "stringValue": "A58BC21B3ADF25280E980D68CE4B3486"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B2F83EF7B702468AE52C20F1723B6EBD"
+                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
                   }
                 },
                 {
@@ -577,7 +589,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B2F83EF7B702468AE52C20F1723B6EBD"
+                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
                   }
                 },
                 {
@@ -589,7 +601,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0A1704789C5C7C4267C014EA48886E62"
+                    "stringValue": "EDB2BFAEE514BD4C612488E51AD984CC"
                   }
                 },
                 {
@@ -613,7 +625,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "F21B8112CB418111858B19F8366C9EC2"
+                    "stringValue": "F19D542E849875A65B7DA20B7CA859AA"
                   }
                 },
                 {
@@ -633,8 +645,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784708698710000000",
-              "observedTimeUnixNano": "1784708698711000000",
+              "timeUnixNano": "1784844317400000000",
+              "observedTimeUnixNano": "1784844317400000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -650,13 +662,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:97579\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:38001\nZN</rs/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:37542\nZN</FN/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:257992\nBt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:1:966\nBt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:1:786\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:257966\ndg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:127506\nZN</jb/uc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:132560\nSd@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:15162\nuc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:128741\nTc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:28401\nEventListener.handleEvent*hg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:128302\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:127702\nZN</jb/lc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:127868\nlc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:127813\nZN</jb/Br.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:36448\nZN<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:258577\nUb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:1:680\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:258631\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:100162\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:38001\noN</as/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:37542\noN</sN/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263325\nPt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:999\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:819\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263299\ncg@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127508\noN</Vb/ac/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:132562\nmd@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:15162\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:128743\nSc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:28401\nEventListener.handleEvent*fg@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:128304\nnc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127704\noN</Vb/ic/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127870\nic@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127815\noN</Vb/zr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:36448\noN<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263948\nxb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:264002\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:11:126\\n\":\"c4efd0af853a574128f8e142112e49a8\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:126\\n\":\"25761f013d0aefdb0aeb1de60c3c3b51\"}"
                   }
                 },
                 {
@@ -668,13 +680,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "2C86034C81B315774B0F685914D0CC2D"
+                    "stringValue": "6D4300A2A90644D3AABED26634D76928"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "B2F83EF7B702468AE52C20F1723B6EBD"
+                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
                   }
                 },
                 {
@@ -686,7 +698,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B2F83EF7B702468AE52C20F1723B6EBD"
+                    "stringValue": "AAD82DFAA45181B35667A8F0A5F2BDD3"
                   }
                 },
                 {
@@ -698,7 +710,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0A1704789C5C7C4267C014EA48886E62"
+                    "stringValue": "EDB2BFAEE514BD4C612488E51AD984CC"
                   }
                 },
                 {
@@ -722,7 +734,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "F21B8112CB418111858B19F8366C9EC2"
+                    "stringValue": "F19D542E849875A65B7DA20B7CA859AA"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "B4D3E2FCF61C7F5A28842A7E5469C8B1"
+              "stringValue": "EB645E3101AD02B19878092644F8EB4F"
             }
           },
           {
@@ -86,8 +86,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784844327059000000",
-              "observedTimeUnixNano": "1784844327059000000",
+              "timeUnixNano": "1784907427072000000",
+              "observedTimeUnixNano": "1784907427077000000",
               "severityNumber": 9,
               "body": {
                 "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784844327057-6919468454921"
+                    "stringValue": "v6-1784907427069-1146141690664"
                   }
                 },
                 {
@@ -157,7 +157,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "D1D7A0DEFEC9BA4FF28F8B171CB545B1"
+                    "stringValue": "7B3AA2CEDBFC0FF7F79681ABA5EE183C"
                   }
                 },
                 {
@@ -205,13 +205,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "2C669990C261E7CE74E0986D8F1CDCA6"
+                    "stringValue": "B8B5018B267DAEA39BB2B43F69112E5F"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
+                    "stringValue": "84259A7738E10AE0AB192A2BA4B0AD42"
                   }
                 },
                 {
@@ -223,7 +223,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
+                    "stringValue": "84259A7738E10AE0AB192A2BA4B0AD42"
                   }
                 },
                 {
@@ -235,7 +235,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "BDFFCF81D47972118133AD0E3D40584D"
+                    "stringValue": "12DB28F4CDFD00ACDF164FBA07DCD966"
                   }
                 },
                 {
@@ -248,11 +248,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1784844327069000000",
-              "observedTimeUnixNano": "1784844327071000000",
+              "timeUnixNano": "1784907427103000000",
+              "observedTimeUnixNano": "1784907427105000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":31,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":66,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -271,13 +271,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 33
+                    "intValue": 68
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 33
+                    "intValue": 68
                   }
                 },
                 {
@@ -289,7 +289,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784844327057-1854453943878"
+                    "stringValue": "v6-1784907427069-8131527510901"
                   }
                 },
                 {
@@ -319,7 +319,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "D1D7A0DEFEC9BA4FF28F8B171CB545B1"
+                    "stringValue": "7B3AA2CEDBFC0FF7F79681ABA5EE183C"
                   }
                 },
                 {
@@ -331,13 +331,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "65C9D15048EB0DE8EF1B110C74A7283D"
+                    "stringValue": "3005DB9FA7F1B9ABBB3F7C996C38316E"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
+                    "stringValue": "84259A7738E10AE0AB192A2BA4B0AD42"
                   }
                 },
                 {
@@ -349,7 +349,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
+                    "stringValue": "84259A7738E10AE0AB192A2BA4B0AD42"
                   }
                 },
                 {
@@ -361,7 +361,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "BDFFCF81D47972118133AD0E3D40584D"
+                    "stringValue": "12DB28F4CDFD00ACDF164FBA07DCD966"
                   }
                 },
                 {
@@ -374,11 +374,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1784844327069000000",
-              "observedTimeUnixNano": "1784844327192000000",
+              "timeUnixNano": "1784907427103000000",
+              "observedTimeUnixNano": "1784907427214000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":2,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":31,\"target\":\"#root>div\"}"
+                "stringValue": "{\"timeToFirstByte\":2,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":66,\"target\":\"#root>div\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -397,13 +397,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 33
+                    "intValue": 68
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 33
+                    "intValue": 68
                   }
                 },
                 {
@@ -415,7 +415,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784844327057-5507014103447"
+                    "stringValue": "v6-1784907427069-9514399158725"
                   }
                 },
                 {
@@ -445,7 +445,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "D1D7A0DEFEC9BA4FF28F8B171CB545B1"
+                    "stringValue": "7B3AA2CEDBFC0FF7F79681ABA5EE183C"
                   }
                 },
                 {
@@ -455,13 +455,13 @@
                   }
                 },
                 {
-                  "key": "emb.web_vital.attribution.lcpElementType",
+                  "key": "emb.web_vital.attribution.elementType",
                   "value": {
                     "stringValue": "div"
                   }
                 },
                 {
-                  "key": "emb.web_vital.attribution.lcpElementBoundingRect",
+                  "key": "emb.web_vital.attribution.elementBoundingRect",
                   "value": {
                     "stringValue": "{\"x\":8,\"y\":8,\"width\":600,\"height\":400}"
                   }
@@ -469,13 +469,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "E78A98369D8FC0CC0FB08EC26E30C70A"
+                    "stringValue": "AFE9D8ED84E931F98B774AF8D1BC36B8"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
+                    "stringValue": "84259A7738E10AE0AB192A2BA4B0AD42"
                   }
                 },
                 {
@@ -487,7 +487,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
+                    "stringValue": "84259A7738E10AE0AB192A2BA4B0AD42"
                   }
                 },
                 {
@@ -499,7 +499,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "BDFFCF81D47972118133AD0E3D40584D"
+                    "stringValue": "12DB28F4CDFD00ACDF164FBA07DCD966"
                   }
                 },
                 {
@@ -520,8 +520,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784844327187000000",
-              "observedTimeUnixNano": "1784844327191000000",
+              "timeUnixNano": "1784907427205000000",
+              "observedTimeUnixNano": "1784907427212000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -553,7 +553,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 128
+                    "intValue": 133
                   }
                 },
                 {
@@ -571,13 +571,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "F3869F8783BE7FFC8FD0F5F3111A6499"
+                    "stringValue": "E28EB8379B07A87C74EB1A2270A9DF04"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
+                    "stringValue": "84259A7738E10AE0AB192A2BA4B0AD42"
                   }
                 },
                 {
@@ -589,7 +589,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
+                    "stringValue": "84259A7738E10AE0AB192A2BA4B0AD42"
                   }
                 },
                 {
@@ -601,7 +601,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "BDFFCF81D47972118133AD0E3D40584D"
+                    "stringValue": "12DB28F4CDFD00ACDF164FBA07DCD966"
                   }
                 },
                 {
@@ -625,7 +625,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "D1D7A0DEFEC9BA4FF28F8B171CB545B1"
+                    "stringValue": "7B3AA2CEDBFC0FF7F79681ABA5EE183C"
                   }
                 },
                 {
@@ -645,8 +645,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784844327605000000",
-              "observedTimeUnixNano": "1784844327605000000",
+              "timeUnixNano": "1784907427656000000",
+              "observedTimeUnixNano": "1784907427657000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -662,13 +662,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:100171\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263332\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:1003\nPromise@[native code]\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:830\ncg@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127508\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:132562\nmd@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:15162\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:128743\nSc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:28403"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:99847\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:262215\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:1:1003\nPromise@[native code]\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:1:830\nug@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:127508\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:132562\ngd@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:15162\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:8:128743\nSc@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:28581\nbb@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:9:28403"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:126\":\"25761f013d0aefdb0aeb1de60c3c3b51\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-U3Td4CsL.js:11:126\":\"20f3b7a0ebcb6792188dfd8be7538be9\"}"
                   }
                 },
                 {
@@ -680,13 +680,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "5EDC774186BCA2F2202EE9E7A882000B"
+                    "stringValue": "5FA8E7485F8FBAA481147B540FB3508D"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
+                    "stringValue": "84259A7738E10AE0AB192A2BA4B0AD42"
                   }
                 },
                 {
@@ -698,7 +698,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
+                    "stringValue": "84259A7738E10AE0AB192A2BA4B0AD42"
                   }
                 },
                 {
@@ -710,7 +710,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "BDFFCF81D47972118133AD0E3D40584D"
+                    "stringValue": "12DB28F4CDFD00ACDF164FBA07DCD966"
                   }
                 },
                 {
@@ -734,7 +734,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "D1D7A0DEFEC9BA4FF28F8B171CB545B1"
+                    "stringValue": "7B3AA2CEDBFC0FF7F79681ABA5EE183C"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "B1521CF199F81556B25F7670A05DE59D"
+              "stringValue": "B4D3E2FCF61C7F5A28842A7E5469C8B1"
             }
           },
           {
@@ -86,8 +86,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784708712725000000",
-              "observedTimeUnixNano": "1784708712728000000",
+              "timeUnixNano": "1784844327059000000",
+              "observedTimeUnixNano": "1784844327059000000",
               "severityNumber": 9,
               "body": {
                 "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784708712723-4852550287100"
+                    "stringValue": "v6-1784844327057-6919468454921"
                   }
                 },
                 {
@@ -157,7 +157,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "319258F58828593E1A7A975D1A65F0BE"
+                    "stringValue": "D1D7A0DEFEC9BA4FF28F8B171CB545B1"
                   }
                 },
                 {
@@ -205,13 +205,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "600EC5977BA5B05F95ED91C3CBF1DCBD"
+                    "stringValue": "2C669990C261E7CE74E0986D8F1CDCA6"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EDC9EFB98AE4669C8261E2AA7F523F9A"
+                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
                   }
                 },
                 {
@@ -223,7 +223,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EDC9EFB98AE4669C8261E2AA7F523F9A"
+                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
                   }
                 },
                 {
@@ -235,7 +235,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "FB3A861F85C85E6C6E65351A42E3E069"
+                    "stringValue": "BDFFCF81D47972118133AD0E3D40584D"
                   }
                 },
                 {
@@ -248,11 +248,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1784708712740000000",
-              "observedTimeUnixNano": "1784708712742000000",
+              "timeUnixNano": "1784844327069000000",
+              "observedTimeUnixNano": "1784844327071000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":37,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":31,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -271,13 +271,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 39
+                    "intValue": 33
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 39
+                    "intValue": 33
                   }
                 },
                 {
@@ -289,7 +289,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784708712723-9172088715617"
+                    "stringValue": "v6-1784844327057-1854453943878"
                   }
                 },
                 {
@@ -319,7 +319,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "319258F58828593E1A7A975D1A65F0BE"
+                    "stringValue": "D1D7A0DEFEC9BA4FF28F8B171CB545B1"
                   }
                 },
                 {
@@ -331,13 +331,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "2A1047619827156BF11FEBE2E7690218"
+                    "stringValue": "65C9D15048EB0DE8EF1B110C74A7283D"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EDC9EFB98AE4669C8261E2AA7F523F9A"
+                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
                   }
                 },
                 {
@@ -349,7 +349,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EDC9EFB98AE4669C8261E2AA7F523F9A"
+                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
                   }
                 },
                 {
@@ -361,7 +361,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "FB3A861F85C85E6C6E65351A42E3E069"
+                    "stringValue": "BDFFCF81D47972118133AD0E3D40584D"
                   }
                 },
                 {
@@ -374,11 +374,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1784708712740000000",
-              "observedTimeUnixNano": "1784708712866000000",
+              "timeUnixNano": "1784844327069000000",
+              "observedTimeUnixNano": "1784844327192000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":2,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":37,\"target\":\"#root>h1\"}"
+                "stringValue": "{\"timeToFirstByte\":2,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":31,\"target\":\"#root>div\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -397,13 +397,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 39
+                    "intValue": 33
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 39
+                    "intValue": 33
                   }
                 },
                 {
@@ -415,7 +415,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1784708712723-9202022209314"
+                    "stringValue": "v6-1784844327057-5507014103447"
                   }
                 },
                 {
@@ -445,7 +445,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "319258F58828593E1A7A975D1A65F0BE"
+                    "stringValue": "D1D7A0DEFEC9BA4FF28F8B171CB545B1"
                   }
                 },
                 {
@@ -455,15 +455,27 @@
                   }
                 },
                 {
+                  "key": "emb.web_vital.attribution.lcpElementType",
+                  "value": {
+                    "stringValue": "div"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.lcpElementBoundingRect",
+                  "value": {
+                    "stringValue": "{\"x\":8,\"y\":8,\"width\":600,\"height\":400}"
+                  }
+                },
+                {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "80AF39065516BAA30C91725CA0844A86"
+                    "stringValue": "E78A98369D8FC0CC0FB08EC26E30C70A"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EDC9EFB98AE4669C8261E2AA7F523F9A"
+                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
                   }
                 },
                 {
@@ -475,7 +487,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EDC9EFB98AE4669C8261E2AA7F523F9A"
+                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
                   }
                 },
                 {
@@ -487,7 +499,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "FB3A861F85C85E6C6E65351A42E3E069"
+                    "stringValue": "BDFFCF81D47972118133AD0E3D40584D"
                   }
                 },
                 {
@@ -508,8 +520,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784708712860000000",
-              "observedTimeUnixNano": "1784708712865000000",
+              "timeUnixNano": "1784844327187000000",
+              "observedTimeUnixNano": "1784844327191000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -541,7 +553,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 135
+                    "intValue": 128
                   }
                 },
                 {
@@ -553,19 +565,19 @@
                 {
                   "key": "first_interaction.y",
                   "value": {
-                    "intValue": 90
+                    "intValue": 418
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "D04FA4056F935EB9A342AADBB1E689E7"
+                    "stringValue": "F3869F8783BE7FFC8FD0F5F3111A6499"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EDC9EFB98AE4669C8261E2AA7F523F9A"
+                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
                   }
                 },
                 {
@@ -577,7 +589,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EDC9EFB98AE4669C8261E2AA7F523F9A"
+                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
                   }
                 },
                 {
@@ -589,7 +601,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "FB3A861F85C85E6C6E65351A42E3E069"
+                    "stringValue": "BDFFCF81D47972118133AD0E3D40584D"
                   }
                 },
                 {
@@ -613,7 +625,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "319258F58828593E1A7A975D1A65F0BE"
+                    "stringValue": "D1D7A0DEFEC9BA4FF28F8B171CB545B1"
                   }
                 },
                 {
@@ -633,8 +645,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1784708713186000000",
-              "observedTimeUnixNano": "1784708713186000000",
+              "timeUnixNano": "1784844327605000000",
+              "observedTimeUnixNano": "1784844327605000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -650,13 +662,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:97588\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:257999\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:1:970\nPromise@[native code]\nBt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:1:797\ndg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:127506\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:132560\nSd@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:15162\nuc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:8:128741\nTc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:9:28403"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:100171\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:263332\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:1003\nPromise@[native code]\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:1:830\ncg@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:127508\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:132562\nmd@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:15162\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:8:128743\nSc@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:9:28403"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-BHchCq0l.js:11:126\":\"c4efd0af853a574128f8e142112e49a8\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-DMHTagtu.js:11:126\":\"25761f013d0aefdb0aeb1de60c3c3b51\"}"
                   }
                 },
                 {
@@ -668,13 +680,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "C21BC262DAC4F3EF0A95FFC8F4062061"
+                    "stringValue": "5EDC774186BCA2F2202EE9E7A882000B"
                   }
                 },
                 {
                   "key": "session.id",
                   "value": {
-                    "stringValue": "EDC9EFB98AE4669C8261E2AA7F523F9A"
+                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
                   }
                 },
                 {
@@ -686,7 +698,7 @@
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EDC9EFB98AE4669C8261E2AA7F523F9A"
+                    "stringValue": "C9C1212233030E81F5C00CC9B1287A59"
                   }
                 },
                 {
@@ -698,7 +710,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "FB3A861F85C85E6C6E65351A42E3E069"
+                    "stringValue": "BDFFCF81D47972118133AD0E3D40584D"
                   }
                 },
                 {
@@ -722,7 +734,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "319258F58828593E1A7A975D1A65F0BE"
+                    "stringValue": "D1D7A0DEFEC9BA4FF28F8B171CB545B1"
                   }
                 },
                 {


### PR DESCRIPTION
## What problem is this solving?

Part of the Web Vital Element Enrichment epic (EMBR-13077). LCP web-vital events carried no information about *which* element was the largest contentful paint. This adds the LCP element's type (backed by the new `LCPElementType` materialized column) and its bounding rectangle so element-level attribution is available in the backend.

## Short description of the changes

- New `lcpElementAttribution` helper in `WebVitalsInstrumentation.ts`, mirroring the existing `ttfbSubPartsAttribution` / `loafScriptsAttribution` pattern. It reads `metric.attribution.lcpEntry?.element` once and, when present, emits:
  - `emb.web_vital.attribution.elementType` — the element's lowercased `tagName`.
  - `emb.web_vital.attribution.elementBoundingRect` — JSON-stringified `{x, y, width, height}` from `getBoundingClientRect()`, each `Math.round`ed. `x`/`y` are intentionally not clamped, since a scrolled-away element legitimately has a negative position.
- Wired into `_emitWebVital` conditioned on `metric.name === 'LCP'`.
- Both attributes are omitted (not empty/garbage) when the element is unavailable. The attribution read and geometry are wrapped in a `try/catch` that logs via `diag`, so a throwing/missing element never drops the whole LCP record.
- Integration harness fix: the vite-6/vite-7 test pages now render a fixed-size `<div>` instead of an `<h1>` as the LCP element. A text heading's box height drifts with each browser's default font (heights of 37/38/41/44 seen across chromium/firefox/webkit), which made the bounding-rect golden nondeterministic. A block with explicit `width`/`height` reports an identical rect in every browser.

## How was this tested?

New unit tests in `WebVitalsInstrumentation.test.ts`:
- Element present → both attributes set (tag lowercased, rounded rect JSON including a negative `x`).
- Element absent → both attributes omitted.
- `getBoundingClientRect()` throws → LCP record still emitted, both attributes omitted, error logged via `diag`.

Full `@embrace-io/web-sdk` unit suite passes; `npm run lint` and `npm run check` are green. Integration goldens regenerated and now match across all three browser engines.

## Checklist

- [x] Tests added/updated
- [x] Lint and typecheck pass
- [x] Golden files regenerated
