### PR TITLE
EMBR-13089 feat(web-vitals): capture CLS layout shifts attribution

### DIFF
--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -1526,6 +1526,255 @@ describe('WebVitalsInstrumentation', () => {
     expect(body['loadState']).to.equal('complete');
   });
 
+  it('should include CLS layout shifts under the cap without a dropped count', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+    clock.tick(5000);
+
+    const nodeA = document.createElement('span');
+    nodeA.id = 'a';
+    const nodeB = document.createElement('span');
+    nodeB.id = 'b';
+
+    emitFunc({
+      name: 'CLS',
+      value: 0.1,
+      rating: 'good',
+      delta: 0.1,
+      id: 'm1',
+      navigationType: 'navigate',
+      navigationId: 1,
+      entries: [
+        {
+          startTime: 1000,
+          sources: [
+            {
+              node: nodeA,
+              previousRect: { x: 0.4, y: 1.6, width: 10.5, height: 20 },
+              currentRect: { x: 5, y: 6, width: 10, height: 20 },
+            },
+          ],
+        },
+        {
+          startTime: 1001,
+          sources: [
+            {
+              node: nodeB,
+              previousRect: { x: 100, y: 200, width: 30, height: 40 },
+              currentRect: { x: 110, y: 205, width: 30, height: 40 },
+            },
+          ],
+        },
+      ],
+      attribution: {},
+    } as unknown as MetricWithAttribution);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const attrs = records[0].attributes;
+    expect(attrs).to.not.have.property(
+      'emb.web_vital.attribution.clsLayoutShiftsDroppedCount',
+    );
+    const shifts = JSON.parse(
+      attrs['emb.web_vital.attribution.clsLayoutShifts'] as string,
+    ) as unknown[];
+    expect(shifts).to.deep.equal([
+      {
+        selector: '#a',
+        startRect: { x: 0, y: 2, width: 11, height: 20 },
+        endRect: { x: 5, y: 6, width: 10, height: 20 },
+      },
+      {
+        selector: '#b',
+        startRect: { x: 100, y: 200, width: 30, height: 40 },
+        endRect: { x: 110, y: 205, width: 30, height: 40 },
+      },
+    ]);
+  });
+
+  it('should cap CLS layout shifts at 50 and report the dropped count', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+    clock.tick(5000);
+
+    const entries = Array.from({ length: 60 }, (_unused, index) => ({
+      startTime: 1000 + index,
+      sources: [
+        {
+          node: document.createElement('div'),
+          previousRect: { x: 0, y: 0, width: 1, height: 1 },
+          currentRect: { x: 1, y: 1, width: 1, height: 1 },
+        },
+      ],
+    }));
+
+    emitFunc({
+      name: 'CLS',
+      value: 0.5,
+      rating: 'poor',
+      delta: 0.5,
+      id: 'm1',
+      navigationType: 'navigate',
+      navigationId: 1,
+      entries,
+      attribution: {},
+    } as unknown as MetricWithAttribution);
+
+    const attrs = memoryExporter.getFinishedLogRecords()[0].attributes;
+    const shifts = JSON.parse(
+      attrs['emb.web_vital.attribution.clsLayoutShifts'] as string,
+    ) as unknown[];
+    expect(shifts).to.have.lengthOf(50);
+    expect(
+      attrs['emb.web_vital.attribution.clsLayoutShiftsDroppedCount'],
+    ).to.equal(10);
+  });
+
+  it('should fall back to an empty selector when a layout shift has no sources', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+    clock.tick(5000);
+
+    emitFunc({
+      name: 'CLS',
+      value: 0.1,
+      rating: 'good',
+      delta: 0.1,
+      id: 'm1',
+      navigationType: 'navigate',
+      navigationId: 1,
+      entries: [{ startTime: 1000, sources: [] }],
+      attribution: {},
+    } as unknown as MetricWithAttribution);
+
+    const records = memoryExporter.getFinishedLogRecords();
+    expect(records).to.have.lengthOf(1);
+    const shifts = JSON.parse(
+      records[0].attributes[
+        'emb.web_vital.attribution.clsLayoutShifts'
+      ] as string,
+    ) as Array<{ selector: string; startRect: unknown; endRect: unknown }>;
+    expect(shifts).to.deep.equal([
+      {
+        selector: '',
+        startRect: { x: 0, y: 0, width: 0, height: 0 },
+        endRect: { x: 0, y: 0, width: 0, height: 0 },
+      },
+    ]);
+  });
+
+  it('should capture the first (most impactful) source of a multi-source layout shift', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
+    clock.tick(5000);
+
+    const first = document.createElement('span');
+    first.id = 'first';
+    const second = document.createElement('span');
+    second.id = 'second';
+
+    emitFunc({
+      name: 'CLS',
+      value: 0.1,
+      rating: 'good',
+      delta: 0.1,
+      id: 'm1',
+      navigationType: 'navigate',
+      navigationId: 1,
+      entries: [
+        {
+          startTime: 1000,
+          sources: [
+            {
+              node: first,
+              previousRect: { x: 0, y: 0, width: 10, height: 10 },
+              currentRect: { x: 5, y: 5, width: 10, height: 10 },
+            },
+            {
+              node: second,
+              previousRect: { x: 20, y: 20, width: 30, height: 30 },
+              currentRect: { x: 25, y: 25, width: 30, height: 30 },
+            },
+          ],
+        },
+      ],
+      attribution: {},
+    } as unknown as MetricWithAttribution);
+
+    const shifts = JSON.parse(
+      memoryExporter.getFinishedLogRecords()[0].attributes[
+        'emb.web_vital.attribution.clsLayoutShifts'
+      ] as string,
+    ) as unknown[];
+    expect(shifts).to.deep.equal([
+      {
+        selector: '#first',
+        startRect: { x: 0, y: 0, width: 10, height: 10 },
+        endRect: { x: 5, y: 5, width: 10, height: 10 },
+      },
+    ]);
+  });
+
+  it('should not emit CLS layout shift attributes for non-CLS metrics', () => {
+    instrumentation = new WebVitalsInstrumentation({
+      diag,
+      perf,
+      listeners: mockWebVitalListeners,
+      urlAttribution: false,
+    });
+
+    const emitFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
+    clock.tick(5000);
+
+    emitFunc({
+      name: 'LCP',
+      value: 22,
+      rating: 'good',
+      delta: 0,
+      id: 'm1',
+      navigationType: 'navigate',
+      entries: [{ startTime: 3000 } as PerformanceEntry],
+      attribution: {
+        timeToFirstByte: 0,
+        resourceLoadDelay: 0,
+        resourceLoadDuration: 0,
+        elementRenderDelay: 0,
+      },
+    } as MetricWithAttribution);
+
+    const attrs = memoryExporter.getFinishedLogRecords()[0].attributes;
+    expect(attrs).to.not.have.property(
+      'emb.web_vital.attribution.clsLayoutShifts',
+    );
+    expect(attrs).to.not.have.property(
+      'emb.web_vital.attribution.clsLayoutShiftsDroppedCount',
+    );
+  });
+
   it('should report FCP metrics with url attribution', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -278,11 +278,14 @@ const lcpElementAttribution = (
     const element = attribution.lcpEntry?.element;
 
     if (element) {
-      const prefix = KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX;
-      attributes[`${prefix}elementType`] = element.tagName.toLowerCase();
-      attributes[`${prefix}elementBoundingRect`] = JSON.stringify(
+      const elementType = element.tagName.toLowerCase();
+      const elementBoundingRect = JSON.stringify(
         roundRect(element.getBoundingClientRect()),
       );
+
+      const prefix = KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX;
+      attributes[`${prefix}elementType`] = elementType;
+      attributes[`${prefix}elementBoundingRect`] = elementBoundingRect;
     }
   } catch (e) {
     diag.error('error building LCP element attribution', e);

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -21,6 +21,7 @@ import {
   KEY_EMB_PAGE_PATH,
   KEY_EMB_TYPE,
 } from '../../../constants/index.ts';
+import { getSelector } from '../../../utils/index.ts';
 import { isEntryTypeSupported } from '../../../utils/performanceObserver/index.ts';
 import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
 import {
@@ -36,6 +37,7 @@ import {
 } from './attributes.ts';
 import {
   ALL_WEB_VITALS,
+  MAX_CLS_LAYOUT_SHIFTS,
   MAX_LOAF_SCRIPT_ENTRIES,
   MAX_LOAF_SCRIPT_URL_LENGTH,
   WEB_VITAL_EVENT_NAME,
@@ -126,6 +128,50 @@ const loafScriptsAttribution = (
     /* eslint-enable baseline-js/use-baseline */
   } catch (e) {
     diag.error('error building loaf scripts for INP', e);
+  }
+
+  return attributes;
+};
+
+const clsLayoutShiftsAttribution = (
+  metric: MetricWithAttribution,
+  diag: DiagLogger,
+): Attributes => {
+  const attributes: Attributes = {};
+
+  try {
+    /* eslint-disable baseline-js/use-baseline */
+    const entries = metric.entries as LayoutShift[];
+    const roundRect = (rect?: DOMRectReadOnly) => ({
+      x: Math.round(rect?.x ?? 0),
+      y: Math.round(rect?.y ?? 0),
+      width: Math.round(rect?.width ?? 0),
+      height: Math.round(rect?.height ?? 0),
+    });
+
+    if (entries.length > 0) {
+      const shifts = entries.slice(0, MAX_CLS_LAYOUT_SHIFTS).map((entry) => {
+        // web-vitals exposes sources sorted by impact area descending, so the
+        // first source is the element that contributed most to the shift.
+        const source = entry.sources[0];
+        return {
+          selector: getSelector(source?.node ?? null),
+          startRect: roundRect(source?.previousRect),
+          endRect: roundRect(source?.currentRect),
+        };
+      });
+
+      const prefix = KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX;
+      attributes[`${prefix}clsLayoutShifts`] = JSON.stringify(shifts);
+
+      if (entries.length > MAX_CLS_LAYOUT_SHIFTS) {
+        attributes[`${prefix}clsLayoutShiftsDroppedCount`] =
+          entries.length - MAX_CLS_LAYOUT_SHIFTS;
+      }
+    }
+    /* eslint-enable baseline-js/use-baseline */
+  } catch (e) {
+    diag.error('error building CLS layout shifts', e);
   }
 
   return attributes;
@@ -416,6 +462,9 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
           : {}),
         ...(metric.name === 'TTFB'
           ? ttfbSubPartsAttribution(metric, this._diag)
+          : {}),
+        ...(metric.name === 'CLS'
+          ? clsLayoutShiftsAttribution(metric, this._diag)
           : {}),
       },
       body:

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -58,6 +58,13 @@ type AttributedPage = {
 
 const roundClamp = (value: number): number => Math.round(Math.max(0, value));
 
+const roundRect = (rect?: DOMRectReadOnly) => ({
+  x: Math.round(rect?.x ?? 0),
+  y: Math.round(rect?.y ?? 0),
+  width: Math.round(rect?.width ?? 0),
+  height: Math.round(rect?.height ?? 0),
+});
+
 const isPrimitiveValue = (
   value: unknown,
 ): value is string | number | boolean => {
@@ -143,12 +150,6 @@ const clsLayoutShiftsAttribution = (
   try {
     /* eslint-disable baseline-js/use-baseline */
     const entries = metric.entries as LayoutShift[];
-    const roundRect = (rect?: DOMRectReadOnly) => ({
-      x: Math.round(rect?.x ?? 0),
-      y: Math.round(rect?.y ?? 0),
-      width: Math.round(rect?.width ?? 0),
-      height: Math.round(rect?.height ?? 0),
-    });
 
     if (entries.length > 0) {
       const shifts = entries.slice(0, MAX_CLS_LAYOUT_SHIFTS).map((entry) => {
@@ -251,16 +252,10 @@ const lcpElementAttribution = (
 
     if (element) {
       const prefix = KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX;
-      const rect = element.getBoundingClientRect();
       attributes[`${prefix}elementType`] = element.tagName.toLowerCase();
-      // x/y are intentionally not clamped: an element scrolled above the
-      // viewport legitimately has a negative position.
-      attributes[`${prefix}elementBoundingRect`] = JSON.stringify({
-        x: Math.round(rect.x),
-        y: Math.round(rect.y),
-        width: Math.round(rect.width),
-        height: Math.round(rect.height),
-      });
+      attributes[`${prefix}elementBoundingRect`] = JSON.stringify(
+        roundRect(element.getBoundingClientRect()),
+      );
     }
   } catch (e) {
     diag.error('error building LCP element attribution', e);

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -511,9 +511,11 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
             }
           : {}),
         ...(metric.name === 'INP'
-          ? loafScriptsAttribution(metric, this._diag)
+          ? {
+              ...loafScriptsAttribution(metric, this._diag),
+              ...inpAttribution(metric, this._diag),
+            }
           : {}),
-        ...(metric.name === 'INP' ? inpAttribution(metric, this._diag) : {}),
         ...(metric.name === 'TTFB'
           ? ttfbSubPartsAttribution(metric, this._diag)
           : {}),

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -511,11 +511,9 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
             }
           : {}),
         ...(metric.name === 'INP'
-          ? {
-              ...loafScriptsAttribution(metric, this._diag),
-              ...inpAttribution(metric, this._diag),
-            }
+          ? loafScriptsAttribution(metric, this._diag)
           : {}),
+        ...(metric.name === 'INP' ? inpAttribution(metric, this._diag) : {}),
         ...(metric.name === 'TTFB'
           ? ttfbSubPartsAttribution(metric, this._diag)
           : {}),

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/constants.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/constants.ts
@@ -3,6 +3,7 @@ import { onCLS, onFCP, onINP, onLCP, onTTFB } from 'web-vitals/attribution';
 export const WEB_VITAL_EVENT_NAME = 'browser.web_vital';
 export const MAX_LOAF_SCRIPT_URL_LENGTH = 2048;
 export const MAX_LOAF_SCRIPT_ENTRIES = 250;
+export const MAX_CLS_LAYOUT_SHIFTS = 50;
 export const ALL_WEB_VITALS = ['CLS', 'INP', 'LCP', 'FCP', 'TTFB'] as const;
 export const WEB_VITALS_ID_TO_LISTENER = {
   /**


### PR DESCRIPTION
## What problem is this solving?

The SDK reports the CLS web vital value but not which elements shifted, so CLS regressions can't be traced back to the responsible DOM nodes. This adds per-shift attribution to the CLS log record.

## Short description of changes

- New `clsLayoutShiftsAttribution`, emitted only for CLS: serializes each layout-shift entry to `emb.web_vital.attribution.clsLayoutShifts` as `{ selector, startRect, endRect }`, taking the first (most impactful) source per shift and reusing web-vitals' `getSelector` for selector parity.
- Caps output at `MAX_CLS_LAYOUT_SHIFTS` (50) and reports `emb.web_vital.attribution.clsLayoutShiftsDroppedCount` when the cap is exceeded.
- Rects rounded to integer CSS pixels; best-effort with any errors logged via `diag`.
- Extracted a shared module-level `roundRect` helper, reused by both the CLS shift rects and the LCP element bounding rect (dropping the duplicated inline rounding on each path).

## How has this been tested?

Unit tests in `WebVitalsInstrumentation.test.ts` cover under-cap serialization with rounding, the 50-cap plus dropped count, the empty-sources fallback, first-source selection on multi-source shifts, and absence of the attributes on non-CLS metrics. `npm run check` and the web-vitals test file pass.

## Checklist

- [ ] Documentation added
- [x] Tests added