### PR TITLE
EMBR-13078 feat(web-vitals): capture INP element_type attribution attribute

### DIFF
--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -696,6 +696,7 @@ describe('WebVitalsInstrumentation', () => {
         id: 'm3',
         entries,
         navigationType: 'navigate',
+        navigationId: 1,
         attribution: {
           interactionTarget: 'button',
           interactionTargetElement: undefined,

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -772,6 +772,29 @@ describe('WebVitalsInstrumentation', () => {
       expect(records[0].attributes['emb.web_vital.attribution.element_type']).to
         .be.undefined;
     });
+
+    it('should log an error and omit element_type when computing it throws', () => {
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlAttribution: false,
+      });
+
+      const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
+
+      fireINPWithEntries(
+        metricReportFunc,
+        null as unknown as PerformanceEventTiming[],
+      );
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records[0].attributes['emb.web_vital.attribution.element_type']).to
+        .be.undefined;
+      expect(diag.getErrorLogs()).to.include(
+        'error building INP element type attribution',
+      );
+    });
   });
 
   it('should report TTFB metrics with sub-part attributes', () => {

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -683,6 +683,96 @@ describe('WebVitalsInstrumentation', () => {
     });
   });
 
+  describe('INPElementType attribution', () => {
+    const fireINPWithEntries = (
+      metricReportFunc: WebVitalOnReport,
+      entries: PerformanceEventTiming[],
+    ) => {
+      metricReportFunc({
+        name: 'INP',
+        value: 200,
+        rating: 'needs-improvement',
+        delta: 200,
+        id: 'm3',
+        entries,
+        navigationType: 'navigate',
+        attribution: {
+          interactionTarget: 'button',
+          interactionTargetElement: undefined,
+          interactionTime: 1000,
+          nextPaintTime: 1200,
+          interactionType: 'pointer',
+          processedEventEntries: [],
+          longAnimationFrameEntries: [],
+          inputDelay: 10,
+          processingDuration: 150,
+          presentationDelay: 40,
+          loadState: 'complete',
+        },
+      } as INPMetricWithAttribution);
+    };
+
+    it('should include INPElementType when the entry has a resolvable target', () => {
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlAttribution: false,
+      });
+
+      const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
+
+      fireINPWithEntries(metricReportFunc, [
+        { target: { tagName: 'BUTTON' } } as unknown as PerformanceEventTiming,
+      ]);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(
+        records[0].attributes['emb.web_vital.attribution.INPElementType'],
+      ).to.equal('button');
+    });
+
+    it('should use the tag name from the first entry with a resolvable target when earlier entries have none', () => {
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlAttribution: false,
+      });
+
+      const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
+
+      fireINPWithEntries(metricReportFunc, [
+        { target: null } as unknown as PerformanceEventTiming,
+        { target: { tagName: 'A' } } as unknown as PerformanceEventTiming,
+      ]);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(
+        records[0].attributes['emb.web_vital.attribution.INPElementType'],
+      ).to.equal('a');
+    });
+
+    it('should omit INPElementType when no entry has a resolvable target', () => {
+      instrumentation = new WebVitalsInstrumentation({
+        diag,
+        perf,
+        listeners: mockWebVitalListeners,
+        urlAttribution: false,
+      });
+
+      const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
+
+      fireINPWithEntries(metricReportFunc, [
+        { target: null } as unknown as PerformanceEventTiming,
+      ]);
+
+      const records = memoryExporter.getFinishedLogRecords();
+      expect(records[0].attributes['emb.web_vital.attribution.INPElementType'])
+        .to.be.undefined;
+    });
+  });
+
   it('should report TTFB metrics with sub-part attributes', () => {
     instrumentation = new WebVitalsInstrumentation({
       diag,

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -683,7 +683,7 @@ describe('WebVitalsInstrumentation', () => {
     });
   });
 
-  describe('INPElementType attribution', () => {
+  describe('element_type attribution', () => {
     const fireINPWithEntries = (
       metricReportFunc: WebVitalOnReport,
       entries: PerformanceEventTiming[],
@@ -712,7 +712,7 @@ describe('WebVitalsInstrumentation', () => {
       } as INPMetricWithAttribution);
     };
 
-    it('should include INPElementType when the entry has a resolvable target', () => {
+    it('should include element_type when the entry has a resolvable target', () => {
       instrumentation = new WebVitalsInstrumentation({
         diag,
         perf,
@@ -728,7 +728,7 @@ describe('WebVitalsInstrumentation', () => {
 
       const records = memoryExporter.getFinishedLogRecords();
       expect(
-        records[0].attributes['emb.web_vital.attribution.INPElementType'],
+        records[0].attributes['emb.web_vital.attribution.element_type'],
       ).to.equal('button');
     });
 
@@ -749,11 +749,11 @@ describe('WebVitalsInstrumentation', () => {
 
       const records = memoryExporter.getFinishedLogRecords();
       expect(
-        records[0].attributes['emb.web_vital.attribution.INPElementType'],
+        records[0].attributes['emb.web_vital.attribution.element_type'],
       ).to.equal('a');
     });
 
-    it('should omit INPElementType when no entry has a resolvable target', () => {
+    it('should omit element_type when no entry has a resolvable target', () => {
       instrumentation = new WebVitalsInstrumentation({
         diag,
         perf,
@@ -768,8 +768,8 @@ describe('WebVitalsInstrumentation', () => {
       ]);
 
       const records = memoryExporter.getFinishedLogRecords();
-      expect(records[0].attributes['emb.web_vital.attribution.INPElementType'])
-        .to.be.undefined;
+      expect(records[0].attributes['emb.web_vital.attribution.element_type']).to
+        .be.undefined;
     });
   });
 

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -147,7 +147,7 @@ const inpAttribution = (
     const tagName = target?.tagName?.toLowerCase();
 
     if (tagName) {
-      attributes[`${KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX}INPElementType`] =
+      attributes[`${KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX}element_type`] =
         tagName;
     }
 

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -132,6 +132,33 @@ const loafScriptsAttribution = (
   return attributes;
 };
 
+const inpAttribution = (
+  metric: MetricWithAttribution,
+  diag: DiagLogger,
+): Attributes => {
+  const attributes: Attributes = {};
+
+  try {
+    /* eslint-disable baseline-js/use-baseline */
+    const target = (metric.entries as PerformanceEventTiming[]).find(
+      (entry) => entry.target,
+    )?.target as Element | null | undefined;
+
+    const tagName = target?.tagName?.toLowerCase();
+
+    if (tagName) {
+      attributes[`${KEY_EMB_WEB_VITAL_ATTRIBUTION_PREFIX}INPElementType`] =
+        tagName;
+    }
+
+    /* eslint-enable baseline-js/use-baseline */
+  } catch (e) {
+    diag.error('error building INP element type attribution', e);
+  }
+
+  return attributes;
+};
+
 const ttfbSubPartsAttribution = (
   metric: MetricWithAttribution,
   diag: DiagLogger,
@@ -445,6 +472,7 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
         ...(metric.name === 'INP'
           ? loafScriptsAttribution(metric, this._diag)
           : {}),
+        ...(metric.name === 'INP' ? inpAttribution(metric, this._diag) : {}),
         ...(metric.name === 'TTFB'
           ? ttfbSubPartsAttribution(metric, this._diag)
           : {}),


### PR DESCRIPTION
## What problem is this solving?

`INPAttribution` only exposes the interaction target as a CSS selector string (`interactionTarget`), not as a DOM element type. There's no way to know what kind of element (button, a, div, etc.) triggered a slow INP interaction, which limits how actionable INP data is for debugging.

## Short description of changes

- Add `inpAttribution` helper in `WebVitalsInstrumentation.ts` that finds the first INP `PerformanceEventTiming` entry with a resolvable `target` (mirroring the same null-guard `.find` that `web-vitals` itself uses internally for `interactionTarget`), and emits `emb.web_vital.attribution.element_type` with the lowercased tag name.
- Attribute is omitted when the target is missing/removed from the DOM by report time.
- Wired into `_emitWebVital`'s attributes for INP metrics only.

## How has this been tested?

Added unit tests in `WebVitalsInstrumentation.test.ts` covering:
- a single entry with a resolvable target
- multiple entries where only one has a resolvable target (null-guard case)
- no entry has a target (attribute omitted)

`npm run check` (tsc + eslint) and the full `WebVitalsInstrumentation` suite pass.

## Checklist

- [ ] Documentation added
- [x] Tests added