### PR TITLE
feat(utils): add measureDocument util for document and viewport size

### DIFF
--- a/packages/web-sdk/src/utils/index.ts
+++ b/packages/web-sdk/src/utils/index.ts
@@ -9,6 +9,10 @@ export { getSelector } from './getSelector.ts';
 export { getVisibilityState } from './getVisibilityState.ts';
 export { GLOBAL_CONFIG } from './globalConfig.ts';
 export { isDeviceIdEnabled } from './isDeviceIdEnabled.ts';
+export {
+  type DocumentMeasurement,
+  measureDocument,
+} from './measureDocument.ts';
 export { NamespacedStorage } from './NamespacedStorage/index.ts';
 export { nsfConfigValidation } from './nsfConfigValidation.ts';
 export {

--- a/packages/web-sdk/src/utils/measureDocument.test.ts
+++ b/packages/web-sdk/src/utils/measureDocument.test.ts
@@ -1,0 +1,137 @@
+import * as chai from 'chai';
+import { measureDocument } from './measureDocument.ts';
+
+const { expect } = chai;
+
+describe('measureDocument', () => {
+  // `scrollingElement` is an accessor on Document.prototype, never an own
+  // property of the document, so deleting the stub restores the real getter.
+  const stubScrollingElement = (value: Element | null) => {
+    Object.defineProperty(document, 'scrollingElement', {
+      configurable: true,
+      get: () => value,
+    });
+  };
+
+  afterEach(() => {
+    Reflect.deleteProperty(document, 'scrollingElement');
+  });
+
+  const createScrollRoot = (dimensions: {
+    scrollHeight: number;
+    scrollWidth: number;
+    clientHeight: number;
+    clientWidth: number;
+  }) => {
+    const scrollRoot = document.createElement('div');
+    for (const [property, value] of Object.entries(dimensions)) {
+      Object.defineProperty(scrollRoot, property, {
+        configurable: true,
+        get: () => value,
+      });
+    }
+
+    return scrollRoot;
+  };
+
+  it('reads every dimension off the scrolling element', () => {
+    stubScrollingElement(
+      createScrollRoot({
+        scrollHeight: 2400,
+        scrollWidth: 1280,
+        clientHeight: 800,
+        clientWidth: 600,
+      }),
+    );
+
+    expect(measureDocument()).to.deep.equal({
+      documentHeight: 2400,
+      documentWidth: 1280,
+      viewportHeight: 800,
+      viewportWidth: 600,
+    });
+  });
+
+  it('returns null when the document has no scrolling element', () => {
+    stubScrollingElement(null);
+
+    expect(measureDocument()).to.equal(null);
+  });
+
+  it('returns null when the scroll root has no layout box', () => {
+    stubScrollingElement(
+      createScrollRoot({
+        scrollHeight: 0,
+        scrollWidth: 0,
+        clientHeight: 0,
+        clientWidth: 0,
+      }),
+    );
+
+    expect(measureDocument()).to.equal(null);
+
+    // A frame collapsed on one axis only still has no viewport to measure
+    // against, so neither dimension may stand in on its own.
+    stubScrollingElement(
+      createScrollRoot({
+        scrollHeight: 4000,
+        scrollWidth: 1280,
+        clientHeight: 0,
+        clientWidth: 1280,
+      }),
+    );
+
+    expect(measureDocument()).to.equal(null);
+  });
+
+  // The branch above is stubbed because measureDocument reads the global
+  // document, which the test page keeps in standards mode. This locks the real
+  // condition behind that stub.
+  it('has no scrolling element in quirks mode with a scrollable body', () => {
+    const frame = document.createElement('iframe');
+    document.body.append(frame);
+
+    try {
+      const frameDocument = frame.contentDocument;
+      if (!frameDocument) {
+        throw new Error('expected a document inside the frame');
+      }
+
+      // Written without a doctype, so the frame parses in quirks mode.
+      frameDocument.write('<style>html, body { overflow: auto }</style>');
+      frameDocument.close();
+
+      expect(frameDocument.compatMode).to.equal('BackCompat');
+      expect(frameDocument.scrollingElement).to.equal(null);
+    } finally {
+      frame.remove();
+    }
+  });
+
+  it('measures the live document when nothing is stubbed', () => {
+    const spacer = document.createElement('div');
+    spacer.style.height = `${window.innerHeight * 3}px`;
+    document.body.append(spacer);
+
+    try {
+      const measurement = measureDocument();
+
+      // The test document is in standards mode, so it always has a scroll root.
+      if (!measurement) {
+        throw new Error('expected a scroll root in a standards-mode document');
+      }
+
+      // The viewport is the frame the document scrolls inside, so it can never
+      // exceed the window, and the spacer makes the document outgrow it.
+      expect(measurement.viewportHeight).to.be.at.most(window.innerHeight);
+      expect(measurement.viewportWidth).to.be.at.most(window.innerWidth);
+      expect(measurement.documentHeight).to.be.greaterThan(
+        measurement.viewportHeight,
+      );
+      expect(measurement.viewportWidth).to.be.greaterThan(0);
+      expect(measurement.documentWidth).to.be.greaterThan(0);
+    } finally {
+      spacer.remove();
+    }
+  });
+});

--- a/packages/web-sdk/src/utils/measureDocument.ts
+++ b/packages/web-sdk/src/utils/measureDocument.ts
@@ -1,0 +1,50 @@
+/**
+ * A point-in-time reading of the document and viewport boxes, in integer CSS
+ * pixels. Resize, zoom, and content mutation all invalidate it.
+ *
+ * `viewportHeight`/`viewportWidth` are the scroll root's client box, which
+ * excludes any space a classic scrollbar takes, so they are `<=`
+ * `window.innerHeight`/`innerWidth` rather than equal to them. The document
+ * boxes are always `>=` their viewport counterparts, and the scrollable range
+ * is the difference between the two.
+ */
+export interface DocumentMeasurement {
+  documentHeight: number;
+  documentWidth: number;
+  viewportHeight: number;
+  viewportWidth: number;
+}
+
+/**
+ * Measures the document's content size and the viewport size off
+ * `document.scrollingElement`, which is the document root in standards mode,
+ * and in quirks mode is `<body>` only when `<body>` is not itself potentially
+ * scrollable. Reading `documentElement` or `<body>` directly is correct in only
+ * one of the two modes.
+ *
+ * Returns `null` in the remaining quirks-mode cases, and when the scroll root
+ * has no layout box. The document may still scroll in the quirks-mode case, but
+ * no element measures it correctly, so callers should report the absence rather
+ * than substitute a zero that would read as a real measurement.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Document/scrollingElement
+ */
+export const measureDocument = (): DocumentMeasurement | null => {
+  const scrollRoot = document.scrollingElement;
+  if (!scrollRoot) {
+    return null;
+  }
+
+  const viewportHeight = scrollRoot.clientHeight;
+  const viewportWidth = scrollRoot.clientWidth;
+  // A non-rendered or zero-sized frame has a scroll root with no layout box.
+  if (!viewportHeight || !viewportWidth) {
+    return null;
+  }
+
+  return {
+    documentHeight: scrollRoot.scrollHeight,
+    documentWidth: scrollRoot.scrollWidth,
+    viewportHeight,
+    viewportWidth,
+  };
+};

--- a/packages/web-sdk/src/utils/measureDocument.ts
+++ b/packages/web-sdk/src/utils/measureDocument.ts
@@ -19,8 +19,8 @@ export interface DocumentMeasurement {
  * Measures the document's content size and the viewport size off
  * `document.scrollingElement`, which is the document root in standards mode,
  * and in quirks mode is `<body>` only when `<body>` is not itself potentially
- * scrollable. Reading `documentElement` or `<body>` directly is correct in only
- * one of the two modes.
+ * scrollable. `documentElement` is correct in standards mode only and `<body>`
+ * in quirks mode only, so neither is safe to read directly.
  *
  * Returns `null` in the remaining quirks-mode cases, and when the scroll root
  * has no layout box. The document may still scroll in the quirks-mode case, but

--- a/packages/web-sdk/src/utils/measureDocument.ts
+++ b/packages/web-sdk/src/utils/measureDocument.ts
@@ -34,6 +34,9 @@ export const measureDocument = (): DocumentMeasurement | null => {
     return null;
   }
 
+  // Reading a dimension forces a synchronous layout reflow, so all four are read
+  // together with nothing written in between, and returned as one snapshot.
+  // https://developer.chrome.com/docs/performance/insights/forced-reflow
   const viewportHeight = scrollRoot.clientHeight;
   const viewportWidth = scrollRoot.clientWidth;
   // A non-rendered or zero-sized frame has a scroll root with no layout box.


### PR DESCRIPTION
Bottom of stack #1453.

## What problem is this solving?

An instrumentation that needs the content size of the document or the size of the viewport has no shared way to read them. A direct read of `documentElement` or `<body>` is correct in one rendering mode only. A pair of `documentElement.scrollHeight` and `window.innerHeight` has a second problem. It mixes a scrollbar-inclusive box with a scrollbar-exclusive one.

## Short description of changes

- Add `measureDocument()` in `packages/web-sdk/src/utils/`. It reads the document size and the viewport size from `document.scrollingElement`, the one element that is correct in both rendering modes
- Return `null` when there is no scroll root, and when the scroll root has no layout box. A caller then omits the attribute instead of emitting a 0 that a consumer would read as a real measurement
- Export `measureDocument` and `DocumentMeasurement` from the utils barrel

Both boxes come back from one call so they share a layout state. The document size and the viewport size only mean something against each other, and the scrollable range is their difference.

This PR adds no consumers. #1452 moves `MaxScrollDepthInstrumentation` onto `measureDocument()`. #1442 uses it for the DOM state snapshot.

## How has this been tested?

Five unit tests cover the util. The first test reads every dimension from a stubbed scroll root. Each stub value is distinct, so the test pins the mapping. Two tests cover the two `null` paths. One test measures the live document. The last test checks the quirks-mode condition in an iframe without a doctype, so the test proves the condition instead of asserting it in prose.

The live-document test appends a spacer three viewports tall. The bare test document measures equal in pairs (600/600, 800/800), so a `> 0` assertion would pass even with the document size and the viewport size swapped.

A mutation test covers each guard: a broken implementation makes the tests fail.

`npm run test`, `npm run lint`, and `npm run check` pass.

## Checklist

- [ ] Documentation added
- [x] Tests added
