### PR TITLE
EMBR-13293 fix(max-scroll-depth): measure via measureDocument and omit box-derived keys

### DIFF
--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -20,9 +20,14 @@ const { expect } = chai;
 
 interface ScrollGeometry {
   scrollY: number;
-  innerHeight: number;
-  scrollHeight: number;
+  viewportHeight: number;
+  documentHeight: number;
 }
+
+// The instrumentation only measures the vertical axis, but a scroll root is only
+// measurable when it has a layout box on both, so the horizontal axis gets a
+// fixed non-zero size that no assertion depends on.
+const HORIZONTAL_SIZE = 600;
 
 describe('MaxScrollDepthInstrumentation', () => {
   let memoryExporter: InMemoryLogRecordExporter;
@@ -30,8 +35,9 @@ describe('MaxScrollDepthInstrumentation', () => {
   let instrumentation: MaxScrollDepthInstrumentation;
 
   let scrollYValue = 0;
-  let innerHeightValue = 0;
-  let scrollHeightValue = 0;
+  let viewportHeightValue = 0;
+  let documentHeightValue = 0;
+  let scrollRootValue: Element | null = null;
   let originalDescriptors: Array<{
     target: object;
     prop: string;
@@ -39,10 +45,18 @@ describe('MaxScrollDepthInstrumentation', () => {
   }> = [];
 
   const stubGeometry = () => {
-    const targets: Array<[object, string, () => number]> = [
+    // A detached element stands in for the scrolling element so the dimensions
+    // the instrumentation reads cannot coincide with the real document root's:
+    // in this standards-mode document, scrollingElement *is* that root.
+    const scrollRoot = document.createElement('div');
+    scrollRootValue = scrollRoot;
+    const targets: Array<[object, string, () => unknown]> = [
       [window, 'scrollY', () => scrollYValue],
-      [window, 'innerHeight', () => innerHeightValue],
-      [document.documentElement, 'scrollHeight', () => scrollHeightValue],
+      [scrollRoot, 'scrollHeight', () => documentHeightValue],
+      [scrollRoot, 'clientHeight', () => viewportHeightValue],
+      [scrollRoot, 'scrollWidth', () => HORIZONTAL_SIZE],
+      [scrollRoot, 'clientWidth', () => HORIZONTAL_SIZE],
+      [document, 'scrollingElement', () => scrollRootValue],
     ];
     for (const [target, prop, get] of targets) {
       originalDescriptors.push({
@@ -69,12 +83,12 @@ describe('MaxScrollDepthInstrumentation', () => {
   // is only read when a log is emitted, not on scroll).
   const setGeometry = ({
     scrollY,
-    innerHeight,
-    scrollHeight,
+    viewportHeight,
+    documentHeight,
   }: ScrollGeometry) => {
     scrollYValue = scrollY;
-    innerHeightValue = innerHeight;
-    scrollHeightValue = scrollHeight;
+    viewportHeightValue = viewportHeight;
+    documentHeightValue = documentHeight;
   };
 
   // Set the scroll geometry and notify the instrumentation as the browser would on a scroll.
@@ -106,8 +120,8 @@ describe('MaxScrollDepthInstrumentation', () => {
     userSessionManager.startSessionPartInternal({ reason: 'init' });
 
     scrollYValue = 0;
-    innerHeightValue = 0;
-    scrollHeightValue = 0;
+    viewportHeightValue = 0;
+    documentHeightValue = 0;
     stubGeometry();
 
     instrumentation = new MaxScrollDepthInstrumentation();
@@ -120,7 +134,7 @@ describe('MaxScrollDepthInstrumentation', () => {
   });
 
   it('emits a max-scroll-depth log on session part end with all attributes', () => {
-    scroll({ scrollY: 450, innerHeight: 100, scrollHeight: 1000 });
+    scroll({ scrollY: 450, viewportHeight: 100, documentHeight: 1000 });
     userSessionManager.endSessionPartInternal({
       reason: 'web_foreground_inactivity',
     });
@@ -132,7 +146,7 @@ describe('MaxScrollDepthInstrumentation', () => {
     expect(logs[0].attributes).to.deep.equal({
       'emb.type': 'emb.otel_log',
       'max_scroll_depth.pixels': 450,
-      // scrollable range = scrollHeight - innerHeight = 1000 - 100 = 900; scrollY / 900 = 450 / 900 = 50%
+      // scrollable range = documentHeight - viewportHeight = 1000 - 100 = 900; scrollY / 900 = 450 / 900 = 50%
       'max_scroll_depth.percent': 50,
       'max_scroll_depth.did_scroll': true,
       'max_scroll_depth.document_height': 1000,
@@ -140,8 +154,8 @@ describe('MaxScrollDepthInstrumentation', () => {
   });
 
   it('reports the furthest scroll position reached, not the last one', () => {
-    scroll({ scrollY: 700, innerHeight: 100, scrollHeight: 1000 });
-    scroll({ scrollY: 200, innerHeight: 100, scrollHeight: 1000 }); // scrolled back up; max should be unaffected
+    scroll({ scrollY: 700, viewportHeight: 100, documentHeight: 1000 });
+    scroll({ scrollY: 200, viewportHeight: 100, documentHeight: 1000 }); // scrolled back up; max should be unaffected
 
     userSessionManager.endSessionPartInternal({
       reason: 'web_foreground_inactivity',
@@ -159,7 +173,7 @@ describe('MaxScrollDepthInstrumentation', () => {
   });
 
   it('always emits on session part end, even when the user did not scroll', () => {
-    setGeometry({ scrollY: 0, innerHeight: 100, scrollHeight: 1000 });
+    setGeometry({ scrollY: 0, viewportHeight: 100, documentHeight: 1000 });
 
     userSessionManager.endSessionPartInternal({
       reason: 'web_foreground_inactivity',
@@ -177,8 +191,8 @@ describe('MaxScrollDepthInstrumentation', () => {
   });
 
   it('resets the tracked max to the current scroll position on part end ', () => {
-    scroll({ scrollY: 900, innerHeight: 100, scrollHeight: 1000 }); // furthest point reached this part
-    scroll({ scrollY: 100, innerHeight: 100, scrollHeight: 1000 }); // user scrolls back up
+    scroll({ scrollY: 900, viewportHeight: 100, documentHeight: 1000 }); // furthest point reached this part
+    scroll({ scrollY: 100, viewportHeight: 100, documentHeight: 1000 }); // user scrolls back up
     userSessionManager.endSessionPartInternal({
       reason: 'web_foreground_inactivity',
     });
@@ -210,7 +224,7 @@ describe('MaxScrollDepthInstrumentation', () => {
   });
 
   it('clamps the percentage to 100 when the scroll position exceeds the scrollable range', () => {
-    scroll({ scrollY: 1000, innerHeight: 100, scrollHeight: 1000 });
+    scroll({ scrollY: 1000, viewportHeight: 100, documentHeight: 1000 });
 
     userSessionManager.endSessionPartInternal({
       reason: 'web_foreground_inactivity',
@@ -227,8 +241,70 @@ describe('MaxScrollDepthInstrumentation', () => {
     });
   });
 
+  it('omits the unmeasurable keys when there is no scrolling element', () => {
+    // scrollingElement is null in quirks mode when the body is potentially
+    // scrollable, leaving nothing to measure the document against. The pixel
+    // depth still comes from window.scrollY, so it is still reported.
+    scroll({ scrollY: 450, viewportHeight: 100, documentHeight: 1000 });
+    scrollRootValue = null;
+
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 450,
+      'max_scroll_depth.did_scroll': true,
+    });
+  });
+
+  it('omits the unmeasurable keys when the scroll root has no layout box', () => {
+    // A non-rendered or zero-sized frame has a scrolling element whose client
+    // box is empty, so there is no viewport to take a percentage against.
+    scroll({ scrollY: 450, viewportHeight: 0, documentHeight: 1000 });
+
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 450,
+      'max_scroll_depth.did_scroll': true,
+    });
+  });
+
+  it('reports the depth of a restored scroll offset the user never scrolled to', () => {
+    // A reload or back navigation restores the scroll position without firing a
+    // scroll event, and that depth was still reached.
+    setGeometry({ scrollY: 800, viewportHeight: 100, documentHeight: 1000 });
+
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 800,
+      // scrollable range = 1000 - 100 = 900; 800 / 900 = 89%
+      'max_scroll_depth.percent': 89,
+      // The depth was restored by the browser, not scrolled to by the user.
+      'max_scroll_depth.did_scroll': false,
+      'max_scroll_depth.document_height': 1000,
+    });
+  });
+
   it('reports 0 percent when the document is not scrollable', () => {
-    setGeometry({ scrollY: 0, innerHeight: 600, scrollHeight: 500 });
+    // The document exactly fills the viewport, leaving no scrollable range. It
+    // can never be shorter than that: both boxes come off the same scroll root.
+    setGeometry({ scrollY: 0, viewportHeight: 500, documentHeight: 500 });
 
     userSessionManager.endSessionPartInternal({
       reason: 'web_foreground_inactivity',

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -1,5 +1,7 @@
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/attributes.ts';
+import type { DocumentMeasurement } from '../../../utils/index.ts';
+import { measureDocument } from '../../../utils/index.ts';
 import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
 import {
   ATTR_MAX_SCROLL_DEPTH_DID_SCROLL,
@@ -63,18 +65,15 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
   }
 
   private _emit(): void {
-    // Read scrollHeight once here since it forces a layout reflow rather than on every scroll event.
+    // The scroll position is readable at any time, so a document that loaded at
+    // a restored offset has already reached that depth even though no scroll
+    // event ever fired for it.
+    this._maxScrollY = Math.max(this._maxScrollY, window.scrollY);
+
+    // Measure once here rather than on every scroll event, since reading the
+    // scroll root's dimensions forces a layout reflow.
     // https://developer.chrome.com/docs/performance/insights/forced-reflow
-    const documentHeight = document.documentElement.scrollHeight;
-    const viewportHeight = window.innerHeight;
-    const scrollBottom = documentHeight - viewportHeight;
-    const scrollPercent =
-      scrollBottom > 0
-        ? Math.min(
-            100,
-            Math.max(0, Math.round((this._maxScrollY / scrollBottom) * 100)),
-          )
-        : 0;
+    const measurement = measureDocument();
 
     this.logger.emit({
       eventName: MAX_SCROLL_DEPTH_EVENT_NAME,
@@ -82,14 +81,44 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
       attributes: {
         [KEY_EMB_TYPE]: EMB_TYPES.OTelLog,
         [ATTR_MAX_SCROLL_DEPTH_PIXELS]: this._maxScrollY,
-        [ATTR_MAX_SCROLL_DEPTH_PERCENT]: scrollPercent,
         [ATTR_MAX_SCROLL_DEPTH_DID_SCROLL]: this._hasScrolled,
-        [ATTR_MAX_SCROLL_DEPTH_DOCUMENT_HEIGHT]: documentHeight,
+        // Depth as a percentage and the document height both need a measurable
+        // scroll root, which a document or a frame can lack. Omit those keys in
+        // that case so consumers read absence rather than a fabricated 0. The
+        // pixel depth comes from the scroll position alone, so it stands on its
+        // own.
+        ...(measurement
+          ? {
+              [ATTR_MAX_SCROLL_DEPTH_PERCENT]: this._scrollPercent(measurement),
+              [ATTR_MAX_SCROLL_DEPTH_DOCUMENT_HEIGHT]:
+                measurement.documentHeight,
+            }
+          : {}),
       },
     });
 
     // Initial state for the next part will be wherever the user left off the scroll position
     this._hasScrolled = false;
     this._maxScrollY = window.scrollY;
+  }
+
+  private _scrollPercent({
+    documentHeight,
+    viewportHeight,
+  }: DocumentMeasurement): number {
+    // Both boxes are read off the same scroll root, so the document is never
+    // shorter than the viewport and the range is never negative.
+    const scrollBottom = documentHeight - viewportHeight;
+    if (scrollBottom === 0) {
+      // The document fits the viewport, so there was no depth to reach.
+      return 0;
+    }
+
+    // Elastic overscroll reports a negative scroll position past the top of the
+    // document, which is still the top.
+    return Math.min(
+      100,
+      Math.max(0, Math.round((this._maxScrollY / scrollBottom) * 100)),
+    );
   }
 }

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -106,8 +106,6 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
     documentHeight,
     viewportHeight,
   }: DocumentMeasurement): number {
-    // Both boxes are read off the same scroll root, so the document is never
-    // shorter than the viewport and the range is never negative.
     const scrollBottom = documentHeight - viewportHeight;
     if (scrollBottom === 0) {
       // The document fits the viewport, so there was no depth to reach.


### PR DESCRIPTION
Middle of stack #1453. Base is #1450.

## What problem is this solving?

`MaxScrollDepthInstrumentation` measured the scroll root by itself. It paired `documentElement.scrollHeight` with `window.innerHeight`. That pair is correct in standards mode only. It also mixes a scrollbar-exclusive box with a scrollbar-inclusive one, so the subtraction did not describe a real range.

`window.scrollY` stops at `scrollHeight - clientHeight`. `window.innerHeight` is never smaller than that client height, because it includes the horizontal scrollbar. The denominator was therefore narrower than the real scrollable range, and `max_scroll_depth.percent` came out too high. It reached 100 before the user reached the bottom. When the whole scrollable range was shorter than the scrollbar, the subtraction went negative and the instrumentation reported 0 for a page that does scroll.

When the page rendered nothing, the instrumentation emitted `percent: 0` and `document_height: 0`. A consumer reads those values as a real measurement at the top of a zero-height page. The correct meaning is no measurement.

The instrumentation also missed restored scroll offsets. The maximum came from scroll events only. A reload or a back navigation restores a deep offset, and the instrumentation then reported a depth of 0.

## Short description of changes

- Measure through `measureDocument()`. Do not read `documentElement` and `window` by hand. Both boxes now come from `document.scrollingElement`, so both are correct in both rendering modes and both exclude the scrollbar
- Omit `max_scroll_depth.percent` and `max_scroll_depth.document_height` when the scroll root is unmeasurable. A consumer then reads absence instead of a false 0. `pixels` and `did_scroll` come from the scroll position alone, so the instrumentation still emits them
- Add the current scroll position to the maximum at emit time. A document that loads at a restored offset has already reached that depth. `did_scroll` stays false in this case, which separates it from a real scroll
- Extract `_scrollPercent`. This method returns 0 for a zero scrollable range. It also clamps elastic overscroll. The range can no longer go negative, because both boxes come off the same element

Data continuity: `percent` now divides by the client height of the scroll root instead of `window.innerHeight`. The two agree unless the page renders a classic, non-overlay horizontal scrollbar. macOS and iOS use overlay scrollbars, so values there do not move. Where a classic scrollbar is present, reported percentages drop by up to the height of that scrollbar as a share of the scrollable range, because the earlier values were too high. `document_height` does not change in standards mode.

## How has this been tested?

The existing unit tests now use the scroll-root geometry. Each test stubs a detached element as `scrollingElement`, so the stubbed dimensions cannot match the real scroll root. Three tests are new. Two tests cover the unmeasurable paths: no scrolling element, and no layout box. Both assert that the two keys are absent. The third test restores an offset and asserts a depth with `did_scroll: false`.

All 9 unit tests pass. `npm run lint` and `npm run check` pass from the repo root.

The change does not affect the golden files. The test document measures 720 high in a 720 viewport. The scrollable range is therefore 0, and `percent` stays 0.

## Checklist

- [ ] Documentation added
- [x] Tests added
