### PR TITLE
EMBR-13084 refactor(utils): measure the viewport off the window when there is no scroll root

### DIFF
--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -50,8 +50,16 @@ describe('MaxScrollDepthInstrumentation', () => {
     // in this standards-mode document, scrollingElement *is* that root.
     const scrollRoot = document.createElement('div');
     scrollRootValue = scrollRoot;
+    // Both the scroll root and the real root carry the same sizes, and so does
+    // the window, so dropping the scroll root changes which element each side is
+    // read from without changing any value. What each source reports for a real
+    // document is measureDocument's own concern, covered by its tests.
     const targets: Array<[object, string, () => unknown]> = [
       [window, 'scrollY', () => scrollYValue],
+      [window, 'innerHeight', () => viewportHeightValue],
+      [window, 'innerWidth', () => HORIZONTAL_SIZE],
+      [document.documentElement, 'scrollHeight', () => documentHeightValue],
+      [document.documentElement, 'scrollWidth', () => HORIZONTAL_SIZE],
       [scrollRoot, 'scrollHeight', () => documentHeightValue],
       [scrollRoot, 'clientHeight', () => viewportHeightValue],
       [scrollRoot, 'scrollWidth', () => HORIZONTAL_SIZE],
@@ -241,10 +249,10 @@ describe('MaxScrollDepthInstrumentation', () => {
     });
   });
 
-  it('omits the unmeasurable keys when there is no scrolling element', () => {
+  it('keeps every attribute when there is no scrolling element', () => {
     // scrollingElement is null in quirks mode when the body is potentially
-    // scrollable, leaving nothing to measure the document against. The pixel
-    // depth still comes from window.scrollY, so it is still reported.
+    // scrollable. <html> stands in for the document there and the window knows
+    // the viewport, so the depth stays measurable.
     scroll({ scrollY: 450, viewportHeight: 100, documentHeight: 1000 });
     scrollRootValue = null;
 
@@ -257,13 +265,17 @@ describe('MaxScrollDepthInstrumentation', () => {
     expect(logs[0].attributes).to.deep.equal({
       'emb.type': 'emb.otel_log',
       'max_scroll_depth.pixels': 450,
+      'max_scroll_depth.percent': 50,
       'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 1000,
     });
   });
 
-  it('omits the unmeasurable keys when the scroll root has no layout box', () => {
-    // A non-rendered or zero-sized frame has a scrolling element whose client
-    // box is empty, so there is no viewport to take a percentage against.
+  it('omits the unmeasurable keys when the frame renders nothing', () => {
+    // A non-rendered or zero-sized frame has no viewport at all: neither the
+    // scroll root's client box nor the window reports one, so there is nothing to
+    // take a percentage against. The pixel depth comes from window.scrollY, so it
+    // is still reported.
     scroll({ scrollY: 450, viewportHeight: 0, documentHeight: 1000 });
 
     userSessionManager.endSessionPartInternal({
@@ -301,9 +313,29 @@ describe('MaxScrollDepthInstrumentation', () => {
     });
   });
 
+  it('reports 0 percent when the document is shorter than the viewport', () => {
+    // In quirks mode <body> can scroll inside itself while the document around it
+    // stays put, which leaves the document shorter than the viewport and the
+    // raw document-minus-viewport subtraction below zero.
+    setGeometry({ scrollY: 0, viewportHeight: 600, documentHeight: 400 });
+
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 0,
+      'max_scroll_depth.percent': 0,
+      'max_scroll_depth.did_scroll': false,
+      'max_scroll_depth.document_height': 400,
+    });
+  });
+
   it('reports 0 percent when the document is not scrollable', () => {
-    // The document exactly fills the viewport, leaving no scrollable range. It
-    // can never be shorter than that: both boxes come off the same scroll root.
+    // The document exactly fills the viewport, leaving no scrollable range.
     setGeometry({ scrollY: 0, viewportHeight: 500, documentHeight: 500 });
 
     userSessionManager.endSessionPartInternal({

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -231,6 +231,40 @@ describe('MaxScrollDepthInstrumentation', () => {
     });
   });
 
+  it('clamps a rubber-band negative scroll position to the top, including across part ends', () => {
+    // Safari reports a negative scroll position during rubber-band overscroll
+    // past the top of the document, which is still the top.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
+    scroll({ scrollY: -50, viewportHeight: 100, documentHeight: 1000 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    // A second part ending while still overscrolled: the depth carried over
+    // from the previous part must be the top, not the negative offset.
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(2);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 0,
+      'max_scroll_depth.percent': 0,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 1000,
+    });
+    expect(logs[1].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 0,
+      'max_scroll_depth.percent': 0,
+      'max_scroll_depth.did_scroll': false,
+      'max_scroll_depth.document_height': 1000,
+    });
+  });
+
   it('clamps the percentage to 100 when the scroll position exceeds the scrollable range', () => {
     scroll({ scrollY: 1000, viewportHeight: 100, documentHeight: 1000 });
 

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -70,8 +70,8 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
     // event ever fired for it.
     this._maxScrollY = Math.max(this._maxScrollY, window.scrollY);
 
-    // Measure once here rather than on every scroll event, since reading the
-    // scroll root's dimensions forces a layout reflow.
+    // Measure once here rather than on every scroll event, since reading
+    // document geometry forces a layout reflow.
     // https://developer.chrome.com/docs/performance/insights/forced-reflow
     const measurement = measureDocument();
 
@@ -82,11 +82,10 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
         [KEY_EMB_TYPE]: EMB_TYPES.OTelLog,
         [ATTR_MAX_SCROLL_DEPTH_PIXELS]: this._maxScrollY,
         [ATTR_MAX_SCROLL_DEPTH_DID_SCROLL]: this._hasScrolled,
-        // Depth as a percentage and the document height both need a measurable
-        // scroll root, which a document or a frame can lack. Omit those keys in
-        // that case so consumers read absence rather than a fabricated 0. The
-        // pixel depth comes from the scroll position alone, so it stands on its
-        // own.
+        // Depth as a percentage needs a viewport, which a document or a frame
+        // can lack. Omit it and the height together in that case so consumers
+        // read absence rather than a fabricated 0. The pixel depth comes from
+        // the scroll position alone, so it stands on its own.
         ...(measurement
           ? {
               [ATTR_MAX_SCROLL_DEPTH_PERCENT]: this._scrollPercent(measurement),
@@ -102,12 +101,8 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
     this._maxScrollY = window.scrollY;
   }
 
-  private _scrollPercent({
-    documentHeight,
-    viewportHeight,
-  }: DocumentMeasurement): number {
-    const scrollBottom = documentHeight - viewportHeight;
-    if (scrollBottom === 0) {
+  private _scrollPercent({ scrollableHeight }: DocumentMeasurement): number {
+    if (scrollableHeight === 0) {
       // The document fits the viewport, so there was no depth to reach.
       return 0;
     }
@@ -116,7 +111,7 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
     // document, which is still the top.
     return Math.min(
       100,
-      Math.max(0, Math.round((this._maxScrollY / scrollBottom) * 100)),
+      Math.max(0, Math.round((this._maxScrollY / scrollableHeight) * 100)),
     );
   }
 }

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -96,9 +96,12 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
       },
     });
 
-    // Initial state for the next part will be wherever the user left off the scroll position
+    // Initial state for the next part will be wherever the user left off the
+    // scroll position, clamped because Safari reports a negative position past
+    // the top of the document during rubber-band overscroll, which is still the
+    // top. https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
     this._hasScrolled = false;
-    this._maxScrollY = window.scrollY;
+    this._maxScrollY = Math.max(0, window.scrollY);
   }
 
   private _scrollPercent({ scrollableHeight }: DocumentMeasurement): number {
@@ -107,11 +110,12 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
       return 0;
     }
 
-    // Elastic overscroll reports a negative scroll position past the top of the
-    // document, which is still the top.
+    // The furthest point reached can exceed the range measured at part end: the
+    // document may have shrunk since, or the position came from overscroll past
+    // the bottom.
     return Math.min(
       100,
-      Math.max(0, Math.round((this._maxScrollY / scrollableHeight) * 100)),
+      Math.round((this._maxScrollY / scrollableHeight) * 100),
     );
   }
 }

--- a/packages/web-sdk/src/utils/measureDocument.test.ts
+++ b/packages/web-sdk/src/utils/measureDocument.test.ts
@@ -1,137 +1,623 @@
 import * as chai from 'chai';
+import type { DocumentMeasurement } from './measureDocument.ts';
 import { measureDocument } from './measureDocument.ts';
 
 const { expect } = chai;
 
+/*
+  Slack for the assertions that the reported viewport tracks the window box. A
+  fractional devicePixelRatio leaves a fractional CSS-pixel viewport that the
+  window getters and the client-box getters round in opposite directions, so on
+  the emulated mobile configs the reported viewport can come out a pixel larger
+  than the window box. Which axis it lands on varies by engine and version, and
+  the assertions print the values they saw.
+*/
+const ROUNDING_SLACK_PX = 1;
+
 describe('measureDocument', () => {
-  // `scrollingElement` is an accessor on Document.prototype, never an own
-  // property of the document, so deleting the stub restores the real getter.
-  const stubScrollingElement = (value: Element | null) => {
-    Object.defineProperty(document, 'scrollingElement', {
-      configurable: true,
-      get: () => value,
+  const restorers: Array<() => void> = [];
+
+  // Some of these are accessors on a prototype (`scrollingElement`,
+  // `scrollHeight`) and some are own properties of the window (`innerHeight`),
+  // so the original descriptor is put back where there was one and the shadowing
+  // own property is deleted where there was not.
+  const stubProp = (target: object, property: string, get: () => unknown) => {
+    const original = Object.getOwnPropertyDescriptor(target, property);
+    Object.defineProperty(target, property, { configurable: true, get });
+    restorers.push(() => {
+      if (original) {
+        Object.defineProperty(target, property, original);
+      } else {
+        Reflect.deleteProperty(target, property);
+      }
     });
   };
 
   afterEach(() => {
-    Reflect.deleteProperty(document, 'scrollingElement');
+    for (const restore of restorers) {
+      restore();
+    }
+    restorers.length = 0;
   });
 
-  const createScrollRoot = (dimensions: {
-    scrollHeight: number;
-    scrollWidth: number;
-    clientHeight: number;
-    clientWidth: number;
-  }) => {
-    const scrollRoot = document.createElement('div');
-    for (const [property, value] of Object.entries(dimensions)) {
-      Object.defineProperty(scrollRoot, property, {
-        configurable: true,
-        get: () => value,
-      });
-    }
-
-    return scrollRoot;
+  // The document root measures the document only where there is no scroll root,
+  // so cases that stub one give it its own scroll box as well.
+  const stubDocumentSize = (scrollHeight: number, scrollWidth: number) => {
+    stubProp(document.documentElement, 'scrollHeight', () => scrollHeight);
+    stubProp(document.documentElement, 'scrollWidth', () => scrollWidth);
   };
 
-  it('reads every dimension off the scrolling element', () => {
-    stubScrollingElement(
-      createScrollRoot({
-        scrollHeight: 2400,
-        scrollWidth: 1280,
+  // A detached element stands in for the scrolling element so the boxes read off
+  // it cannot coincide with the real document root's: in this standards-mode
+  // document, scrollingElement *is* that root.
+  const stubScrollRoot = (
+    boxes: {
+      clientHeight: number;
+      clientWidth: number;
+      scrollHeight: number;
+      scrollWidth: number;
+    } | null,
+  ) => {
+    if (boxes === null) {
+      stubProp(document, 'scrollingElement', () => null);
+      return;
+    }
+
+    const scrollRoot = document.createElement('div');
+    stubProp(scrollRoot, 'clientHeight', () => boxes.clientHeight);
+    stubProp(scrollRoot, 'clientWidth', () => boxes.clientWidth);
+    stubProp(scrollRoot, 'scrollHeight', () => boxes.scrollHeight);
+    stubProp(scrollRoot, 'scrollWidth', () => boxes.scrollWidth);
+    stubProp(document, 'scrollingElement', () => scrollRoot);
+  };
+
+  /*
+    Stubbed boxes, so these pin how the pieces are combined: which element each
+    side is read from, when the window box stands in, and when the whole
+    measurement is refused. What the browser actually puts in those boxes is
+    covered by the real documents further down.
+  */
+  describe('composition', () => {
+    it('reads both the document and the viewport off the scroll root', () => {
+      // The document root carries a different size so a measurement taken off it
+      // rather than off the scroll root cannot pass this.
+      stubDocumentSize(999, 999);
+      stubScrollRoot({
         clientHeight: 800,
         clientWidth: 600,
-      }),
-    );
+        scrollHeight: 2400,
+        scrollWidth: 1280,
+      });
 
-    expect(measureDocument()).to.deep.equal({
-      documentHeight: 2400,
-      documentWidth: 1280,
-      viewportHeight: 800,
-      viewportWidth: 600,
+      expect(measureDocument()).to.deep.equal({
+        documentHeight: 2400,
+        documentWidth: 1280,
+        viewportHeight: 800,
+        viewportWidth: 600,
+        scrollableHeight: 1600,
+      });
+    });
+
+    it('measures the document off <html> when there is no scroll root', () => {
+      // Quirks mode leaves no scroll root when <body> is potentially scrollable,
+      // so <html> supplies the document and the window supplies the viewport.
+      stubDocumentSize(2400, 1280);
+      stubScrollRoot(null);
+      stubProp(window, 'innerHeight', () => 800);
+      stubProp(window, 'innerWidth', () => 600);
+
+      expect(measureDocument()).to.deep.equal({
+        documentHeight: 2400,
+        documentWidth: 1280,
+        viewportHeight: 800,
+        viewportWidth: 600,
+        scrollableHeight: 1600,
+      });
+    });
+
+    it('reports a document smaller than the viewport rather than hiding it', () => {
+      // That is a real measurement of a document that does not scroll, not a
+      // missing one, and the scrollable range floors at zero rather than going
+      // negative.
+      stubDocumentSize(400, 1280);
+      stubScrollRoot(null);
+      stubProp(window, 'innerHeight', () => 600);
+      stubProp(window, 'innerWidth', () => 1280);
+
+      expect(measureDocument()).to.deep.equal({
+        documentHeight: 400,
+        documentWidth: 1280,
+        viewportHeight: 600,
+        viewportWidth: 1280,
+        scrollableHeight: 0,
+      });
+    });
+
+    it('returns null when the frame renders nothing', () => {
+      // What a zero-sized or display:none frame reports in every engine: the
+      // scroll root and the window both come back zero.
+      stubDocumentSize(0, 0);
+      stubScrollRoot({
+        clientHeight: 0,
+        clientWidth: 0,
+        scrollHeight: 0,
+        scrollWidth: 0,
+      });
+      stubProp(window, 'innerHeight', () => 0);
+      stubProp(window, 'innerWidth', () => 0);
+
+      expect(measureDocument()).to.equal(null);
+    });
+
+    it('measures the live document when nothing is stubbed', () => {
+      const spacer = document.createElement('div');
+      spacer.style.height = `${window.innerHeight * 3}px`;
+      document.body.append(spacer);
+
+      try {
+        const measurement = measureDocument();
+
+        // The test page renders, so it always has a viewport.
+        if (measurement === null) {
+          throw new Error('expected a viewport in a rendered document');
+        }
+
+        // Carried on the viewport assertions so a failure says what the engine
+        // actually reported, which is the whole question when they disagree.
+        const diagnostic = JSON.stringify({
+          innerWidth: window.innerWidth,
+          innerHeight: window.innerHeight,
+          clientWidth: document.documentElement.clientWidth,
+          clientHeight: document.documentElement.clientHeight,
+          devicePixelRatio: window.devicePixelRatio,
+        });
+
+        // The viewport is the frame the document scrolls inside, so it tracks
+        // the window box, and the spacer makes the document outgrow it.
+        expect(measurement.viewportHeight, diagnostic).to.be.at.most(
+          window.innerHeight + ROUNDING_SLACK_PX,
+        );
+        expect(measurement.viewportWidth, diagnostic).to.be.at.most(
+          window.innerWidth + ROUNDING_SLACK_PX,
+        );
+        expect(measurement.documentHeight).to.be.greaterThan(
+          measurement.viewportHeight,
+        );
+        expect(measurement.viewportWidth).to.be.greaterThan(0);
+        expect(measurement.documentWidth).to.be.greaterThan(0);
+      } finally {
+        spacer.remove();
+      }
     });
   });
 
-  it('returns null when the document has no scrolling element', () => {
-    stubScrollingElement(null);
+  /*
+    Real documents rather than stubbed getters. Every case below builds an actual
+    document in an iframe and checks the measurement against what the browser
+    itself does, so engine differences surface here instead of in production.
 
-    expect(measureDocument()).to.equal(null);
-  });
+    The load-bearing assertion is `scrollableHeight === maxScrollY`: the range we
+    report has to be the range the document can actually scroll through. That is
+    the property max-scroll-depth divides by. The fixtures deliberately include
+    the shapes where the wrong source element stops satisfying it, since a suite
+    built only from reset, in-flow content is one where every element happens to
+    agree.
+  */
+  describe('across document states', () => {
+    const frames: HTMLIFrameElement[] = [];
 
-  it('returns null when the scroll root has no layout box', () => {
-    stubScrollingElement(
-      createScrollRoot({
-        scrollHeight: 0,
-        scrollWidth: 0,
-        clientHeight: 0,
-        clientWidth: 0,
-      }),
-    );
+    const FRAME_HEIGHT = 300;
+    const FRAME_WIDTH = 400;
 
-    expect(measureDocument()).to.equal(null);
+    /*
+      document.write is used rather than srcdoc because srcdoc always parses in
+      standards mode, and rather than a data: src because that gives the frame an
+      opaque origin that blocks contentDocument. The markup is static test fixture
+      text going into an isolated frame, so none of the usual injection concerns
+      with document.write apply.
+    */
+    const makeDocument = (
+      html: string,
+      frameStyle = `width:${FRAME_WIDTH}px;height:${FRAME_HEIGHT}px`,
+    ): Document => {
+      const frame = document.createElement('iframe');
+      frame.style.cssText = `border:0;${frameStyle}`;
+      document.body.appendChild(frame);
+      frames.push(frame);
+      /*
+        Settle the frame's own box before writing into it. The child document's
+        viewport comes from the parent's layout of this element, so writing first
+        lays the content out against a provisional viewport and the document keeps
+        growing afterwards.
+      */
+      void frame.offsetHeight;
 
-    // A frame collapsed on one axis only still has no viewport to measure
-    // against, so neither dimension may stand in on its own.
-    stubScrollingElement(
-      createScrollRoot({
-        scrollHeight: 4000,
-        scrollWidth: 1280,
-        clientHeight: 0,
-        clientWidth: 1280,
-      }),
-    );
+      const doc = frame.contentDocument;
+      if (!doc) {
+        throw new Error('iframe document was not reachable');
+      }
+      doc.open();
+      doc.write(html);
+      doc.close();
+      // Force layout so the measurement reads a settled tree.
+      void doc.documentElement.offsetHeight;
+      return doc;
+    };
 
-    expect(measureDocument()).to.equal(null);
-  });
+    // How far the browser actually lets this document scroll vertically.
+    const maxScrollY = (doc: Document): number => {
+      const view = doc.defaultView;
+      if (!view) {
+        throw new Error('document has no browsing context');
+      }
+      view.scrollTo(0, 1_000_000);
+      const reached = view.scrollY;
+      view.scrollTo(0, 0);
+      return reached;
+    };
 
-  // The branch above is stubbed because measureDocument reads the global
-  // document, which the test page keeps in standards mode. This locks the real
-  // condition behind that stub.
-  it('has no scrolling element in quirks mode with a scrollable body', () => {
-    const frame = document.createElement('iframe');
-    document.body.append(frame);
+    /*
+      Engines disagree on these primitives, and the disagreements are the whole
+      reason this block exists, so every assertion carries them. A failure in CI
+      then says what the browser actually reported rather than only which
+      expectation broke.
+    */
+    const state = (doc: Document): string => {
+      const view = doc.defaultView;
+      const scrollRoot = doc.scrollingElement;
+      return JSON.stringify({
+        compatMode: doc.compatMode,
+        scrollRoot: scrollRoot ? scrollRoot.tagName : null,
+        scrollRootClientHeight: scrollRoot ? scrollRoot.clientHeight : null,
+        scrollRootClientWidth: scrollRoot ? scrollRoot.clientWidth : null,
+        htmlScrollHeight: doc.documentElement.scrollHeight,
+        bodyScrollHeight: doc.body ? doc.body.scrollHeight : null,
+        innerHeight: view ? view.innerHeight : null,
+        innerWidth: view ? view.innerWidth : null,
+      });
+    };
 
-    try {
-      const frameDocument = frame.contentDocument;
-      if (!frameDocument) {
-        throw new Error('expected a document inside the frame');
+    // Holds for every measurement the util returns, in every engine.
+    const expectSelfConsistent = (
+      measurement: DocumentMeasurement,
+      doc: Document,
+    ): void => {
+      const where = state(doc);
+      const view = doc.defaultView;
+      if (!view) {
+        throw new Error('document has no browsing context');
       }
 
-      // Written without a doctype, so the frame parses in quirks mode.
-      frameDocument.write('<style>html, body { overflow: auto }</style>');
-      frameDocument.close();
-
-      expect(frameDocument.compatMode).to.equal('BackCompat');
-      expect(frameDocument.scrollingElement).to.equal(null);
-    } finally {
-      frame.remove();
-    }
-  });
-
-  it('measures the live document when nothing is stubbed', () => {
-    const spacer = document.createElement('div');
-    spacer.style.height = `${window.innerHeight * 3}px`;
-    document.body.append(spacer);
-
-    try {
-      const measurement = measureDocument();
-
-      // The test document is in standards mode, so it always has a scroll root.
-      if (!measurement) {
-        throw new Error('expected a scroll root in a standards-mode document');
-      }
-
-      // The viewport is the frame the document scrolls inside, so it can never
-      // exceed the window, and the spacer makes the document outgrow it.
-      expect(measurement.viewportHeight).to.be.at.most(window.innerHeight);
-      expect(measurement.viewportWidth).to.be.at.most(window.innerWidth);
-      expect(measurement.documentHeight).to.be.greaterThan(
-        measurement.viewportHeight,
+      expect(measurement.viewportHeight, where).to.be.greaterThan(0);
+      expect(measurement.viewportWidth, where).to.be.greaterThan(0);
+      // The reported viewport tracks the window box: the scroll-root path
+      // excludes classic scrollbar space and the window path includes it.
+      expect(measurement.viewportHeight, where).to.be.at.most(
+        view.innerHeight + ROUNDING_SLACK_PX,
       );
-      expect(measurement.viewportWidth).to.be.greaterThan(0);
-      expect(measurement.documentWidth).to.be.greaterThan(0);
-    } finally {
-      spacer.remove();
-    }
+      expect(measurement.viewportWidth, where).to.be.at.most(
+        view.innerWidth + ROUNDING_SLACK_PX,
+      );
+      expect(measurement.scrollableHeight, where).to.equal(
+        Math.max(0, measurement.documentHeight - measurement.viewportHeight),
+      );
+      expect(
+        measurement.scrollableHeight,
+        `reported scrollable range must match what the document can scroll. ${where}`,
+      ).to.equal(maxScrollY(doc));
+    };
+
+    const measured = (doc: Document): DocumentMeasurement => {
+      const measurement = measureDocument(doc);
+      if (!measurement) {
+        throw new Error('expected a measurement');
+      }
+      return measurement;
+    };
+
+    const STANDARDS = '<!DOCTYPE html>';
+    const RESET = '<style>html,body{margin:0;padding:0}</style>';
+
+    afterEach(() => {
+      for (const frame of frames) {
+        frame.remove();
+      }
+      frames.length = 0;
+    });
+
+    describe('standards mode', () => {
+      it('reports no scrollable range for a document shorter than the viewport', () => {
+        const doc = makeDocument(
+          `${STANDARDS}${RESET}<body><div style="height:50px"></div></body>`,
+        );
+
+        expect(doc.compatMode).to.equal('CSS1Compat');
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight).to.equal(0);
+        expect(measurement.viewportHeight).to.equal(FRAME_HEIGHT);
+      });
+
+      it('reports the scrollable range for a document taller than the viewport', () => {
+        const doc = makeDocument(
+          `${STANDARDS}${RESET}<body><div style="height:2000px"></div></body>`,
+        );
+
+        expect(doc.compatMode).to.equal('CSS1Compat');
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight).to.be.greaterThan(0);
+        expect(measurement.documentHeight).to.be.at.least(2000);
+      });
+
+      it('reports no scrollable range when the content is exactly the viewport height', () => {
+        const doc = makeDocument(
+          `${STANDARDS}${RESET}<body><div style="height:${FRAME_HEIGHT}px"></div></body>`,
+        );
+
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight).to.equal(0);
+      });
+
+      it('reports no vertical range for a document that only overflows horizontally', () => {
+        const doc = makeDocument(
+          `${STANDARDS}${RESET}<body><div style="width:3000px;height:10px"></div></body>`,
+        );
+
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight).to.equal(0);
+        expect(measurement.documentWidth).to.be.greaterThan(
+          measurement.viewportWidth,
+        );
+      });
+
+      it('measures both axes when the document overflows in both', () => {
+        const doc = makeDocument(
+          `${STANDARDS}${RESET}<body><div style="width:3000px;height:2000px"></div></body>`,
+        );
+
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight).to.be.greaterThan(0);
+        expect(measurement.documentWidth).to.be.greaterThan(
+          measurement.viewportWidth,
+        );
+      });
+
+      it('matches the real scroll range when the content height is fractional', () => {
+        // scrollHeight is an integer while scroll offsets are not, so a fractional
+        // document is where a rounding mismatch would show up.
+        const doc = makeDocument(
+          `${STANDARDS}${RESET}<body><div style="height:1999.5px"></div></body>`,
+        );
+
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+      });
+
+      it('accounts for the default body margin', () => {
+        // No reset, so the UA margin on <body> is part of the document box. Real
+        // pages far more often look like this than like the reset cases above.
+        const doc = makeDocument(
+          `${STANDARDS}<body><div style="height:2000px"></div></body>`,
+        );
+
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight).to.be.greaterThan(0);
+      });
+
+      it('still reports the viewport when the root element is display:none', () => {
+        // Every engine keeps reporting the viewport off the root element here,
+        // even though display:none otherwise leaves an element with no client box
+        // to report at all.
+        // https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight
+        const doc = makeDocument(
+          `${STANDARDS}<style>html{display:none}</style><body>hi</body>`,
+        );
+
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.viewportHeight).to.equal(FRAME_HEIGHT);
+      });
+    });
+
+    describe('quirks mode', () => {
+      it('reports no scrollable range for a document shorter than the viewport', () => {
+        const doc = makeDocument(
+          `${RESET}<body><div style="height:50px"></div></body>`,
+        );
+
+        expect(doc.compatMode).to.equal('BackCompat');
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight).to.equal(0);
+      });
+
+      it('reports the scrollable range for a document taller than the viewport', () => {
+        const doc = makeDocument(
+          `${RESET}<body><div style="height:2000px"></div></body>`,
+        );
+
+        expect(doc.compatMode).to.equal('BackCompat');
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight).to.be.greaterThan(0);
+      });
+
+      it('accounts for the default body margin', () => {
+        const doc = makeDocument(
+          '<body><div style="height:2000px"></div></body>',
+        );
+
+        expect(doc.compatMode).to.equal('BackCompat');
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight).to.be.greaterThan(0);
+      });
+
+      it('covers overflow from out-of-flow content', () => {
+        // An absolutely positioned child is laid out against the initial
+        // containing block, so it sits outside <html>'s own scrolling area
+        // entirely. Only the scroll root's scroll box spans it, and measuring off
+        // <html> here reports a document that does not scroll at all.
+        const doc = makeDocument(
+          `${RESET}<body><div style="position:absolute;top:0;height:2100px;width:10px"></div></body>`,
+        );
+
+        expect(doc.compatMode).to.equal('BackCompat');
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight, state(doc)).to.be.greaterThan(0);
+      });
+
+      it('never reports a fabricated zero box when the document source comes up empty', () => {
+        // Null scroll root (body potentially scrollable on both axes) plus an
+        // out-of-flow child, which can leave <html>'s scroll height at zero.
+        const doc = makeDocument(
+          `${RESET}<style>html{overflow:auto}body{overflow:auto}</style><body><div style="position:absolute;top:0;height:2100px;width:10px"></div></body>`,
+        );
+
+        expect(doc.compatMode).to.equal('BackCompat');
+        expect(doc.scrollingElement).to.equal(null);
+        const measurement = measureDocument(doc);
+        if (measurement === null) {
+          return;
+        }
+
+        expect(measurement.documentHeight, state(doc)).to.be.greaterThan(0);
+        expect(measurement.documentWidth, state(doc)).to.be.greaterThan(0);
+        expect(measurement.viewportHeight, state(doc)).to.be.greaterThan(0);
+        expect(measurement.viewportWidth, state(doc)).to.be.greaterThan(0);
+      });
+
+      it("covers <html>'s own margin", () => {
+        // <html>'s scrolling area excludes its own margin, so measuring the
+        // document off <html> comes up short by exactly that margin.
+        const doc = makeDocument(
+          '<style>body{margin:0;padding:0}html{margin:50px;padding:0}</style><body><div style="height:2000px"></div></body>',
+        );
+
+        expect(doc.compatMode).to.equal('BackCompat');
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight, state(doc)).to.be.greaterThan(0);
+      });
+
+      it("covers <html>'s own border", () => {
+        // The same exclusion as the margin case, on the border edge.
+        const doc = makeDocument(
+          '<style>body{margin:0;padding:0}html{border:20px solid;padding:0}</style><body><div style="height:2000px"></div></body>',
+        );
+
+        expect(doc.compatMode).to.equal('BackCompat');
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight, state(doc)).to.be.greaterThan(0);
+      });
+
+      it('measures the viewport off <body>, which is the scroll root here', () => {
+        const doc = makeDocument(
+          `${RESET}<body><div style="height:2000px"></div></body>`,
+        );
+
+        expect(doc.scrollingElement).to.equal(doc.body);
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+      });
+
+      it('falls back to the window when <body> is potentially scrollable', () => {
+        // <html> overflow must be non-visible so the body's overflow does not
+        // propagate to the viewport, which is what makes <body> potentially
+        // scrollable and leaves scrollingElement null.
+        // https://drafts.csswg.org/cssom-view/#potentially-scrollable
+        const doc = makeDocument(
+          `${RESET}<style>html{overflow:hidden}body{overflow:scroll;height:50px}</style><body><div style="height:2000px"></div></body>`,
+        );
+
+        expect(doc.compatMode).to.equal('BackCompat');
+        expect(doc.scrollingElement).to.equal(null);
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+      });
+
+      it('keeps the range positive when the body scrolls a tall child inside a constrained <html>', () => {
+        // <html> is constrained, but its scroll area still covers the tall child,
+        // so the document side stays larger than the viewport here.
+        const doc = makeDocument(
+          `${RESET}<style>html{overflow:hidden;height:50px}body{overflow:scroll}</style><body><div style="height:2000px"></div></body>`,
+        );
+
+        expect(doc.compatMode).to.equal('BackCompat');
+        expect(doc.scrollingElement).to.equal(null);
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight).to.be.greaterThan(0);
+      });
+
+      it('never reports a negative range when <html> measures shorter than the viewport', () => {
+        // The shape the clamp exists for: no scroll root, so the viewport comes
+        // from the window, while the document is measured off an <html> that is
+        // both constrained and holding nothing tall.
+        const doc = makeDocument(
+          `${RESET}<style>html{overflow:hidden;height:50px}body{overflow:scroll}</style><body><div style="height:20px"></div></body>`,
+        );
+
+        expect(doc.compatMode).to.equal('BackCompat');
+        expect(doc.scrollingElement).to.equal(null);
+        const measurement = measured(doc);
+        expectSelfConsistent(measurement, doc);
+        expect(measurement.scrollableHeight).to.equal(0);
+        /*
+          Engines split here, which is exactly why the clamp lives in the producer
+          rather than at each call site. Chromium and Firefox report an <html>
+          scroll height shorter than the viewport, so the raw subtraction would go
+          negative. WebKit floors it at the viewport, so the same subtraction lands
+          on zero. Both are covered by `<=`.
+        */
+        expect(measurement.documentHeight, state(doc)).to.be.at.most(
+          measurement.viewportHeight,
+        );
+      });
+    });
+
+    describe('no viewport', () => {
+      it('returns null for a zero-sized frame', () => {
+        const doc = makeDocument(
+          `${STANDARDS}${RESET}<body><div style="height:2000px"></div></body>`,
+          'width:0;height:0',
+        );
+
+        expect(measureDocument(doc), state(doc)).to.equal(null);
+      });
+
+      it('returns null for a display:none frame', () => {
+        const doc = makeDocument(
+          `${STANDARDS}${RESET}<body><div style="height:2000px"></div></body>`,
+          'display:none',
+        );
+
+        expect(measureDocument(doc), state(doc)).to.equal(null);
+      });
+
+      it('returns null for a document with no browsing context', () => {
+        const detached = document.implementation.createHTMLDocument('detached');
+
+        expect(detached.defaultView).to.equal(null);
+        expect(measureDocument(detached)).to.equal(null);
+      });
+
+      it('returns null rather than throwing when the root element has been removed', () => {
+        const doc = makeDocument(
+          `${STANDARDS}${RESET}<body><div style="height:2000px"></div></body>`,
+        );
+        doc.documentElement.remove();
+
+        expect(doc.scrollingElement).to.equal(null);
+        expect(measureDocument(doc)).to.equal(null);
+      });
+    });
   });
 });

--- a/packages/web-sdk/src/utils/measureDocument.ts
+++ b/packages/web-sdk/src/utils/measureDocument.ts
@@ -2,51 +2,69 @@
  * A point-in-time reading of the document and viewport boxes, in integer CSS
  * pixels. Resize, zoom, and content mutation all invalidate it.
  *
- * `viewportHeight`/`viewportWidth` are the scroll root's client box, which
- * excludes any space a classic scrollbar takes, so they are `<=`
- * `window.innerHeight`/`innerWidth` rather than equal to them. The document
- * boxes are always `>=` their viewport counterparts, and the scrollable range
- * is the difference between the two.
+ * `viewportHeight`/`viewportWidth` are the box the document scrolls inside,
+ * read from the scroll root's client box, or from the window where there is
+ * no scroll root.
+ *
+ * `scrollableHeight` is the scrollable range the measurement supports, floored
+ * at zero: exact off a scroll root, approximate where the viewport came from
+ * the window. Take it rather than subtracting the boxes, which can go negative.
  */
 export interface DocumentMeasurement {
   documentHeight: number;
   documentWidth: number;
+  scrollableHeight: number;
   viewportHeight: number;
   viewportWidth: number;
 }
 
 /**
- * Measures the document's content size and the viewport size off
- * `document.scrollingElement`, which is the document root in standards mode,
- * and in quirks mode is `<body>` only when `<body>` is not itself potentially
- * scrollable. `documentElement` is correct in standards mode only and `<body>`
- * in quirks mode only, so neither is safe to read directly.
- *
- * Returns `null` in the remaining quirks-mode cases, and when the scroll root
- * has no layout box. The document may still scroll in the quirks-mode case, but
- * no element measures it correctly, so callers should report the absence rather
- * than substitute a zero that would read as a real measurement.
+ * Measures the document off `document.scrollingElement`, the only element whose
+ * scroll box spans the viewport's scrolling area. In quirks mode `<html>` reports
+ * just its own, dropping its margin, border, and out-of-flow content, so it
+ * stands in only where there is no scroll root. The viewport cannot come from
+ * `<html>` either, whose quirks-mode client box is its own padding box, so it
+ * comes from the scroll root or else the window. Returns `null` where there is
+ * no browsing context, no root element, or nothing rendered.
  * https://developer.mozilla.org/en-US/docs/Web/API/Document/scrollingElement
  */
-export const measureDocument = (): DocumentMeasurement | null => {
-  const scrollRoot = document.scrollingElement;
-  if (!scrollRoot) {
+export const measureDocument = (
+  doc: Document = document,
+): DocumentMeasurement | null => {
+  // No browsing context, so nothing reports a viewport.
+  const view = doc.defaultView;
+  if (!view) {
+    return null;
+  }
+
+  const scrollRoot = doc.scrollingElement;
+  const documentSource = scrollRoot ?? doc.documentElement;
+
+  // A document whose root element was removed has nothing to measure.
+  if (!documentSource) {
     return null;
   }
 
   // Reading a dimension forces a synchronous layout reflow, so all four are read
   // together with nothing written in between, and returned as one snapshot.
   // https://developer.chrome.com/docs/performance/insights/forced-reflow
-  const viewportHeight = scrollRoot.clientHeight;
-  const viewportWidth = scrollRoot.clientWidth;
-  // A non-rendered or zero-sized frame has a scroll root with no layout box.
-  if (!viewportHeight || !viewportWidth) {
+  const documentHeight = documentSource.scrollHeight;
+  const documentWidth = documentSource.scrollWidth;
+  // The window stands in only where there is no scroll root to read the
+  // viewport off.
+  const viewportHeight = scrollRoot?.clientHeight ?? view.innerHeight;
+  const viewportWidth = scrollRoot?.clientWidth ?? view.innerWidth;
+
+  // Nothing renders, as in a frame sized to zero or display:none, or the
+  // document source reports no box at all.
+  if (!documentHeight || !documentWidth || !viewportHeight || !viewportWidth) {
     return null;
   }
 
   return {
-    documentHeight: scrollRoot.scrollHeight,
-    documentWidth: scrollRoot.scrollWidth,
+    documentHeight,
+    documentWidth,
+    scrollableHeight: Math.max(0, documentHeight - viewportHeight),
     viewportHeight,
     viewportWidth,
   };


### PR DESCRIPTION
## What problem is this solving?

`measureDocument` read both the document and the viewport off `document.scrollingElement`, which is `null` in quirks mode when `<body>` is potentially scrollable, so `MaxScrollDepthInstrumentation` dropped `max_scroll_depth.percent` and `max_scroll_depth.document_height` for those documents even though the depth was measurable. Extracted from #1442, which rebases on top as the util's second consumer.

## Short description of changes

Three commits, one concern each:

1. **fix(utils)**: measure the document off the scroll root, falling back to `<html>` for the document boxes and to the window for the viewport where there is no scroll root. `null` now means only "nothing to measure" (no browsing context, no root element, nothing rendered, or a zero box), never a measurable quirks document. The fallback range is approximate (quirks `<html>` undercounts; `innerHeight` includes scrollbar space): approximate-but-present beats omission. Tests rebuilt around real documents in iframes, since doctype-dependent behavior cannot be stubbed.
2. **refactor(max-scroll-depth)**: take `scrollableHeight` (floored at zero) from the measurement instead of subtracting boxes at the call site, where the subtraction can go negative.
3. **fix(max-scroll-depth)**: clamp the scroll position carried into the next session part; Safari reports it negative during rubber-band overscroll past the top.

## How has this been tested?

`npm run lint`, `npm run check`, and the web-sdk unit suite pass; both affected test files pass under `npm run test:multiBrowsers` (Chromium, Firefox, WebKit, Pixel 5 and iPhone 12 emulations).
