### PR TITLE
ci(renovate): group all Playwright deps together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,7 +49,11 @@
     },
     {
       "description": "Playwright",
-      "matchDepNames": ["playwright"],
+      "matchDepNames": [
+        "@playwright/test",
+        "mcr.microsoft.com/playwright",
+        "playwright"
+      ],
       "groupName": "playwright"
     },
     {


### PR DESCRIPTION
## What problem is this solving?

The Renovate `playwright` group only matched the bare `playwright` package, so `@playwright/test` and the `mcr.microsoft.com/playwright` Docker image were bumped in separate PRs. Those three have to move in lockstep; when they drift, the browser binaries in the image stop matching the test runner and CI breaks.

## Short description of changes

- Extend `matchDepNames` for the `playwright` group to include `@playwright/test` and `mcr.microsoft.com/playwright`.

## How has this been tested?

Config-only change; validated against the Renovate JSON schema referenced in the file. Grouping takes effect on the next Renovate run.

## Checklist

- [ ] Documentation added
- [ ] Tests added