### PR TITLE
fix(tests): pass UPDATE_GOLDEN through to the integration test task

### DIFF
--- a/tests/integration/turbo.json
+++ b/tests/integration/turbo.json
@@ -13,7 +13,8 @@
     },
     "test": {
       "dependsOn": ["^build", "install-dependencies", "build-platforms"],
-      "cache": false
+      "cache": false,
+      "passThroughEnv": ["UPDATE_GOLDEN"]
     },
     "update-golden": {
       "dependsOn": ["^build", "install-dependencies", "build-platforms"],


### PR DESCRIPTION
## What problem is this solving?

`test:integration:container:update-golden` never regenerated anything. Turbo runs in `envMode: strict` and the integration `test` task never declared `UPDATE_GOLDEN`, so it was stripped before `test-with-mock-api.ts` could read it and the run silently fell back to compare mode.

## Short description of changes

Declare `passThroughEnv: ["UPDATE_GOLDEN"]` on the integration `test` task. Not `env`, since the task is already `cache: false`.

## How has this been tested?

Probed what the task actually receives: `"1"` with the declaration, `undefined` without. Full container run not exercised.

## Checklist

- [ ] Documentation added
- [ ] Tests added
