### PR TITLE
feat(logs): add log.flush() and use it to drain e2e telemetry deterministically

### DIFF
--- a/packages/web-sdk/src/api-logs/api/LogAPI/LogAPI.test.ts
+++ b/packages/web-sdk/src/api-logs/api/LogAPI/LogAPI.test.ts
@@ -33,6 +33,7 @@ describe('LogAPI', () => {
       // Mock implementation of LogManager
       message: sinon.stub(),
       logException: sinon.stub(),
+      flush: sinon.stub().resolves(),
     };
     logAPI.setGlobalLogManager(logManager);
     const result = logAPI.getLogManager();
@@ -45,6 +46,7 @@ describe('LogAPI', () => {
       // Mock implementation of LogManager
       message: sinon.stub(),
       logException: sinon.stub(),
+      flush: sinon.stub().resolves(),
     };
     logAPI.setGlobalLogManager(mockLogManager);
 

--- a/packages/web-sdk/src/api-logs/manager/NoOpLogManager/NoOpLogManager.ts
+++ b/packages/web-sdk/src/api-logs/manager/NoOpLogManager/NoOpLogManager.ts
@@ -17,4 +17,8 @@ export class NoOpLogManager implements LogManager {
   ) {
     // no op
   }
+
+  public flush(): Promise<void> {
+    return Promise.resolve();
+  }
 }

--- a/packages/web-sdk/src/api-logs/manager/ProxyLogManager/ProxyLogManager.test.ts
+++ b/packages/web-sdk/src/api-logs/manager/ProxyLogManager/ProxyLogManager.test.ts
@@ -17,6 +17,7 @@ describe('ProxyLogManager', () => {
     mockDelegate = {
       message: sinon.stub(),
       logException: sinon.stub(),
+      flush: sinon.stub().resolves(),
     };
   });
 

--- a/packages/web-sdk/src/api-logs/manager/ProxyLogManager/ProxyLogManager.ts
+++ b/packages/web-sdk/src/api-logs/manager/ProxyLogManager/ProxyLogManager.ts
@@ -30,4 +30,8 @@ export class ProxyLogManager implements LogManager {
   ) {
     this.getDelegate().message(message, level, options);
   }
+
+  public flush(): Promise<void> {
+    return this.getDelegate().flush();
+  }
 }

--- a/packages/web-sdk/src/api-logs/manager/types.ts
+++ b/packages/web-sdk/src/api-logs/manager/types.ts
@@ -21,6 +21,17 @@ export interface LogManager {
   ) => void;
 
   logException: (error: unknown, options?: LogExceptionOptions) => void;
+
+  /**
+   * Exports any logs still held in the batch buffer instead of waiting for the
+   * next scheduled export. Useful before a deliberate teardown, and gives tests
+   * a known point to drain from rather than racing the export schedule.
+   *
+   * Resolves once the export settles and never rejects: failures are reported
+   * on the diagnostic channel. Note the safe-proxy wrapper around the public
+   * API only traps synchronous throws, so this must absorb its own rejections.
+   */
+  flush: () => Promise<void>;
 }
 
 export type LogSeverity = 'info' | 'warning' | 'error';

--- a/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
@@ -12,6 +12,7 @@ import {
   ATTR_EXCEPTION_TYPE,
 } from '@opentelemetry/semantic-conventions';
 import * as chai from 'chai';
+import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import {
   FailingStorage,
@@ -1328,6 +1329,59 @@ describe('EmbraceLogManager', () => {
 
       expect(memoryExporter.getFinishedLogRecords()).to.have.lengthOf(0);
       expect(secondMemoryExporter.getFinishedLogRecords()).to.have.lengthOf(1);
+    });
+
+    it('should force flush the overridden logger provider', async () => {
+      const loggerProvider = new LoggerProvider({
+        processors: [
+          new SimpleLogRecordProcessor({
+            exporter: new InMemoryLogRecordExporter(),
+          }),
+        ],
+      });
+      const forceFlush = sinon.spy(loggerProvider, 'forceFlush');
+
+      const testManager = new EmbraceLogManager({
+        perf,
+        userSessionManager,
+        limitManager,
+        loggerProvider,
+        storage,
+        visibilityDoc: window.document,
+      });
+
+      await testManager.flush();
+
+      void expect(forceFlush.calledOnce).to.be.true;
+    });
+
+    it('should resolve rather than reject when the flush fails', async () => {
+      const loggerProvider = new LoggerProvider({
+        processors: [
+          new SimpleLogRecordProcessor({
+            exporter: new InMemoryLogRecordExporter(),
+          }),
+        ],
+      });
+      sinon
+        .stub(loggerProvider, 'forceFlush')
+        .rejects(new Error('exporter unavailable'));
+
+      const testManager = new EmbraceLogManager({
+        diag,
+        perf,
+        userSessionManager,
+        limitManager,
+        loggerProvider,
+        storage,
+        visibilityDoc: window.document,
+      });
+
+      // The safe proxy around the public API only traps synchronous throws, so
+      // a rejection here would surface to user code.
+      await testManager.flush();
+
+      expect(diag.getErrorLogs().join(' ')).to.include('exporter unavailable');
     });
 
     it('should include exception number when logging an exception', () => {

--- a/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.ts
@@ -2,6 +2,7 @@ import type { Attributes, DiagLogger } from '@opentelemetry/api';
 import { diag } from '@opentelemetry/api';
 import type { Logger } from '@opentelemetry/api-logs';
 import { logs, SeverityNumber } from '@opentelemetry/api-logs';
+import type { LoggerProvider } from '@opentelemetry/sdk-logs';
 import {
   ATTR_EXCEPTION_MESSAGE,
   ATTR_EXCEPTION_STACKTRACE,
@@ -49,10 +50,22 @@ const EMBRACE_EXCEPTION_NUMBER_STORAGE_KEY = 'embrace_exception_number';
 const getJSFileBundleIDs = () =>
   JSON.stringify(GLOBAL_CONFIG._EmbraceFileBundleIDs || {});
 
+/**
+ * The logs API surface only guarantees `getLogger`, so a provider reached
+ * through the global registry has to be probed before flushing it.
+ */
+type FlushableLoggerProvider = { forceFlush: () => Promise<void> };
+
+const isFlushable = (provider: unknown): provider is FlushableLoggerProvider =>
+  typeof provider === 'object' &&
+  provider !== null &&
+  typeof (provider as FlushableLoggerProvider).forceFlush === 'function';
+
 export class EmbraceLogManager implements LogManager {
   private readonly _diag: DiagLogger;
   private readonly _perf: PerformanceManager;
   private readonly _logger: Logger;
+  private readonly _loggerProviderOverride?: LoggerProvider;
   private readonly _userSessionManager: UserSessionManagerInternal;
   private readonly _limitManager: LimitManagerInternal;
   private readonly _visibilityDoc: VisibilityStateDocument;
@@ -76,10 +89,27 @@ export class EmbraceLogManager implements LogManager {
       });
     this._perf = perf;
     this._logger = loggerProvider.getLogger('embrace-web-sdk-logs');
+    this._loggerProviderOverride = globalLoggerProviderOverride;
     this._userSessionManager = userSessionManager;
     this._limitManager = limitManager;
     this._visibilityDoc = visibilityDoc;
     this._storage = storage;
+  }
+
+  public async flush(): Promise<void> {
+    try {
+      // Resolved here rather than in the constructor because when the SDK
+      // registers globally the provider is set after this manager is built.
+      const provider = this._loggerProviderOverride ?? logs.getLoggerProvider();
+
+      if (isFlushable(provider)) {
+        await provider.forceFlush();
+      }
+    } catch (e) {
+      this._diag.error(
+        `flush: ${e instanceof Error ? e.message : 'Unknown error'}`,
+      );
+    }
   }
 
   private _validateAttributes(attributes: unknown): Attributes {

--- a/packages/web-sdk/src/sdk/logExportSchedule.test.ts
+++ b/packages/web-sdk/src/sdk/logExportSchedule.test.ts
@@ -1,0 +1,80 @@
+import { context, diag, trace } from '@opentelemetry/api';
+import { logs } from '@opentelemetry/api-logs';
+import { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import { log } from '../api-logs/index.ts';
+import { initSDK } from './initSDK.ts';
+import { registry } from './registry.ts';
+
+const { expect } = chai;
+
+const PROBE_BODY = 'batch-window-probe';
+
+/**
+ * The end-to-end request assertions depend on this window: page-load telemetry
+ * and a later interaction only share a request while both fall inside it.
+ * Chromium 149 to 151 shifted page-load timing across the boundary and broke
+ * those tests, so it is pinned here where a fake clock can assert it exactly
+ * rather than inferred from wall-clock racing in a browser.
+ *
+ * This lives in its own file because @web/test-runner isolates each file in a
+ * fresh page. Sharing a file with other initSDK tests lets an SDK built by an
+ * earlier test keep timers registered, which the fake clock then fires.
+ */
+describe('log export schedule', () => {
+  let logExporter: InMemoryLogRecordExporter;
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    logExporter = new InMemoryLogRecordExporter();
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+    logExporter.reset();
+    trace.disable();
+    logs.disable();
+    diag.disable();
+    context.disable();
+    registry.clear();
+  });
+
+  // Instrumentations emit logs of their own, so count only this probe.
+  const probeCount = () =>
+    logExporter
+      .getFinishedLogRecords()
+      .filter((record) => record.body === PROBE_BODY).length;
+
+  it('should hold a log in the batch buffer until the scheduled delay elapses', async () => {
+    const result = initSDK({
+      logExporters: [logExporter],
+      // Reads navigation timing entries that a fake clock leaves undefined.
+      defaultInstrumentationConfig: { omit: new Set(['document-load']) },
+    });
+    void expect(result).not.to.be.false;
+
+    log.message(PROBE_BODY, 'info');
+
+    await clock.tickAsync(999);
+    expect(probeCount()).to.equal(0);
+
+    await clock.tickAsync(2);
+    expect(probeCount()).to.equal(1);
+  });
+
+  it('should export immediately when flushed instead of waiting for the delay', async () => {
+    const result = initSDK({
+      logExporters: [logExporter],
+      defaultInstrumentationConfig: { omit: new Set(['document-load']) },
+    });
+    void expect(result).not.to.be.false;
+
+    log.message(PROBE_BODY, 'info');
+
+    await log.flush();
+
+    expect(probeCount()).to.equal(1);
+  });
+});

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "A50FF184BD131ACD1F54DC019D84A2B6"
+              "stringValue": "1ED344555C230BDC3C848ADCB6FCFBF1"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.7827.55 Safari/537.36"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.7922.34 Safari/537.36"
             }
           },
           {
@@ -81,280 +81,130 @@
       "scopeLogs": [
         {
           "scope": {
+            "name": "FirstInteractionInstrumentation",
+            "version": "1.0.0"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1786472661936600098",
+              "observedTimeUnixNano": "1786472661938000000",
+              "severityNumber": 9,
+              "body": {},
+              "eventName": "first-interaction",
+              "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "emb.otel_log"
+                  }
+                },
+                {
+                  "key": "first_interaction.interaction_type",
+                  "value": {
+                    "stringValue": "click"
+                  }
+                },
+                {
+                  "key": "first_interaction.element_type",
+                  "value": {
+                    "stringValue": "button"
+                  }
+                },
+                {
+                  "key": "first_interaction.element_selector",
+                  "value": {
+                    "stringValue": "#root>section>button"
+                  }
+                },
+                {
+                  "key": "first_interaction.time",
+                  "value": {
+                    "doubleValue": 135.10009765625
+                  }
+                },
+                {
+                  "key": "first_interaction.x",
+                  "value": {
+                    "intValue": 409
+                  }
+                },
+                {
+                  "key": "first_interaction.y",
+                  "value": {
+                    "intValue": 418
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "BC0CA7B3F7DE747242512A6FCC8497B2"
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "F8F73C66002D3261AF9F0A771EE441BB"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "F5C2288ADC85C2C589C427C16CCA98C3"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {
+                    "stringValue": "/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {
+                    "stringValue": "4309EBAD69AAF596F7B879C63B1644FB"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            }
+          ]
+        },
+        {
+          "scope": {
             "name": "WebVitalsInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776845159699951",
-              "observedTimeUnixNano": "1785776845163000000",
+              "timeUnixNano": "1786472661820100098",
+              "observedTimeUnixNano": "1786472661944000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":1.400000000372529,\"dnsDuration\":0,\"connectionDuration\":0.09999999962747097,\"requestDuration\":0.599999999627471}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "ttfb"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "doubleValue": 2.099999999627471
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "doubleValue": 2.099999999627471
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776845156-5011193110148"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "E535D8023BBD2875266064B2C8DA1EF4"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "4E799221F1E9E306FDC7E3936131573A"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.redirect",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.domainLookup",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tcpConnection",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tlsNegotiation",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.serverResponse",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.unattributed",
-                  "value": {
-                    "intValue": 2
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "2916CDC69E6E832A0D2AA380890633D9"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "E4FBF4865E389A1556AC4CFDEED0C26F"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            },
-            {
-              "timeUnixNano": "1785776845178500000",
-              "observedTimeUnixNano": "1785776845180000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"timeToFirstByte\":2.099999999627471,\"firstByteToFCP\":85.90000000037253,\"loadState\":\"complete\"}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "fcp"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 88
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 88
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776845156-3776831330914"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "E535D8023BBD2875266064B2C8DA1EF4"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "4E799221F1E9E306FDC7E3936131573A"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "649F2B4F480101DFB16EF3062F3A5FAE"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "E4FBF4865E389A1556AC4CFDEED0C26F"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            },
-            {
-              "timeUnixNano": "1785776845178500000",
-              "observedTimeUnixNano": "1785776845298000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"timeToFirstByte\":2.099999999627471,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":85.90000000037253,\"target\":\"#root>div\"}"
+                "stringValue": "{\"timeToFirstByte\":3.5,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":84.5,\"target\":\"#root>div\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -391,7 +241,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1785776845156-9557481738102"
+                    "stringValue": "v6-1786472661798-2319856561631"
                   }
                 },
                 {
@@ -403,13 +253,13 @@
                 {
                   "key": "browser.web_vital.navigation_id",
                   "value": {
-                    "intValue": 0
+                    "intValue": 690
                   }
                 },
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E535D8023BBD2875266064B2C8DA1EF4"
+                    "stringValue": "F5C2288ADC85C2C589C427C16CCA98C3"
                   }
                 },
                 {
@@ -427,7 +277,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4E799221F1E9E306FDC7E3936131573A"
+                    "stringValue": "4309EBAD69AAF596F7B879C63B1644FB"
                   }
                 },
                 {
@@ -451,13 +301,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "ABDCC527D028097EA2947095F81530E1"
+                    "stringValue": "690991103F087F17992F59477ECE6C3C"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "E4FBF4865E389A1556AC4CFDEED0C26F"
+                    "stringValue": "F8F73C66002D3261AF9F0A771EE441BB"
                   }
                 },
                 {
@@ -470,120 +320,6 @@
                   "key": "url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            }
-          ]
-        },
-        {
-          "scope": {
-            "name": "FirstInteractionInstrumentation",
-            "version": "1.0.0"
-          },
-          "logRecords": [
-            {
-              "timeUnixNano": "1785776845290399902",
-              "observedTimeUnixNano": "1785776845292000000",
-              "severityNumber": 9,
-              "body": {},
-              "eventName": "first-interaction",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "emb.otel_log"
-                  }
-                },
-                {
-                  "key": "first_interaction.interaction_type",
-                  "value": {
-                    "stringValue": "click"
-                  }
-                },
-                {
-                  "key": "first_interaction.element_type",
-                  "value": {
-                    "stringValue": "button"
-                  }
-                },
-                {
-                  "key": "first_interaction.element_selector",
-                  "value": {
-                    "stringValue": "#root>section>button"
-                  }
-                },
-                {
-                  "key": "first_interaction.time",
-                  "value": {
-                    "doubleValue": 130.70004882849753
-                  }
-                },
-                {
-                  "key": "first_interaction.x",
-                  "value": {
-                    "intValue": 409
-                  }
-                },
-                {
-                  "key": "first_interaction.y",
-                  "value": {
-                    "intValue": 418
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "8FC824E7C2906F80E8508505EFF583AB"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "E4FBF4865E389A1556AC4CFDEED0C26F"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "E535D8023BBD2875266064B2C8DA1EF4"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "4E799221F1E9E306FDC7E3936131573A"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
                   }
                 }
               ],
@@ -597,8 +333,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776845716600098",
-              "observedTimeUnixNano": "1785776845716000000",
+              "timeUnixNano": "1786472662262700195",
+              "observedTimeUnixNano": "1786472662262000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -614,13 +350,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at of.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:99939)\n    at qb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:263951\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:999\n    at new Promise (<anonymous>)\n    at Pt (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:819)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:263923)\n    at dg (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127507)"
+                    "stringValue": "Error\n    at uf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:100346)\n    at Kb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:38034)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:264739\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:999\n    at new Promise (<anonymous>)\n    at Bt (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:819)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:264711)\n    at _g (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127507)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:126\":\"9274659292b972ba96db246840f74172\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:126\":\"5bf4b0c65e35249c3327dc129edaab0b\"}"
                   }
                 },
                 {
@@ -632,13 +368,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "D2973904E3F6A94D0B6AA2D070773CE0"
+                    "stringValue": "FA0F8545A6D1A55300464FBB49DC9B49"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "E4FBF4865E389A1556AC4CFDEED0C26F"
+                    "stringValue": "F8F73C66002D3261AF9F0A771EE441BB"
                   }
                 },
                 {
@@ -650,7 +386,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E535D8023BBD2875266064B2C8DA1EF4"
+                    "stringValue": "F5C2288ADC85C2C589C427C16CCA98C3"
                   }
                 },
                 {
@@ -674,7 +410,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4E799221F1E9E306FDC7E3936131573A"
+                    "stringValue": "4309EBAD69AAF596F7B879C63B1644FB"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "A50FF184BD131ACD1F54DC019D84A2B6"
+              "stringValue": "1ED344555C230BDC3C848ADCB6FCFBF1"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.7827.55 Safari/537.36"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.7922.34 Safari/537.36"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "44520f5222f81ea06a060ca9a932ed58",
-              "spanId": "105a2ac45df66171",
+              "traceId": "728fdc9915c447eb58264228e4453b54",
+              "spanId": "e58774eef6130297",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1785776845153000000",
-              "endTimeUnixNano": "1785776845741000000",
+              "startTimeUnixNano": "1786472661795000000",
+              "endTimeUnixNano": "1786472662287400146",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "E4FBF4865E389A1556AC4CFDEED0C26F"
+                    "stringValue": "F8F73C66002D3261AF9F0A771EE441BB"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "doubleValue": 1785776845153.1
+                    "intValue": 1786472661795
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E535D8023BBD2875266064B2C8DA1EF4"
+                    "stringValue": "F5C2288ADC85C2C589C427C16CCA98C3"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 10
+                    "intValue": 9
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4E799221F1E9E306FDC7E3936131573A"
+                    "stringValue": "4309EBAD69AAF596F7B879C63B1644FB"
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1785776845290399902",
+                  "timeUnixNano": "1786472661936600098",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1785776845715500000",
+                  "timeUnixNano": "1786472662261900146",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "ecf6e76bffe0b2429fd85f36f0b55dd3",
-              "spanId": "c866fed4306a516f",
-              "parentSpanId": "821cfdfd194bde38",
+              "traceId": "d5f71dc3fc29f708f056c6c9cb3c9d08",
+              "spanId": "d06eb4fcf800ba41",
+              "parentSpanId": "0bfce5336dc32058",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1785776845090500000",
-              "endTimeUnixNano": "1785776845092800049",
+              "startTimeUnixNano": "1786472661733200195",
+              "endTimeUnixNano": "1786472661736000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -336,7 +336,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4E799221F1E9E306FDC7E3936131573A"
+                    "stringValue": "4309EBAD69AAF596F7B879C63B1644FB"
                   }
                 },
                 {
@@ -351,55 +351,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1785776845090500000",
+                  "timeUnixNano": "1786472661732999903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1785776845091900000",
+                  "timeUnixNano": "1786472661734499903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1785776845091900000",
+                  "timeUnixNano": "1786472661734499903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1785776845091900000",
+                  "timeUnixNano": "1786472661734499903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1785776845090500000",
+                  "timeUnixNano": "1786472661731899903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1785776845092000000",
+                  "timeUnixNano": "1786472661734799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1785776845092200000",
+                  "timeUnixNano": "1786472661734799903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1785776845092600000",
+                  "timeUnixNano": "1786472661735399903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1785776845092800000",
+                  "timeUnixNano": "1786472661735799903",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -412,13 +412,13 @@
               "flags": 257
             },
             {
-              "traceId": "ecf6e76bffe0b2429fd85f36f0b55dd3",
-              "spanId": "29c53f07dace1d36",
-              "parentSpanId": "821cfdfd194bde38",
+              "traceId": "d5f71dc3fc29f708f056c6c9cb3c9d08",
+              "spanId": "02a102009e1c4c2f",
+              "parentSpanId": "0bfce5336dc32058",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1785776845094800049",
-              "endTimeUnixNano": "1785776845098800049",
+              "startTimeUnixNano": "1786472661738400146",
+              "endTimeUnixNano": "1786472661743300049",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -429,13 +429,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 422163
+                    "intValue": 422951
                   }
                 },
                 {
@@ -459,19 +459,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 422163
+                    "intValue": 422951
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 422463
+                    "intValue": 423251
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 422163
+                    "intValue": 422951
                   }
                 },
                 {
@@ -489,7 +489,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4E799221F1E9E306FDC7E3936131573A"
+                    "stringValue": "4309EBAD69AAF596F7B879C63B1644FB"
                   }
                 },
                 {
@@ -504,49 +504,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1785776845094100049",
+                  "timeUnixNano": "1786472661737400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1785776845094100049",
+                  "timeUnixNano": "1786472661737400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1785776845094100049",
+                  "timeUnixNano": "1786472661737400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1785776845094100049",
+                  "timeUnixNano": "1786472661737400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1785776845094100049",
+                  "timeUnixNano": "1786472661737400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1785776845096300049",
+                  "timeUnixNano": "1786472661739900098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1785776845097000049",
+                  "timeUnixNano": "1786472661740800098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1785776845098100049",
+                  "timeUnixNano": "1786472661742300098",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -559,12 +559,12 @@
               "flags": 257
             },
             {
-              "traceId": "ecf6e76bffe0b2429fd85f36f0b55dd3",
-              "spanId": "821cfdfd194bde38",
+              "traceId": "d5f71dc3fc29f708f056c6c9cb3c9d08",
+              "spanId": "0bfce5336dc32058",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1785776845090500000",
-              "endTimeUnixNano": "1785776845159699951",
+              "startTimeUnixNano": "1786472661733200195",
+              "endTimeUnixNano": "1786472661801500000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -581,7 +581,7 @@
                 {
                   "key": "user_agent.original",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.7827.55 Safari/537.36"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.7922.34 Safari/537.36"
                   }
                 },
                 {
@@ -599,7 +599,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4E799221F1E9E306FDC7E3936131573A"
+                    "stringValue": "4309EBAD69AAF596F7B879C63B1644FB"
                   }
                 },
                 {
@@ -613,38 +613,44 @@
               "events": [
                 {
                   "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1786472661732999903",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1785776845096099951",
+                  "timeUnixNano": "1786472661740199903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1785776845158699951",
+                  "timeUnixNano": "1786472661801099903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1785776845158699951",
+                  "timeUnixNano": "1786472661801099903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1785776845158699951",
+                  "timeUnixNano": "1786472661801099903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1785776845158699951",
+                  "timeUnixNano": "1786472661801099903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1785776845158899951",
+                  "timeUnixNano": "1786472661801299903",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -665,12 +671,140 @@
           },
           "spans": [
             {
-              "traceId": "c060ea92eaaf934020e43b23c08a20eb",
-              "spanId": "1a830d5ab47609f3",
+              "traceId": "16b38f56c62010fd1349f574d78dd78e",
+              "spanId": "733a708d1cf20aa5",
+              "name": "POST",
+              "kind": 3,
+              "startTimeUnixNano": "1786472661907000000",
+              "endTimeUnixNano": "1786472661912000000",
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/v2/logs"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": 200
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": 3001
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "perf.network_request"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {
+                    "stringValue": "/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {
+                    "stringValue": "4309EBAD69AAF596F7B879C63B1644FB"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1786472661907599952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1786472661909599952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1786472661909699952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1786472661909699952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1786472661909799952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1786472661909799952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1786472661910499952",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1786472661910699952",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            },
+            {
+              "traceId": "44a11e0b85828b066b02378e7f030891",
+              "spanId": "54c48024a20e7ad9",
               "name": "GET",
               "kind": 3,
-              "startTimeUnixNano": "1785776845292000000",
-              "endTimeUnixNano": "1785776845298000000",
+              "startTimeUnixNano": "1786472661938000000",
+              "endTimeUnixNano": "1786472661944000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -723,7 +857,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4E799221F1E9E306FDC7E3936131573A"
+                    "stringValue": "4309EBAD69AAF596F7B879C63B1644FB"
                   }
                 },
                 {
@@ -738,49 +872,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1785776845292900098",
+                  "timeUnixNano": "1786472661938700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1785776845292900098",
+                  "timeUnixNano": "1786472661938700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1785776845292900098",
+                  "timeUnixNano": "1786472661938700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1785776845292900098",
+                  "timeUnixNano": "1786472661938700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1785776845292900098",
+                  "timeUnixNano": "1786472661938700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1785776845292900098",
+                  "timeUnixNano": "1786472661938700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1785776845294700098",
+                  "timeUnixNano": "1786472661940500098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1785776845294700098",
+                  "timeUnixNano": "1786472661940500098",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -801,12 +935,12 @@
           },
           "spans": [
             {
-              "traceId": "ca4ed6e896d3421c91fbef001e805641",
-              "spanId": "b547b999892d20b2",
+              "traceId": "40cbb8baff2c9c5f91b3fefac46c3dcd",
+              "spanId": "4f101d593faab94a",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1785776845157600098",
-              "endTimeUnixNano": "1785776845741699951",
+              "startTimeUnixNano": "1786472661799400146",
+              "endTimeUnixNano": "1786472662288200195",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -823,7 +957,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4E799221F1E9E306FDC7E3936131573A"
+                    "stringValue": "4309EBAD69AAF596F7B879C63B1644FB"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "A4935294BD8CA96E3123D8BBBEE248F7"
+              "stringValue": "F64D1DAAF3DF4AE2E7C4705481E0380F"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.7827.55 Safari/537.36"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.7922.34 Safari/537.36"
             }
           },
           {
@@ -81,285 +81,13 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "WebVitalsInstrumentation",
-            "version": "1.0.0"
-          },
-          "logRecords": [
-            {
-              "timeUnixNano": "1785776842130199951",
-              "observedTimeUnixNano": "1785776842134000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"waitingDuration\":0.09999999962747097,\"cacheDuration\":1.2000000001862645,\"dnsDuration\":0,\"connectionDuration\":0.20000000018626451,\"requestDuration\":0.7999999998137355}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "ttfb"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "doubleValue": 2.2999999998137355
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "doubleValue": 2.2999999998137355
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776842127-3223227644164"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "8D090CBE209EC5282B343891623D69D7"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "B681DE37301B6AE362D401C4874C7AB2"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.redirect",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.domainLookup",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tcpConnection",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tlsNegotiation",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.serverResponse",
-                  "value": {
-                    "intValue": 1
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.unattributed",
-                  "value": {
-                    "intValue": 2
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "B0ABC1B8FBD9512AC859D3B38651EBEC"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "5C931D0C5ACC73139171E5A47C832ECE"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            },
-            {
-              "timeUnixNano": "1785776842160800049",
-              "observedTimeUnixNano": "1785776842164000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"timeToFirstByte\":2.2999999998137355,\"firstByteToFCP\":97.70000000018626,\"loadState\":\"complete\"}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "fcp"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 100
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 100
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776842127-9892767362247"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "8D090CBE209EC5282B343891623D69D7"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "B681DE37301B6AE362D401C4874C7AB2"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "88E740DFF754213C637CEC73EAC71363"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "5C931D0C5ACC73139171E5A47C832ECE"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            }
-          ]
-        },
-        {
-          "scope": {
             "name": "FirstInteractionInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776842258000000",
-              "observedTimeUnixNano": "1785776842260000000",
+              "timeUnixNano": "1786472658954400146",
+              "observedTimeUnixNano": "1786472658956000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -391,7 +119,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "doubleValue": 127.80009765550494
+                    "doubleValue": 143.40009765326977
                   }
                 },
                 {
@@ -409,13 +137,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "669C147E710A12CE98E97FA527FAEFE8"
+                    "stringValue": "BA8EED3AD045590204F4F2DBF1818406"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5C931D0C5ACC73139171E5A47C832ECE"
+                    "stringValue": "BBE8F6F30DC0D9E63C33EE2D470C7760"
                   }
                 },
                 {
@@ -427,7 +155,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "8D090CBE209EC5282B343891623D69D7"
+                    "stringValue": "E3C7F9B3C05F013D263979D6D579632D"
                   }
                 },
                 {
@@ -451,7 +179,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "B681DE37301B6AE362D401C4874C7AB2"
+                    "stringValue": "865C846C32631042F17D1DB7464EE0E5"
                   }
                 },
                 {
@@ -471,8 +199,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776842261400146",
-              "observedTimeUnixNano": "1785776842261000000",
+              "timeUnixNano": "1786472658957200195",
+              "observedTimeUnixNano": "1786472658957000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -488,13 +216,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at of.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:99939)\n    at qb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:263951\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:999\n    at new Promise (<anonymous>)\n    at Pt (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:819)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:263923)\n    at dg (http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127507)"
+                    "stringValue": "Error\n    at uf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:100346)\n    at Kb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:38034)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:264739\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:999\n    at new Promise (<anonymous>)\n    at Bt (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:819)\n    at i (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:264711)\n    at _g (http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127507)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:126\":\"9274659292b972ba96db246840f74172\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:126\":\"5bf4b0c65e35249c3327dc129edaab0b\"}"
                   }
                 },
                 {
@@ -506,13 +234,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "2E518F35330D1703F60AFD71F54A9B93"
+                    "stringValue": "237667895E10362DDF465EBF980E953A"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "5C931D0C5ACC73139171E5A47C832ECE"
+                    "stringValue": "BBE8F6F30DC0D9E63C33EE2D470C7760"
                   }
                 },
                 {
@@ -524,7 +252,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "8D090CBE209EC5282B343891623D69D7"
+                    "stringValue": "E3C7F9B3C05F013D263979D6D579632D"
                   }
                 },
                 {
@@ -548,7 +276,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "B681DE37301B6AE362D401C4874C7AB2"
+                    "stringValue": "865C846C32631042F17D1DB7464EE0E5"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "E3872464DDACEFAD1C8962FF072F118B"
+              "stringValue": "C99E0F70BBF1CCCCBF8EF0A975CB241A"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:153.0) Gecko/20100101 Firefox/153.0"
             }
           },
           {
@@ -81,411 +81,13 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "WebVitalsInstrumentation",
-            "version": "1.0.0"
-          },
-          "logRecords": [
-            {
-              "timeUnixNano": "1785776865301000000",
-              "observedTimeUnixNano": "1785776865304000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":3,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "ttfb"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 4
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 4
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776865291-1514577544614"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "D4A671F61A33302A2B29D8AB864A03D3"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "5E3EC5B76358EB24CA9DB18AF03C94A7"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.redirect",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.domainLookup",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tcpConnection",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tlsNegotiation",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.serverResponse",
-                  "value": {
-                    "intValue": 1
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.unattributed",
-                  "value": {
-                    "intValue": 3
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "CDEE63D12D55154E1C6C9224FFF28023"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "EFFEB99C8E2482BA3F58FA770012A60A"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            },
-            {
-              "timeUnixNano": "1785776865301000000",
-              "observedTimeUnixNano": "1785776865306000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"timeToFirstByte\":4,\"firstByteToFCP\":64,\"loadState\":\"complete\"}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "fcp"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 68
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 68
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776865291-7438379666260"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "D4A671F61A33302A2B29D8AB864A03D3"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "5E3EC5B76358EB24CA9DB18AF03C94A7"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "231A3E398D29E63DA8C7B2157389F20D"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "EFFEB99C8E2482BA3F58FA770012A60A"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            },
-            {
-              "timeUnixNano": "1785776865301000000",
-              "observedTimeUnixNano": "1785776865467000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"timeToFirstByte\":4,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":64,\"target\":\"#root>div\"}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "lcp"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 68
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 68
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776865291-5317436476812"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "D4A671F61A33302A2B29D8AB864A03D3"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "5E3EC5B76358EB24CA9DB18AF03C94A7"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.elementType",
-                  "value": {
-                    "stringValue": "div"
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.elementBoundingRect",
-                  "value": {
-                    "stringValue": "{\"x\":8,\"y\":8,\"width\":600,\"height\":400}"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "75A1281F1106DB9BF21DD189DD10639C"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "EFFEB99C8E2482BA3F58FA770012A60A"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            }
-          ]
-        },
-        {
-          "scope": {
             "name": "FirstInteractionInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776865462000000",
-              "observedTimeUnixNano": "1785776865464000000",
+              "timeUnixNano": "1786472686073000000",
+              "observedTimeUnixNano": "1786472686074000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -517,7 +119,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 161
+                    "intValue": 177
                   }
                 },
                 {
@@ -535,13 +137,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "9916D2634C6CB8FE5FD7D3CA3B08A52B"
+                    "stringValue": "0ADECD4F01B27160E724184B23A8A3F3"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EFFEB99C8E2482BA3F58FA770012A60A"
+                    "stringValue": "83EBFB06B4F25280947CED5BCD64AF8E"
                   }
                 },
                 {
@@ -553,7 +155,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D4A671F61A33302A2B29D8AB864A03D3"
+                    "stringValue": "F5432B7B9F12DD1E8D071BEBEB572E99"
                   }
                 },
                 {
@@ -577,7 +179,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5E3EC5B76358EB24CA9DB18AF03C94A7"
+                    "stringValue": "EECFC0268642F990F2E3C3DAB8DB9EB3"
                   }
                 },
                 {
@@ -593,12 +195,146 @@
         },
         {
           "scope": {
+            "name": "WebVitalsInstrumentation",
+            "version": "1.0.0"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1786472685900000000",
+              "observedTimeUnixNano": "1786472686095000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":5,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":87,\"target\":\"#root>div\"}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "lcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 92
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 92
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v6-1786472685887-4117857994899"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_id",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "F5432B7B9F12DD1E8D071BEBEB572E99"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {
+                    "stringValue": "/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {
+                    "stringValue": "EECFC0268642F990F2E3C3DAB8DB9EB3"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.elementType",
+                  "value": {
+                    "stringValue": "div"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.elementBoundingRect",
+                  "value": {
+                    "stringValue": "{\"x\":8,\"y\":8,\"width\":600,\"height\":400}"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "04894CC6A8472CAECF9BEE5B9D787B75"
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "83EBFB06B4F25280947CED5BCD64AF8E"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            }
+          ]
+        },
+        {
+          "scope": {
             "name": "embrace-web-sdk-logs"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776865900000000",
-              "observedTimeUnixNano": "1785776865901000000",
+              "timeUnixNano": "1786472686410000000",
+              "observedTimeUnixNano": "1786472686409000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -614,13 +350,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:99939\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:38001\nWM</is/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:37542\nWM</$M/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:263951\nPt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:999\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:819\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:263925\ndg@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127508\nWM</Hb/rc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:132562\nSd@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:15162\nrc@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:128743\nEc@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:28581\nvb@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:28401\nEventListener.handleEvent*hg@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:128304\nic@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127704\nWM</Hb/ac/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127870\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127815\nWM</Hb/zr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:36448\nWM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:264574\nDb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:264628\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:100346\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:38034\neN</rs/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:37542\neN</WM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:264739\nBt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:999\nBt@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:819\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:264713\n_g@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127508\neN</Yb/sc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:132562\nvd@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:28401\nEventListener.handleEvent*gg@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:128304\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127704\neN</Yb/rc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127870\nrc@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127815\neN</Yb/Br.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:36448\neN<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:265362\nwb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:265416\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:126\\n\":\"9274659292b972ba96db246840f74172\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:126\\n\":\"5bf4b0c65e35249c3327dc129edaab0b\"}"
                   }
                 },
                 {
@@ -632,13 +368,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "EC4F7F93F806B917707059F1CAC25E9C"
+                    "stringValue": "F4B0990100A446D7D6AE002954948F00"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EFFEB99C8E2482BA3F58FA770012A60A"
+                    "stringValue": "83EBFB06B4F25280947CED5BCD64AF8E"
                   }
                 },
                 {
@@ -650,7 +386,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D4A671F61A33302A2B29D8AB864A03D3"
+                    "stringValue": "F5432B7B9F12DD1E8D071BEBEB572E99"
                   }
                 },
                 {
@@ -674,7 +410,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5E3EC5B76358EB24CA9DB18AF03C94A7"
+                    "stringValue": "EECFC0268642F990F2E3C3DAB8DB9EB3"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "E3872464DDACEFAD1C8962FF072F118B"
+              "stringValue": "C99E0F70BBF1CCCCBF8EF0A975CB241A"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:153.0) Gecko/20100101 Firefox/153.0"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "0e2329c0ea1ce08a329ee095a308637e",
-              "spanId": "bde1ef5e9d23e758",
+              "traceId": "1c4167a4ef05b0c81740a76e48862499",
+              "spanId": "391e37c4fdcb754a",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1785776865290000000",
-              "endTimeUnixNano": "1785776865933000000",
+              "startTimeUnixNano": "1786472685886000000",
+              "endTimeUnixNano": "1786472686442000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "EFFEB99C8E2482BA3F58FA770012A60A"
+                    "stringValue": "83EBFB06B4F25280947CED5BCD64AF8E"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1785776865289
+                    "intValue": 1786472685885
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D4A671F61A33302A2B29D8AB864A03D3"
+                    "stringValue": "F5432B7B9F12DD1E8D071BEBEB572E99"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 8
+                    "intValue": 9
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5E3EC5B76358EB24CA9DB18AF03C94A7"
+                    "stringValue": "EECFC0268642F990F2E3C3DAB8DB9EB3"
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1785776865462000000",
+                  "timeUnixNano": "1786472686073000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1785776865899000000",
+                  "timeUnixNano": "1786472686409000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "98d350d51073c65a2c25f57d277732df",
-              "spanId": "a70631166e05e12b",
-              "parentSpanId": "bd501fb96ae635b1",
+              "traceId": "423bff8e6d6ba1bf0854be1b075dc5ad",
+              "spanId": "059b9a7ef64b6baf",
+              "parentSpanId": "396bacbfb285299b",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1785776865233000000",
-              "endTimeUnixNano": "1785776865237000000",
+              "startTimeUnixNano": "1786472685808000000",
+              "endTimeUnixNano": "1786472685813000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -336,7 +336,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5E3EC5B76358EB24CA9DB18AF03C94A7"
+                    "stringValue": "EECFC0268642F990F2E3C3DAB8DB9EB3"
                   }
                 },
                 {
@@ -351,55 +351,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1785776865233000000",
+                  "timeUnixNano": "1786472685808000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1785776865236000000",
+                  "timeUnixNano": "1786472685812000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1785776865236000000",
+                  "timeUnixNano": "1786472685812000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1785776865236000000",
+                  "timeUnixNano": "1786472685812000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1785776865233000000",
+                  "timeUnixNano": "1786472685808000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1785776865236000000",
+                  "timeUnixNano": "1786472685813000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1785776865236000000",
+                  "timeUnixNano": "1786472685813000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1785776865237000000",
+                  "timeUnixNano": "1786472685813000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1785776865237000000",
+                  "timeUnixNano": "1786472685813000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -412,13 +412,13 @@
               "flags": 257
             },
             {
-              "traceId": "98d350d51073c65a2c25f57d277732df",
-              "spanId": "ad43fb08089e93f9",
-              "parentSpanId": "bd501fb96ae635b1",
+              "traceId": "423bff8e6d6ba1bf0854be1b075dc5ad",
+              "spanId": "334e1aa5d8b0b0f1",
+              "parentSpanId": "396bacbfb285299b",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1785776865241000000",
-              "endTimeUnixNano": "1785776865251000000",
+              "startTimeUnixNano": "1786472685819000000",
+              "endTimeUnixNano": "1786472685840000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -429,13 +429,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 422163
+                    "intValue": 422951
                   }
                 },
                 {
@@ -453,19 +453,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 422163
+                    "intValue": 422951
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 422463
+                    "intValue": 423251
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 422163
+                    "intValue": 422951
                   }
                 },
                 {
@@ -483,7 +483,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5E3EC5B76358EB24CA9DB18AF03C94A7"
+                    "stringValue": "EECFC0268642F990F2E3C3DAB8DB9EB3"
                   }
                 },
                 {
@@ -498,49 +498,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1785776865241000000",
+                  "timeUnixNano": "1786472685819000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1785776865241000000",
+                  "timeUnixNano": "1786472685819000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1785776865241000000",
+                  "timeUnixNano": "1786472685819000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1785776865241000000",
+                  "timeUnixNano": "1786472685819000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1785776865241000000",
+                  "timeUnixNano": "1786472685819000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1785776865250000000",
+                  "timeUnixNano": "1786472685839000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1785776865250000000",
+                  "timeUnixNano": "1786472685839000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1785776865251000000",
+                  "timeUnixNano": "1786472685840000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -553,12 +553,12 @@
               "flags": 257
             },
             {
-              "traceId": "98d350d51073c65a2c25f57d277732df",
-              "spanId": "bd501fb96ae635b1",
+              "traceId": "423bff8e6d6ba1bf0854be1b075dc5ad",
+              "spanId": "396bacbfb285299b",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1785776865233000000",
-              "endTimeUnixNano": "1785776865301000000",
+              "startTimeUnixNano": "1786472685808000000",
+              "endTimeUnixNano": "1786472685896000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -575,7 +575,7 @@
                 {
                   "key": "user_agent.original",
                   "value": {
-                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+                    "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:153.0) Gecko/20100101 Firefox/153.0"
                   }
                 },
                 {
@@ -593,7 +593,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5E3EC5B76358EB24CA9DB18AF03C94A7"
+                    "stringValue": "EECFC0268642F990F2E3C3DAB8DB9EB3"
                   }
                 },
                 {
@@ -608,43 +608,37 @@
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1785776865245000000",
+                  "timeUnixNano": "1786472685820000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1785776865297000000",
+                  "timeUnixNano": "1786472685890000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1785776865297000000",
+                  "timeUnixNano": "1786472685890000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1785776865303000000",
+                  "timeUnixNano": "1786472685895000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1785776865303000000",
+                  "timeUnixNano": "1786472685895000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1785776865303000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "firstContentfulPaint",
-                  "timeUnixNano": "1785776865301000000",
+                  "timeUnixNano": "1786472685895000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -665,12 +659,140 @@
           },
           "spans": [
             {
-              "traceId": "743d10722b98ff98325f1014a6fe0401",
-              "spanId": "02ea64c2c6016224",
+              "traceId": "78c75167f403ccd87c669d6eedfd71bb",
+              "spanId": "5eefea66007a0203",
+              "name": "POST",
+              "kind": 3,
+              "startTimeUnixNano": "1786472686004000000",
+              "endTimeUnixNano": "1786472686009000000",
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/v2/logs"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": 200
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": 3001
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "perf.network_request"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {
+                    "stringValue": "/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {
+                    "stringValue": "EECFC0268642F990F2E3C3DAB8DB9EB3"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1786472686005000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1786472686005000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1786472686005000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1786472686005000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1786472686005000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1786472686005000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1786472686005000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1786472686005000000",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            },
+            {
+              "traceId": "50b29aeab526c91e0f62a2aaae96d46e",
+              "spanId": "928e84c034ef0f10",
               "name": "GET",
               "kind": 3,
-              "startTimeUnixNano": "1785776865464000000",
-              "endTimeUnixNano": "1785776865468000000",
+              "startTimeUnixNano": "1786472686075000000",
+              "endTimeUnixNano": "1786472686093000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -723,7 +845,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5E3EC5B76358EB24CA9DB18AF03C94A7"
+                    "stringValue": "EECFC0268642F990F2E3C3DAB8DB9EB3"
                   }
                 },
                 {
@@ -738,49 +860,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1785776865465000000",
+                  "timeUnixNano": "1786472686076000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1785776865465000000",
+                  "timeUnixNano": "1786472686076000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1785776865465000000",
+                  "timeUnixNano": "1786472686076000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1785776865465000000",
+                  "timeUnixNano": "1786472686076000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1785776865465000000",
+                  "timeUnixNano": "1786472686076000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1785776865465000000",
+                  "timeUnixNano": "1786472686076000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1785776865465000000",
+                  "timeUnixNano": "1786472686076000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1785776865465000000",
+                  "timeUnixNano": "1786472686076000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -801,12 +923,12 @@
           },
           "spans": [
             {
-              "traceId": "47e7ab9799eff572d5c9c216db42ee4e",
-              "spanId": "7037fa047b181a15",
+              "traceId": "039f0c9fee9a8dd1d685b495f5eda497",
+              "spanId": "1a9d3fcc7031387d",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1785776865292000000",
-              "endTimeUnixNano": "1785776865934000000",
+              "startTimeUnixNano": "1786472685888000000",
+              "endTimeUnixNano": "1786472686444000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -823,7 +945,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5E3EC5B76358EB24CA9DB18AF03C94A7"
+                    "stringValue": "EECFC0268642F990F2E3C3DAB8DB9EB3"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
@@ -54,13 +54,13 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "D9D8DBBAEA335BC695F5901E4CF6614E"
+              "stringValue": "8D7BB6497D5C4AFE491E9D9BC3096511"
             }
           },
           {
             "key": "user_agent.original",
             "value": {
-              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:151.0) Gecko/20100101 Firefox/151.0"
+              "stringValue": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:153.0) Gecko/20100101 Firefox/153.0"
             }
           },
           {
@@ -81,285 +81,13 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "WebVitalsInstrumentation",
-            "version": "1.0.0"
-          },
-          "logRecords": [
-            {
-              "timeUnixNano": "1785776860228000000",
-              "observedTimeUnixNano": "1785776860231000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"timeToFirstByte\":5,\"firstByteToFCP\":80,\"loadState\":\"dom-interactive\"}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "fcp"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 85
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 85
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776860218-9591464949333"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "2B441938B72EAB04FF1002DD6B91A8F4"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "D3E8CAD9105375F76B2A81FC3132F240"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "6B104DD893BBD9B379A55D103F5F8497"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "6B15AB9928237BCF56E9BCEFAED7E596"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            },
-            {
-              "timeUnixNano": "1785776860230000000",
-              "observedTimeUnixNano": "1785776860232000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":4,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "ttfb"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 5
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 5
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776860218-1922213661788"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "2B441938B72EAB04FF1002DD6B91A8F4"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "D3E8CAD9105375F76B2A81FC3132F240"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.redirect",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.domainLookup",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tcpConnection",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tlsNegotiation",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.serverResponse",
-                  "value": {
-                    "intValue": 1
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.unattributed",
-                  "value": {
-                    "intValue": 4
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "75043D3DEE3D174C33CDDB8E32F9C280"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "6B15AB9928237BCF56E9BCEFAED7E596"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            }
-          ]
-        },
-        {
-          "scope": {
             "name": "FirstInteractionInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776860391000000",
-              "observedTimeUnixNano": "1785776860392000000",
+              "timeUnixNano": "1786472681183000000",
+              "observedTimeUnixNano": "1786472681183000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -391,7 +119,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 161
+                    "intValue": 168
                   }
                 },
                 {
@@ -409,13 +137,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "839C9DFF981F2B3327E0FF0E413B831F"
+                    "stringValue": "3C338F1910F838DD88BCDF228932DD07"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "6B15AB9928237BCF56E9BCEFAED7E596"
+                    "stringValue": "BA5CD7A5FDB6A6C3C57B481E378FACD9"
                   }
                 },
                 {
@@ -427,7 +155,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "2B441938B72EAB04FF1002DD6B91A8F4"
+                    "stringValue": "BC2D40BA321B234104C3471E6B7C6FD1"
                   }
                 },
                 {
@@ -451,7 +179,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "D3E8CAD9105375F76B2A81FC3132F240"
+                    "stringValue": "F75BD171560A11C01AB9FD23856788D7"
                   }
                 },
                 {
@@ -471,8 +199,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776860393000000",
-              "observedTimeUnixNano": "1785776860393000000",
+              "timeUnixNano": "1786472681184000000",
+              "observedTimeUnixNano": "1786472681184000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -488,13 +216,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:99939\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:38001\nWM</is/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:37542\nWM</$M/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:263951\nPt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:999\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:819\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:263925\ndg@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127508\nWM</Hb/rc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:132562\nSd@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:15162\nrc@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:128743\nEc@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:28581\nvb@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:28401\nEventListener.handleEvent*hg@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:128304\nic@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127704\nWM</Hb/ac/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127870\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127815\nWM</Hb/zr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:36448\nWM<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:264574\nDb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:264628\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:100346\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:38034\neN</rs/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:37542\neN</WM/i/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:264739\nBt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:999\nBt@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:819\ni@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:264713\n_g@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127508\neN</Yb/sc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:132562\nvd@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:28401\nEventListener.handleEvent*gg@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:128304\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127704\neN</Yb/rc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127870\nrc@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127815\neN</Yb/Br.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:36448\neN<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:265362\nwb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:265416\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:126\\n\":\"9274659292b972ba96db246840f74172\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:126\\n\":\"5bf4b0c65e35249c3327dc129edaab0b\"}"
                   }
                 },
                 {
@@ -506,13 +234,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "C5AFB95C15737A4EEDB79C0A94E46B50"
+                    "stringValue": "7E503BA84D7C1C19BFF22B3EFDD55D47"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "6B15AB9928237BCF56E9BCEFAED7E596"
+                    "stringValue": "BA5CD7A5FDB6A6C3C57B481E378FACD9"
                   }
                 },
                 {
@@ -524,7 +252,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "2B441938B72EAB04FF1002DD6B91A8F4"
+                    "stringValue": "BC2D40BA321B234104C3471E6B7C6FD1"
                   }
                 },
                 {
@@ -548,7 +276,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "D3E8CAD9105375F76B2A81FC3132F240"
+                    "stringValue": "F75BD171560A11C01AB9FD23856788D7"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "2A112E41EF0EECC9A7449C2DB3D596F8"
+              "stringValue": "4A6474977014C30E0489662C8203E20C"
             }
           },
           {
@@ -81,411 +81,13 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "WebVitalsInstrumentation",
-            "version": "1.0.0"
-          },
-          "logRecords": [
-            {
-              "timeUnixNano": "1785776877982000000",
-              "observedTimeUnixNano": "1785776877984000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":0}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "ttfb"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 1
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 1
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776877979-7109453890475"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "D1D31C46119CCD2C135B80188CEDFF7E"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "27CD159065306A50FB509CF4B74B0AF4"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.redirect",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.domainLookup",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tcpConnection",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tlsNegotiation",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.serverResponse",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.unattributed",
-                  "value": {
-                    "intValue": 2
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "476D133B888F6784213F09516AA888CB"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "B37A03C1AC4598A2FD17402EB0F32E2F"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            },
-            {
-              "timeUnixNano": "1785776878013000000",
-              "observedTimeUnixNano": "1785776878015000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"timeToFirstByte\":1,\"firstByteToFCP\":67,\"loadState\":\"complete\"}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "fcp"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 68
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 68
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776877979-8709089672588"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "D1D31C46119CCD2C135B80188CEDFF7E"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "27CD159065306A50FB509CF4B74B0AF4"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "C469207DB4D630F9A84E836A7B14FFE3"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "B37A03C1AC4598A2FD17402EB0F32E2F"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            },
-            {
-              "timeUnixNano": "1785776878013000000",
-              "observedTimeUnixNano": "1785776878124000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"timeToFirstByte\":1,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":67,\"target\":\"#root>div\"}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "lcp"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 68
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 68
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776877979-7571465194990"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "D1D31C46119CCD2C135B80188CEDFF7E"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "27CD159065306A50FB509CF4B74B0AF4"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.elementType",
-                  "value": {
-                    "stringValue": "div"
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.elementBoundingRect",
-                  "value": {
-                    "stringValue": "{\"x\":8,\"y\":8,\"width\":600,\"height\":400}"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "6110C2619057DB248F0C2D1256223FDA"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "B37A03C1AC4598A2FD17402EB0F32E2F"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            }
-          ]
-        },
-        {
-          "scope": {
             "name": "FirstInteractionInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776878115000000",
-              "observedTimeUnixNano": "1785776878122000000",
+              "timeUnixNano": "1786472703054000000",
+              "observedTimeUnixNano": "1786472703057000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -517,7 +119,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 133
+                    "intValue": 172
                   }
                 },
                 {
@@ -535,13 +137,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "1A9189CF3087BBCF87FD294BF71D064E"
+                    "stringValue": "CAA47C404E34DA101DA34F687148FBA7"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B37A03C1AC4598A2FD17402EB0F32E2F"
+                    "stringValue": "B75890F3698F7BBA673A960453DEE01B"
                   }
                 },
                 {
@@ -553,7 +155,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D1D31C46119CCD2C135B80188CEDFF7E"
+                    "stringValue": "436485A4641B104B55E92E4FD0CA946D"
                   }
                 },
                 {
@@ -577,7 +179,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "27CD159065306A50FB509CF4B74B0AF4"
+                    "stringValue": "975D04B5104743FCB19ABD4A83F69599"
                   }
                 },
                 {
@@ -593,12 +195,146 @@
         },
         {
           "scope": {
+            "name": "WebVitalsInstrumentation",
+            "version": "1.0.0"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "1786472702891000000",
+              "observedTimeUnixNano": "1786472703058000000",
+              "severityNumber": 9,
+              "body": {
+                "stringValue": "{\"timeToFirstByte\":2,\"resourceLoadDelay\":0,\"resourceLoadDuration\":0,\"elementRenderDelay\":46,\"target\":\"#root>div\"}"
+              },
+              "eventName": "browser.web_vital",
+              "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.web_vital"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.name",
+                  "value": {
+                    "stringValue": "lcp"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.value",
+                  "value": {
+                    "intValue": 48
+                  }
+                },
+                {
+                  "key": "browser.web_vital.delta",
+                  "value": {
+                    "intValue": 48
+                  }
+                },
+                {
+                  "key": "browser.web_vital.rating",
+                  "value": {
+                    "stringValue": "good"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.id",
+                  "value": {
+                    "stringValue": "v6-1786472702878-6642817473869"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
+                  "key": "browser.web_vital.navigation_id",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.session_part_id",
+                  "value": {
+                    "stringValue": "436485A4641B104B55E92E4FD0CA946D"
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {
+                    "stringValue": "/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {
+                    "stringValue": "975D04B5104743FCB19ABD4A83F69599"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.elementType",
+                  "value": {
+                    "stringValue": "div"
+                  }
+                },
+                {
+                  "key": "emb.web_vital.attribution.elementBoundingRect",
+                  "value": {
+                    "stringValue": "{\"x\":8,\"y\":8,\"width\":600,\"height\":400}"
+                  }
+                },
+                {
+                  "key": "log.record.uid",
+                  "value": {
+                    "stringValue": "0EB6278780EE8ACD62274AAF5FD27726"
+                  }
+                },
+                {
+                  "key": "emb.user_session_id",
+                  "value": {
+                    "stringValue": "B75890F3698F7BBA673A960453DEE01B"
+                  }
+                },
+                {
+                  "key": "emb.user_session_previous_id",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0
+            }
+          ]
+        },
+        {
+          "scope": {
             "name": "embrace-web-sdk-logs"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776878568000000",
-              "observedTimeUnixNano": "1785776878568000000",
+              "timeUnixNano": "1786472703396000000",
+              "observedTimeUnixNano": "1786472703397000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -614,13 +350,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:99948\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:263958\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:1003\nPromise@[native code]\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:830\ndg@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127508\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:132562\nSd@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:15162\nrc@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:128743\nEc@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:28581\nvb@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:28403"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:100355\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:38041\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:264746\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:1003\nPromise@[native code]\nBt@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:830\n_g@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127508\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:132562\nvd@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:28403"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:126\":\"9274659292b972ba96db246840f74172\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:126\":\"5bf4b0c65e35249c3327dc129edaab0b\"}"
                   }
                 },
                 {
@@ -632,13 +368,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "4D9EB2BAF3F11063F128BBA7A0EC5E57"
+                    "stringValue": "9151B4D40C6666CE285654B0E91B6C7A"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B37A03C1AC4598A2FD17402EB0F32E2F"
+                    "stringValue": "B75890F3698F7BBA673A960453DEE01B"
                   }
                 },
                 {
@@ -650,7 +386,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D1D31C46119CCD2C135B80188CEDFF7E"
+                    "stringValue": "436485A4641B104B55E92E4FD0CA946D"
                   }
                 },
                 {
@@ -674,7 +410,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "27CD159065306A50FB509CF4B74B0AF4"
+                    "stringValue": "975D04B5104743FCB19ABD4A83F69599"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "2A112E41EF0EECC9A7449C2DB3D596F8"
+              "stringValue": "4A6474977014C30E0489662C8203E20C"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "3470232c510bb8e998d5041acef0c836",
-              "spanId": "eda0182be2fb2400",
+              "traceId": "bd9123c496ba7872dfdab5e82f9e6495",
+              "spanId": "60014d7a2fd061ae",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1785776877976000000",
-              "endTimeUnixNano": "1785776878635000000",
+              "startTimeUnixNano": "1786472702876000000",
+              "endTimeUnixNano": "1786472703464000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B37A03C1AC4598A2FD17402EB0F32E2F"
+                    "stringValue": "B75890F3698F7BBA673A960453DEE01B"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1785776877975
+                    "intValue": 1786472702874
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "D1D31C46119CCD2C135B80188CEDFF7E"
+                    "stringValue": "436485A4641B104B55E92E4FD0CA946D"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 11
+                    "intValue": 10
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "27CD159065306A50FB509CF4B74B0AF4"
+                    "stringValue": "975D04B5104743FCB19ABD4A83F69599"
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1785776878115000000",
+                  "timeUnixNano": "1786472703054000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1785776878566000000",
+                  "timeUnixNano": "1786472703395000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "07df7db055abf98d3884ec70430131bf",
-              "spanId": "f184fde738eaf193",
-              "parentSpanId": "6bc3b1974023556b",
+              "traceId": "4d746752acc779479bba7affd23f1165",
+              "spanId": "53dece8e3a2118d1",
+              "parentSpanId": "a2beca4dbf75387d",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1785776877946000000",
-              "endTimeUnixNano": "1785776877947000000",
+              "startTimeUnixNano": "1786472702844000000",
+              "endTimeUnixNano": "1786472702845000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -342,7 +342,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "27CD159065306A50FB509CF4B74B0AF4"
+                    "stringValue": "975D04B5104743FCB19ABD4A83F69599"
                   }
                 },
                 {
@@ -357,55 +357,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1785776877946000000",
+                  "timeUnixNano": "1786472702844000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1785776877946000000",
+                  "timeUnixNano": "1786472702844000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1785776877946000000",
+                  "timeUnixNano": "1786472702844000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1785776877946000000",
+                  "timeUnixNano": "1786472702844000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1785776877945000000",
+                  "timeUnixNano": "1786472702843000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1785776877946000000",
+                  "timeUnixNano": "1786472702844000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1785776877946000000",
+                  "timeUnixNano": "1786472702844000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1785776877946000000",
+                  "timeUnixNano": "1786472702845000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1785776877947000000",
+                  "timeUnixNano": "1786472702845000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -418,13 +418,13 @@
               "flags": 257
             },
             {
-              "traceId": "07df7db055abf98d3884ec70430131bf",
-              "spanId": "e28a5958543cfda4",
-              "parentSpanId": "6bc3b1974023556b",
+              "traceId": "4d746752acc779479bba7affd23f1165",
+              "spanId": "db71c8a27bdda909",
+              "parentSpanId": "a2beca4dbf75387d",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1785776877951000000",
-              "endTimeUnixNano": "1785776877952000000",
+              "startTimeUnixNano": "1786472702849000000",
+              "endTimeUnixNano": "1786472702851000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -435,19 +435,19 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 422175
+                    "intValue": 422963
                   }
                 },
                 {
                   "key": "http.response_content_length_uncompressed",
                   "value": {
-                    "intValue": 422163
+                    "intValue": 422951
                   }
                 },
                 {
@@ -459,19 +459,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 422175
+                    "intValue": 422963
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 422475
+                    "intValue": 423263
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 422163
+                    "intValue": 422951
                   }
                 },
                 {
@@ -489,7 +489,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "27CD159065306A50FB509CF4B74B0AF4"
+                    "stringValue": "975D04B5104743FCB19ABD4A83F69599"
                   }
                 },
                 {
@@ -504,49 +504,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1785776877951000000",
+                  "timeUnixNano": "1786472702850000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1785776877951000000",
+                  "timeUnixNano": "1786472702850000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1785776877951000000",
+                  "timeUnixNano": "1786472702850000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1785776877951000000",
+                  "timeUnixNano": "1786472702850000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1785776877951000000",
+                  "timeUnixNano": "1786472702850000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1785776877951000000",
+                  "timeUnixNano": "1786472702851000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1785776877952000000",
+                  "timeUnixNano": "1786472702851000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1785776877952000000",
+                  "timeUnixNano": "1786472702852000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -559,12 +559,12 @@
               "flags": 257
             },
             {
-              "traceId": "07df7db055abf98d3884ec70430131bf",
-              "spanId": "6bc3b1974023556b",
+              "traceId": "4d746752acc779479bba7affd23f1165",
+              "spanId": "a2beca4dbf75387d",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1785776877946000000",
-              "endTimeUnixNano": "1785776877982000000",
+              "startTimeUnixNano": "1786472702844000000",
+              "endTimeUnixNano": "1786472702882000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -599,7 +599,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "27CD159065306A50FB509CF4B74B0AF4"
+                    "stringValue": "975D04B5104743FCB19ABD4A83F69599"
                   }
                 },
                 {
@@ -614,43 +614,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1785776877946000000",
+                  "timeUnixNano": "1786472702844000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1785776877950000000",
+                  "timeUnixNano": "1786472702848000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1785776877982000000",
+                  "timeUnixNano": "1786472702881000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1785776877982000000",
+                  "timeUnixNano": "1786472702881000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1785776877982000000",
+                  "timeUnixNano": "1786472702881000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1785776877982000000",
+                  "timeUnixNano": "1786472702881000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1785776877982000000",
+                  "timeUnixNano": "1786472702882000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -671,12 +671,140 @@
           },
           "spans": [
             {
-              "traceId": "e327c087e00d0ef8c95b4489984fde12",
-              "spanId": "7b78b4ea0026e530",
+              "traceId": "41fec49cc61ee6593d2684eba8888515",
+              "spanId": "b6aacd87c3a37cb5",
+              "name": "POST",
+              "kind": 3,
+              "startTimeUnixNano": "1786472702993000000",
+              "endTimeUnixNano": "1786472703000000000",
+              "attributes": [
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/v2/logs"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": 200
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": 3001
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "perf.network_request"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {
+                    "stringValue": "/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {
+                    "stringValue": "975D04B5104743FCB19ABD4A83F69599"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1786472702996000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1786472702997000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1786472702997000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1786472702997000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1786472702997000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1786472702997000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1786472702998000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1786472702998000000",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            },
+            {
+              "traceId": "c181b0e39516168af9b7ae5ad5ed4c39",
+              "spanId": "6bdc1c83508de23f",
               "name": "GET",
               "kind": 3,
-              "startTimeUnixNano": "1785776878123000000",
-              "endTimeUnixNano": "1785776878125000000",
+              "startTimeUnixNano": "1786472703058000000",
+              "endTimeUnixNano": "1786472703059000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -729,7 +857,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "27CD159065306A50FB509CF4B74B0AF4"
+                    "stringValue": "975D04B5104743FCB19ABD4A83F69599"
                   }
                 },
                 {
@@ -744,43 +872,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1785776878123000000",
+                  "timeUnixNano": "1786472703058000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1785776878123000000",
+                  "timeUnixNano": "1786472703058000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1785776878123000000",
+                  "timeUnixNano": "1786472703058000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1785776878123000000",
+                  "timeUnixNano": "1786472703058000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1785776878123000000",
+                  "timeUnixNano": "1786472703058000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1785776878123000000",
+                  "timeUnixNano": "1786472703058000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1785776878125000000",
+                  "timeUnixNano": "1786472703060000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -801,12 +929,12 @@
           },
           "spans": [
             {
-              "traceId": "41563d9dbf88345d6ba5a165f81c6929",
-              "spanId": "1b2f5459ff956e9f",
+              "traceId": "9bae2b4fab09e63f0aef6b1576024f49",
+              "spanId": "a9e1fbf3b9a1b8de",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1785776877980000000",
-              "endTimeUnixNano": "1785776878636000000",
+              "startTimeUnixNano": "1786472702879000000",
+              "endTimeUnixNano": "1786472703465000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -823,7 +951,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "27CD159065306A50FB509CF4B74B0AF4"
+                    "stringValue": "975D04B5104743FCB19ABD4A83F69599"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "1539133486E61E0419CCE7E09FD89F37"
+              "stringValue": "81883314EDF130B571F6FACF72D24A27"
             }
           },
           {
@@ -81,285 +81,13 @@
       "scopeLogs": [
         {
           "scope": {
-            "name": "WebVitalsInstrumentation",
-            "version": "1.0.0"
-          },
-          "logRecords": [
-            {
-              "timeUnixNano": "1785776874833000000",
-              "observedTimeUnixNano": "1785776874839000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "ttfb"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 2
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 2
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776874829-7224443254960"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "52B3A2EA40283C8C705A20B890F8FC44"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "04906A6659B9EE3DB820678DAC236C52"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.redirect",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.domainLookup",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tcpConnection",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.tlsNegotiation",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.serverResponse",
-                  "value": {
-                    "intValue": 1
-                  }
-                },
-                {
-                  "key": "emb.web_vital.attribution.unattributed",
-                  "value": {
-                    "intValue": 1
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "E4C03F3C73B23EDCE50D713B7EA9C050"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "6CE248D50AE22A2C92C4FCD92A55C8CE"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            },
-            {
-              "timeUnixNano": "1785776874855000000",
-              "observedTimeUnixNano": "1785776874857000000",
-              "severityNumber": 9,
-              "body": {
-                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":61,\"loadState\":\"complete\"}"
-              },
-              "eventName": "browser.web_vital",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.web_vital"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.name",
-                  "value": {
-                    "stringValue": "fcp"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.value",
-                  "value": {
-                    "intValue": 63
-                  }
-                },
-                {
-                  "key": "browser.web_vital.delta",
-                  "value": {
-                    "intValue": 63
-                  }
-                },
-                {
-                  "key": "browser.web_vital.rating",
-                  "value": {
-                    "stringValue": "good"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.id",
-                  "value": {
-                    "stringValue": "v6-1785776874829-6005377744662"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_type",
-                  "value": {
-                    "stringValue": "navigate"
-                  }
-                },
-                {
-                  "key": "browser.web_vital.navigation_id",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "emb.session_part_id",
-                  "value": {
-                    "stringValue": "52B3A2EA40283C8C705A20B890F8FC44"
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "04906A6659B9EE3DB820678DAC236C52"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                },
-                {
-                  "key": "log.record.uid",
-                  "value": {
-                    "stringValue": "66FFFFE58539421A535146010AC05D7F"
-                  }
-                },
-                {
-                  "key": "emb.user_session_id",
-                  "value": {
-                    "stringValue": "6CE248D50AE22A2C92C4FCD92A55C8CE"
-                  }
-                },
-                {
-                  "key": "emb.user_session_previous_id",
-                  "value": {
-                    "stringValue": ""
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0
-            }
-          ]
-        },
-        {
-          "scope": {
             "name": "FirstInteractionInstrumentation",
             "version": "1.0.0"
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776874992000000",
-              "observedTimeUnixNano": "1785776874999000000",
+              "timeUnixNano": "1786472700075000000",
+              "observedTimeUnixNano": "1786472700078000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -391,7 +119,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 159
+                    "intValue": 168
                   }
                 },
                 {
@@ -409,13 +137,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "FB43C9927640FC63A81058BD1AAA96E2"
+                    "stringValue": "CA747D57311275B43A11449FAF2D5C35"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "6CE248D50AE22A2C92C4FCD92A55C8CE"
+                    "stringValue": "185E7E2D427E9CFAC02F02E8A2371877"
                   }
                 },
                 {
@@ -427,7 +155,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "52B3A2EA40283C8C705A20B890F8FC44"
+                    "stringValue": "A1610CF0F4DDDD321CC52B9033FEE944"
                   }
                 },
                 {
@@ -451,7 +179,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "04906A6659B9EE3DB820678DAC236C52"
+                    "stringValue": "2901F4BB021DCD2C9535824CC116C6E6"
                   }
                 },
                 {
@@ -471,8 +199,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1785776874999000000",
-              "observedTimeUnixNano": "1785776874999000000",
+              "timeUnixNano": "1786472700078000000",
+              "observedTimeUnixNano": "1786472700079000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
@@ -488,13 +216,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:99948\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:263958\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:1003\nPromise@[native code]\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:1:830\ndg@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:127508\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:132562\nSd@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:15162\nrc@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:8:128743\nEc@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:28581\nvb@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:9:28403"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:100355\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:38041\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:264746\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:1003\nPromise@[native code]\nBt@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:1:830\n_g@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:127508\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:132562\nvd@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:9:28403"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-VQ0oftNp.js:11:126\":\"9274659292b972ba96db246840f74172\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-D5RM5fH2.js:11:126\":\"5bf4b0c65e35249c3327dc129edaab0b\"}"
                   }
                 },
                 {
@@ -506,13 +234,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "D558236C8C945096702C87523E4BD409"
+                    "stringValue": "D0A8CC73B2734240D74FE75D093FC7C6"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "6CE248D50AE22A2C92C4FCD92A55C8CE"
+                    "stringValue": "185E7E2D427E9CFAC02F02E8A2371877"
                   }
                 },
                 {
@@ -524,7 +252,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "52B3A2EA40283C8C705A20B890F8FC44"
+                    "stringValue": "A1610CF0F4DDDD321CC52B9033FEE944"
                   }
                 },
                 {
@@ -548,7 +276,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "04906A6659B9EE3DB820678DAC236C52"
+                    "stringValue": "2901F4BB021DCD2C9535824CC116C6E6"
                   }
                 },
                 {

--- a/tests/integration/utils/run-e2e-tests.ts
+++ b/tests/integration/utils/run-e2e-tests.ts
@@ -4,6 +4,8 @@ import testWithMockApi, {
 
 const EXPECTED_SPAN_ENDED_TEXT =
   'EmbraceSessionPartBatchedSpanProcessor non-session-part span ended';
+// What every platform's 'Send Log' button emits.
+const TEST_LOG_MESSAGE = 'This is a test log message';
 
 type E2ETestFixture = {
   waitUntilSpanLogged: () => Promise<void>;
@@ -174,16 +176,48 @@ const runE2ETests = ({
       },
     );
 
+    // The other tests drain page-load telemetry so they can assert their own
+    // traffic in isolation, which hides the behavior real users get. This keeps
+    // that behavior covered: an interaction landing after the batch window ships
+    // in a separate request rather than sharing one. Waiting for the page-load
+    // flush before clicking makes that ordering certain instead of racing it.
+    testE2E(
+      'it should ship page-load telemetry separately from a later interaction',
+      async ({
+        page,
+        requests,
+        waitForOTelRequest,
+        navigateAndWaitUntilReady,
+      }) => {
+        await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
+
+        await waitForOTelRequest();
+        const pageLoadRequestCount = requests.length;
+        const pageLoadPayload = JSON.stringify(requests);
+
+        await page.getByRole('button', { name: 'Send Log' }).click();
+        await waitForOTelRequest();
+
+        testE2E.expect(requests.length).toBeGreaterThan(pageLoadRequestCount);
+        testE2E.expect(pageLoadPayload).not.toContain(TEST_LOG_MESSAGE);
+        testE2E
+          .expect(JSON.stringify(requests.slice(pageLoadRequestCount)))
+          .toContain(TEST_LOG_MESSAGE);
+      },
+    );
+
     testE2E(
       'it should send a log',
       async ({
         page,
         requests,
         waitForOTelRequest,
+        settleAndResetRequests,
         navigateAndWaitUntilReady,
         browserName,
       }) => {
         await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
+        await settleAndResetRequests();
 
         const button = page.getByRole('button', { name: 'Send Log' });
         await button.click();
@@ -348,6 +382,7 @@ const runE2ETests = ({
       async ({
         page,
         waitForOTelRequest,
+        settleAndResetRequests,
         withSimulatedResponse,
         navigateAndWaitUntilReady,
         waitUntilSpanLogged,
@@ -355,6 +390,7 @@ const runE2ETests = ({
         browserName,
       }) => {
         await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
+        await settleAndResetRequests();
         await withSimulatedResponse({
           body: 'something',
           status: 204,

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -70,6 +70,7 @@ type TestWithMockApi = {
   requests: EmbraceDataRequest[];
   waitForRequest: (url: RegExp) => Promise<void>;
   waitForOTelRequest: (count?: number) => Promise<void>;
+  settleAndResetRequests: () => Promise<void>;
   waitForOTelRequestMatching: (pattern: RegExp) => Promise<void>;
   waitForRemoteConfigRequest: () => Promise<void>;
   withRemoteConfig: (remoteConfig?: Record<string, unknown>) => Promise<void>;
@@ -168,6 +169,19 @@ const testWithMockApi = base.extend<TestWithMockApi>({
           .poll(() => requests.length, { timeout: testInfo.timeout })
           .toBeGreaterThanOrEqual(consumed + count);
         consumed += count;
+      });
+    },
+    { scope: 'test' },
+  ],
+  settleAndResetRequests: [
+    // Drain page-load telemetry through the SDK rather than waiting out
+    // BatchLogRecordProcessor's 1s schedule: once flush resolves the buffer is
+    // empty as a fact, so clearing here leaves later assertions counting only
+    // their own interaction's traffic with no timing assumption.
+    async ({ page, requests }, use) => {
+      await use(async () => {
+        await page.evaluate(() => window.EMBRACE_SDK.log.flush());
+        requests.length = 0;
       });
     },
     { scope: 'test' },


### PR DESCRIPTION
## What problem is this solving?

`test-integration` has been red on main since #1460. Six tests fail with `expect(requests).toHaveLength(1)` receiving 2, on Next 16 Pages across all three browsers.

The SDK is fine. The tests assumed a timing coincidence:

- `BatchLogRecordProcessor` is built with no options (`initSDK.ts:253`), so it takes OTel's default `scheduledDelayMillis` of **1000ms**.
- The `requests` fixture accumulates from page load and is never reset.
- So `toHaveLength(1)` only held while the click's log landed in the *same 1s batch window* as the page-load web vitals.

Measured locally: page-load FCP recorded at `...412.9358`, the batch flushes ~1s later, and the click's `first-interaction` lands at `...414.3994`. A **1.46s** gap, past the boundary, so page-load telemetry ships as its own request and the count becomes 2.

Chromium 149 → 151, Firefox → 153 and WebKit → 26.5 shifted page-load timing just far enough to cross that line. Same class of latent fragility as the soft-navigation test in #1462: a test whose outcome silently depended on browser timing.

## Short description of changes

- New public `log.flush()` on `LogManager`, which exports logs still held in the batch buffer instead of waiting for the next scheduled export. It resolves rather than rejecting on failure, because the safe-proxy wrapper around the public API only traps synchronous throws.
- The fixture reaches it via `window.EMBRACE_SDK.log.flush()`. That global comes from #1472 below this one in the stack, so no harness change is needed here.
- New `settleAndResetRequests` fixture awaits that flush, then clears the buffer. Once flush resolves the buffer is empty as a fact, so no timing assumption remains.
- Called after `navigateAndWaitUntilReady` in the two affected tests, so each assertion counts only the traffic its own interaction caused.
- Regenerated 9 vite-7 goldens. These previously encoded the race outcome, capturing page-load telemetry that happened to share a batch with the click.

Plus the two tests that keep this honest, since nothing pinned either behaviour before:

- `logExportSchedule.test.ts` pins the 1000ms window with a fake clock: nothing exported at 999ms, exactly one record at 1001ms. It lives in its own file because @web/test-runner isolates each file in a fresh page, and sharing one with the other `initSDK` tests lets an SDK built earlier keep timers registered that the fake clock then fires.
- A new e2e test covers what `settleAndResetRequests` deliberately hides from the other tests: that real telemetry still ships separately when an interaction lands after the batch window. Waiting for the page-load flush *before* clicking makes that ordering certain rather than raced, so it is deterministic despite asserting timing-dependent behaviour.

Rejected alternatives: raising `scheduledDelayMillis` only widens the window, so the next browser bump reopens it, and there is no config knob for it today. A quiet-period wait (the first commit here) infers the flush from an absence of requests, which is a heuristic rather than a guarantee.

### Why `log.flush()` rather than the existing `SDKControl.flush()`

`SDKControl.flush()` does drain logs, but it awaits `tracerProvider.forceFlush()` as well, so it drains more than the fixture asks for. Using it here changed a request count and cost one integration test. The fixture wants logs only. It is also marked `@deprecated`, so new test infrastructure should not depend on it. It is left untouched.

### Why there is no matching `trace.flush()`

Spans cannot be flushed on demand today, and this is a wire-protocol constraint rather than a gap. Non-session-part spans carry no session identifiers: they are correlated server-side by travelling in the same export payload as the session-part span, which is why `EmbraceSessionPartBatchedSpanProcessor.forceFlush()` is a deliberate no-op (see `EmbraceUserSessionManager/README.md`). Flushing the pending buffer alone would emit spans the backend cannot attribute to a part.

Logs are self-describing and spans are not, so the asymmetry here is intentional. Making spans flushable means stamping the session and part ids onto every span, which changes what the server reads for correlation and needs its own ticket.

## Coverage

No assertions were lost. The `ttfb`/`fcp` that left `send-log.json` are asserted identically by `log.json`, which this change does not touch, and `lcp` is retained in `handle-204-with-body-logs.json`:

| Golden | ttfb | fcp | lcp |
| --- | --- | --- | --- |
| `send-log.json` before | yes | yes | |
| `send-log.json` after | | | |
| `log.json` (untouched) | yes | yes | |
| `handle-204-with-body-logs.json` | | | yes |

Note `log.json` holds these by accident rather than design: that test selects the first `/logs` request, and the comment above it says it means to take the last. Fixed separately in the stacked follow-up.

## How has this been tested?

- Reproduced the failure locally first, 5 failures matching CI's 6.
- Next 16 Pages after the fix: 31 passed, 0 failed.
- Unit suite: 1041 passed, 0 failed, including the flush, its failure path, and the batch-window boundary.
- Full integration suite: 327 passed, 72 skipped, 0 failed (up from 300; the new e2e test runs across 9 platforms and 3 browsers).
- Goldens are byte-identical across the quiet-period, `SDKControl.flush()` and `log.flush()` implementations, confirming all three produce the same request boundaries.
- Confirmed the boundary test is not vacuous: moving its first tick to 1001ms makes it fail with `expected 1 to equal +0`, so it detects the window rather than passing regardless.
- Confirmed the `Error parsing gzip request: aborted` server noise is pre-existing: it appears 8 times with the change stashed.
- `npm run lint` and `npm run check` from the repo root: clean.

## Checklist

- [ ] Documentation added
- [x] Tests added


