### PR TITLE
test: pin the log batch window and cover real request splitting

### DIFF
--- a/packages/web-sdk/src/sdk/logExportSchedule.test.ts
+++ b/packages/web-sdk/src/sdk/logExportSchedule.test.ts
@@ -1,0 +1,80 @@
+import { context, diag, trace } from '@opentelemetry/api';
+import { logs } from '@opentelemetry/api-logs';
+import { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import { log } from '../api-logs/index.ts';
+import { initSDK } from './initSDK.ts';
+import { registry } from './registry.ts';
+
+const { expect } = chai;
+
+const PROBE_BODY = 'batch-window-probe';
+
+/**
+ * The end-to-end request assertions depend on this window: page-load telemetry
+ * and a later interaction only share a request while both fall inside it.
+ * Chromium 149 to 151 shifted page-load timing across the boundary and broke
+ * those tests, so it is pinned here where a fake clock can assert it exactly
+ * rather than inferred from wall-clock racing in a browser.
+ *
+ * This lives in its own file because @web/test-runner isolates each file in a
+ * fresh page. Sharing a file with other initSDK tests lets an SDK built by an
+ * earlier test keep timers registered, which the fake clock then fires.
+ */
+describe('log export schedule', () => {
+  let logExporter: InMemoryLogRecordExporter;
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    logExporter = new InMemoryLogRecordExporter();
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+    logExporter.reset();
+    trace.disable();
+    logs.disable();
+    diag.disable();
+    context.disable();
+    registry.clear();
+  });
+
+  // Instrumentations emit logs of their own, so count only this probe.
+  const probeCount = () =>
+    logExporter
+      .getFinishedLogRecords()
+      .filter((record) => record.body === PROBE_BODY).length;
+
+  it('should hold a log in the batch buffer until the scheduled delay elapses', async () => {
+    const result = initSDK({
+      logExporters: [logExporter],
+      // Reads navigation timing entries that a fake clock leaves undefined.
+      defaultInstrumentationConfig: { omit: new Set(['document-load']) },
+    });
+    void expect(result).not.to.be.false;
+
+    log.message(PROBE_BODY, 'info');
+
+    await clock.tickAsync(999);
+    expect(probeCount()).to.equal(0);
+
+    await clock.tickAsync(2);
+    expect(probeCount()).to.equal(1);
+  });
+
+  it('should export immediately when flushed instead of waiting for the delay', async () => {
+    const result = initSDK({
+      logExporters: [logExporter],
+      defaultInstrumentationConfig: { omit: new Set(['document-load']) },
+    });
+    void expect(result).not.to.be.false;
+
+    log.message(PROBE_BODY, 'info');
+
+    await log.flush();
+
+    expect(probeCount()).to.equal(1);
+  });
+});

--- a/tests/integration/utils/run-e2e-tests.ts
+++ b/tests/integration/utils/run-e2e-tests.ts
@@ -4,6 +4,8 @@ import testWithMockApi, {
 
 const EXPECTED_SPAN_ENDED_TEXT =
   'EmbraceSessionPartBatchedSpanProcessor non-session-part span ended';
+// What every platform's 'Send Log' button emits.
+const TEST_LOG_MESSAGE = 'This is a test log message';
 
 type E2ETestFixture = {
   waitUntilSpanLogged: () => Promise<void>;
@@ -171,6 +173,36 @@ const runE2ETests = ({
             `${browserName}-${codifiedName}-log.json`,
           );
         }
+      },
+    );
+
+    // The other tests drain page-load telemetry so they can assert their own
+    // traffic in isolation, which hides the behavior real users get. This keeps
+    // that behavior covered: an interaction landing after the batch window ships
+    // in a separate request rather than sharing one. Waiting for the page-load
+    // flush before clicking makes that ordering certain instead of racing it.
+    testE2E(
+      'it should ship page-load telemetry separately from a later interaction',
+      async ({
+        page,
+        requests,
+        waitForOTelRequest,
+        navigateAndWaitUntilReady,
+      }) => {
+        await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
+
+        await waitForOTelRequest();
+        const pageLoadRequestCount = requests.length;
+        const pageLoadPayload = JSON.stringify(requests);
+
+        await page.getByRole('button', { name: 'Send Log' }).click();
+        await waitForOTelRequest();
+
+        testE2E.expect(requests.length).toBeGreaterThan(pageLoadRequestCount);
+        testE2E.expect(pageLoadPayload).not.toContain(TEST_LOG_MESSAGE);
+        testE2E
+          .expect(JSON.stringify(requests.slice(pageLoadRequestCount)))
+          .toContain(TEST_LOG_MESSAGE);
       },
     );
 


### PR DESCRIPTION
Stacked on #1466.

## What problem is this solving?

The batch window that #1466's request assertions depend on had nothing pinning it. Page-load telemetry and a later interaction share a request only while both fall inside the window, and Chromium 149 to 151 shifted page-load timing across that boundary, which is what broke `test-integration`. Nothing would have caught a change to the window itself.

Separately, #1466 drains page-load telemetry so each test can assert its own traffic in isolation. That is correct for those tests, but it means no test covers what real users get: telemetry genuinely splitting across requests.

## Short description of changes

- `logExportSchedule.test.ts` pins the boundary with a fake clock: nothing is exported at 999ms, exactly one record at 1001ms. Deterministic, no wall-clock racing.
- A new e2e test covers the real splitting behavior. It waits for the page-load flush *before* clicking, which makes the ordering certain rather than racing it, so the test is deterministic despite asserting timing-dependent behavior.

The unit test lives in its own file on purpose: `@web/test-runner` isolates each file in a fresh page, and sharing a file with the other `initSDK` tests lets an SDK built by an earlier test keep timers registered, which the fake clock then fires.

## How has this been tested?

- Verified the boundary test is not vacuous: moving the first tick to 1001ms makes it fail with `expected 1 to equal +0`, so it genuinely detects the window rather than passing regardless.
- Unit suite: 1041 passed, 0 failed.
- Integration suite: 327 passed, 72 skipped, 0 failed (up from 300, the new test across 9 platforms and 3 browsers).
- `npm run lint` and `npm run check` from the repo root: clean.

## Checklist

- [ ] Documentation added
- [x] Tests added
