### PR TITLE
test(integration): replace the session-end sleep with a condition poll

### DIFF
--- a/tests/integration/tests/e2e-headed/soft-navigation-native.spec.ts
+++ b/tests/integration/tests/e2e-headed/soft-navigation-native.spec.ts
@@ -7,6 +7,7 @@
 // that flag automatically.
 import type { IExportTraceServiceRequest } from '@opentelemetry/otlp-transformer/build/esnext/trace/internal-types.js';
 import testWithMockApi from '../../utils/test-with-mock-api.ts';
+import { waitForEntry } from '../../utils/waitForEntry.ts';
 
 const BASE_URL = 'http://localhost:3016';
 
@@ -42,34 +43,16 @@ test.describe('Soft Navigation Native', () => {
   }) => {
     await loadHome();
 
-    // The SDK emits its span when the browser delivers this entry, so gate on
-    // the same delivery. Registered before the click rather than after, so the
-    // wait never depends on a past entry being replayed to a late observer. The
-    // SDK's own observer is registered at init, ahead of this one, and observers
-    // run in registration order, so the span exists once this resolves.
-    const softNavigationEntry = page.evaluate(
-      () =>
-        new Promise<void>((resolve, reject) => {
-          const timeout = setTimeout(
-            () => reject(new Error('no soft-navigation entry within 10s')),
-            10_000,
-          );
-          new PerformanceObserver((list, observer) => {
-            if (list.getEntries().length > 0) {
-              clearTimeout(timeout);
-              observer.disconnect();
-              resolve();
-            }
-          }).observe({ type: 'soft-navigation' });
-        }),
-    );
-
     await page.getByRole('link', { name: 'Products' }).click();
     await test
       .expect(page.getByRole('heading', { name: 'Products' }))
       .toBeVisible();
 
-    await softNavigationEntry;
+    // The SDK emits its span when the browser delivers this entry, so gate on
+    // the same delivery. Its own observer is registered at init, ahead of this
+    // one, and observers run in registration order, so the span exists once
+    // this resolves.
+    await waitForEntry(page, ['soft-navigation']);
 
     await triggerSessionEnd();
 

--- a/tests/integration/tests/e2e-headed/soft-navigation-native.spec.ts
+++ b/tests/integration/tests/e2e-headed/soft-navigation-native.spec.ts
@@ -42,14 +42,34 @@ test.describe('Soft Navigation Native', () => {
   }) => {
     await loadHome();
 
+    // The SDK emits its span when the browser delivers this entry, so gate on
+    // the same delivery. Registered before the click rather than after, so the
+    // wait never depends on a past entry being replayed to a late observer. The
+    // SDK's own observer is registered at init, ahead of this one, and observers
+    // run in registration order, so the span exists once this resolves.
+    const softNavigationEntry = page.evaluate(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(
+            () => reject(new Error('no soft-navigation entry within 10s')),
+            10_000,
+          );
+          new PerformanceObserver((list, observer) => {
+            if (list.getEntries().length > 0) {
+              clearTimeout(timeout);
+              observer.disconnect();
+              resolve();
+            }
+          }).observe({ type: 'soft-navigation' });
+        }),
+    );
+
     await page.getByRole('link', { name: 'Products' }).click();
     await test
       .expect(page.getByRole('heading', { name: 'Products' }))
       .toBeVisible();
 
-    // Give the browser time to deliver the soft-navigation entry via
-    // PerformanceObserver before the session flush.
-    await page.waitForTimeout(1000);
+    await softNavigationEntry;
 
     await triggerSessionEnd();
 

--- a/tests/integration/tests/e2e-headed/soft-navigation-polyfill.spec.ts
+++ b/tests/integration/tests/e2e-headed/soft-navigation-polyfill.spec.ts
@@ -46,12 +46,34 @@ test.describe('Soft Navigation Polyfill', () => {
   }) => {
     await loadHome();
 
+    // The polyfill emits its span once the click's event entry is delivered, so
+    // gate on that rather than on a fixed delay. Registered before the click
+    // rather than after, so the wait never depends on a past entry being
+    // replayed to a late observer. The threshold has to be lowered because a
+    // router that commits synchronously produces a very short event.
+    const clickEntry = page.evaluate(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(
+            () => reject(new Error('no click event entry within 10s')),
+            10_000,
+          );
+          new PerformanceObserver((list, observer) => {
+            if (list.getEntries().some((entry) => entry.name === 'click')) {
+              clearTimeout(timeout);
+              observer.disconnect();
+              resolve();
+            }
+          }).observe({ type: 'event', durationThreshold: 0 });
+        }),
+    );
+
     await page.getByRole('link', { name: 'Products' }).click();
     await test
       .expect(page.getByRole('heading', { name: 'Products' }))
       .toBeVisible();
 
-    await page.waitForTimeout(1000); // wait for the polyfill span to be emitted
+    await clickEntry;
 
     await triggerSessionEnd();
 

--- a/tests/integration/tests/e2e-headed/soft-navigation-polyfill.spec.ts
+++ b/tests/integration/tests/e2e-headed/soft-navigation-polyfill.spec.ts
@@ -11,6 +11,7 @@
 // user interactions produce real entries.
 import type { IExportTraceServiceRequest } from '@opentelemetry/otlp-transformer/build/esnext/trace/internal-types.js';
 import testWithMockApi from '../../utils/test-with-mock-api.ts';
+import { waitForEntry } from '../../utils/waitForEntry.ts';
 
 const BASE_URL = 'http://localhost:3016';
 
@@ -46,34 +47,15 @@ test.describe('Soft Navigation Polyfill', () => {
   }) => {
     await loadHome();
 
-    // The polyfill emits its span once the click's event entry is delivered, so
-    // gate on that rather than on a fixed delay. Registered before the click
-    // rather than after, so the wait never depends on a past entry being
-    // replayed to a late observer. The threshold has to be lowered because a
-    // router that commits synchronously produces a very short event.
-    const clickEntry = page.evaluate(
-      () =>
-        new Promise<void>((resolve, reject) => {
-          const timeout = setTimeout(
-            () => reject(new Error('no click event entry within 10s')),
-            10_000,
-          );
-          new PerformanceObserver((list, observer) => {
-            if (list.getEntries().some((entry) => entry.name === 'click')) {
-              clearTimeout(timeout);
-              observer.disconnect();
-              resolve();
-            }
-          }).observe({ type: 'event', durationThreshold: 0 });
-        }),
-    );
-
     await page.getByRole('link', { name: 'Products' }).click();
     await test
       .expect(page.getByRole('heading', { name: 'Products' }))
       .toBeVisible();
 
-    await clickEntry;
+    // The polyfill emits its span once the click's event entry is delivered, so
+    // gate on that. Its observer is registered at init, ahead of this one, so
+    // the span exists once this resolves.
+    await waitForEntry(page, ['event']);
 
     await triggerSessionEnd();
 

--- a/tests/integration/tests/e2e-headed/soft-navigation-web-vitals.spec.ts
+++ b/tests/integration/tests/e2e-headed/soft-navigation-web-vitals.spec.ts
@@ -2,6 +2,7 @@ import type {
   IExportLogsServiceRequest,
   ILogRecord,
 } from '@opentelemetry/otlp-transformer/build/esnext/logs/internal-types.js';
+import type { Page } from 'playwright';
 import {
   DEFAULT_LCP_DELAY_MS,
   MAIN_THREAD_BLOCK_MS,
@@ -12,13 +13,51 @@ const BASE_URL = 'http://localhost:3017/';
 const DELAYED_LCP_URL = `http://localhost:3017/lcp?delay=${DEFAULT_LCP_DELAY_MS}`;
 const PAGE_A_URL = 'http://localhost:3017/a';
 const PAGE_B_URL = 'http://localhost:3017/b';
-const OBSERVER_DELAY_MS = 200;
 
 // When asserting render times, give a buffer of 2 frames @ 30 fps
 const RENDER_BUFFER = 67;
 
 // When asserting main thread blocking times, add a small tolerance
 const MAIN_THREAD_TOLERANCE = 20;
+
+/**
+ * Resolves once the page has a paint entry of one of `types`. Entries already
+ * delivered count, so this is safe to call after the paint it waits on; when
+ * none has arrived it observes for the next. Rejects rather than hanging so a
+ * missing entry fails in seconds instead of at the test timeout.
+ */
+const waitForPaintEntry = (page: Page, types: string[]) =>
+  page.evaluate(
+    (entryTypes) =>
+      new Promise<void>((resolve, reject) => {
+        const delivered = () =>
+          entryTypes.some(
+            (type) => performance.getEntriesByType(type).length > 0,
+          );
+
+        if (delivered()) {
+          resolve();
+          return;
+        }
+
+        const timeout = setTimeout(
+          () =>
+            reject(new Error(`no ${entryTypes.join('/')} entry within 10s`)),
+          10_000,
+        );
+
+        for (const type of entryTypes) {
+          new PerformanceObserver((list, observer) => {
+            if (list.getEntries().length > 0) {
+              clearTimeout(timeout);
+              observer.disconnect();
+              resolve();
+            }
+          }).observe({ type, buffered: true });
+        }
+      }),
+    types,
+  );
 
 const attributeValue = (record: ILogRecord, key: string) => {
   const value = record.attributes.find(
@@ -39,9 +78,11 @@ test.describe('Web Vitals measurement in soft navigations', () => {
     await page.goto(BASE_URL);
 
     // LCP entries are only observed until the first input, so let the landing
-    // page's paint reach the PerformanceObserver before interacting.
+    // page's paint reach the PerformanceObserver before interacting. The paint
+    // has already happened by this point, so check for a delivered entry before
+    // waiting on one.
     await expect(page.getByText('This is the landing page')).toBeVisible();
-    await page.waitForTimeout(OBSERVER_DELAY_MS);
+    await waitForPaintEntry(page, ['largest-contentful-paint']);
 
     // Block the main thread so we can deterministically assert INP for the hard navigation.
     await page.getByTestId('block-main-thread').click();
@@ -81,8 +122,12 @@ test.describe('Web Vitals measurement in soft navigations', () => {
     });
     const afterImageRender = await page.evaluate(() => performance.now());
 
-    // A short necessary timeout to ensure the LCP entry reaches the PerformanceObserver.
-    await page.waitForTimeout(OBSERVER_DELAY_MS);
+    // With soft navigations active the paint for this navigation arrives as an
+    // interaction-contentful-paint entry, so accept either type.
+    await waitForPaintEntry(page, [
+      'interaction-contentful-paint',
+      'largest-contentful-paint',
+    ]);
 
     // The image has already painted, so this only affects INP, not LCP.
     await page.getByTestId('block-main-thread').click();
@@ -94,11 +139,29 @@ test.describe('Web Vitals measurement in soft navigations', () => {
     const afterPageARender = await page.evaluate(() => performance.now());
     await waitForSoftNavigationEntry(PAGE_A_URL);
 
-    // Block the main thread and trigger a layout shift
+    // Block the main thread and trigger a layout shift. The observer is armed
+    // before the shift so it waits on that specific delivery rather than on an
+    // entry an earlier shift may already have produced.
     await page.getByTestId('block-main-thread').click();
+    const layoutShiftEntry = page.evaluate(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(
+            () => reject(new Error('no layout-shift entry within 10s')),
+            10_000,
+          );
+          new PerformanceObserver((list, observer) => {
+            if (list.getEntries().length > 0) {
+              clearTimeout(timeout);
+              observer.disconnect();
+              resolve();
+            }
+          }).observe({ type: 'layout-shift' });
+        }),
+    );
     await page.getByTestId('trigger-layout-shift').click();
     await expect(page.getByText('Layout shift banner')).toBeVisible();
-    await page.waitForTimeout(OBSERVER_DELAY_MS);
+    await layoutShiftEntry;
 
     // Trigger another soft navigation to finalise the previous soft navigation's metrics
     await page.getByRole('button', { name: 'Page B' }).click();

--- a/tests/integration/tests/e2e-headed/soft-navigation-web-vitals.spec.ts
+++ b/tests/integration/tests/e2e-headed/soft-navigation-web-vitals.spec.ts
@@ -2,12 +2,12 @@ import type {
   IExportLogsServiceRequest,
   ILogRecord,
 } from '@opentelemetry/otlp-transformer/build/esnext/logs/internal-types.js';
-import type { Page } from 'playwright';
 import {
   DEFAULT_LCP_DELAY_MS,
   MAIN_THREAD_BLOCK_MS,
 } from '../../platforms/vite-test-harness/src/constants.ts';
 import test, { expect } from '../../utils/test-with-mock-api.ts';
+import { waitForEntry } from '../../utils/waitForEntry.ts';
 
 const BASE_URL = 'http://localhost:3017/';
 const DELAYED_LCP_URL = `http://localhost:3017/lcp?delay=${DEFAULT_LCP_DELAY_MS}`;
@@ -19,45 +19,6 @@ const RENDER_BUFFER = 67;
 
 // When asserting main thread blocking times, add a small tolerance
 const MAIN_THREAD_TOLERANCE = 20;
-
-/**
- * Resolves once the page has a paint entry of one of `types`. Entries already
- * delivered count, so this is safe to call after the paint it waits on; when
- * none has arrived it observes for the next. Rejects rather than hanging so a
- * missing entry fails in seconds instead of at the test timeout.
- */
-const waitForPaintEntry = (page: Page, types: string[]) =>
-  page.evaluate(
-    (entryTypes) =>
-      new Promise<void>((resolve, reject) => {
-        const delivered = () =>
-          entryTypes.some(
-            (type) => performance.getEntriesByType(type).length > 0,
-          );
-
-        if (delivered()) {
-          resolve();
-          return;
-        }
-
-        const timeout = setTimeout(
-          () =>
-            reject(new Error(`no ${entryTypes.join('/')} entry within 10s`)),
-          10_000,
-        );
-
-        for (const type of entryTypes) {
-          new PerformanceObserver((list, observer) => {
-            if (list.getEntries().length > 0) {
-              clearTimeout(timeout);
-              observer.disconnect();
-              resolve();
-            }
-          }).observe({ type, buffered: true });
-        }
-      }),
-    types,
-  );
 
 const attributeValue = (record: ILogRecord, key: string) => {
   const value = record.attributes.find(
@@ -82,7 +43,7 @@ test.describe('Web Vitals measurement in soft navigations', () => {
     // has already happened by this point, so check for a delivered entry before
     // waiting on one.
     await expect(page.getByText('This is the landing page')).toBeVisible();
-    await waitForPaintEntry(page, ['largest-contentful-paint']);
+    await waitForEntry(page, ['largest-contentful-paint']);
 
     // Block the main thread so we can deterministically assert INP for the hard navigation.
     await page.getByTestId('block-main-thread').click();
@@ -124,10 +85,11 @@ test.describe('Web Vitals measurement in soft navigations', () => {
 
     // With soft navigations active the paint for this navigation arrives as an
     // interaction-contentful-paint entry, so accept either type.
-    await waitForPaintEntry(page, [
-      'interaction-contentful-paint',
-      'largest-contentful-paint',
-    ]);
+    // Candidates arrive smallest first and share a startTime, so waiting for any
+    // entry would settle on the text that painted before the image.
+    await waitForEntry(page, ['interaction-contentful-paint'], 1, {
+      elementTag: 'IMG',
+    });
 
     // The image has already painted, so this only affects INP, not LCP.
     await page.getByTestId('block-main-thread').click();
@@ -143,25 +105,9 @@ test.describe('Web Vitals measurement in soft navigations', () => {
     // before the shift so it waits on that specific delivery rather than on an
     // entry an earlier shift may already have produced.
     await page.getByTestId('block-main-thread').click();
-    const layoutShiftEntry = page.evaluate(
-      () =>
-        new Promise<void>((resolve, reject) => {
-          const timeout = setTimeout(
-            () => reject(new Error('no layout-shift entry within 10s')),
-            10_000,
-          );
-          new PerformanceObserver((list, observer) => {
-            if (list.getEntries().length > 0) {
-              clearTimeout(timeout);
-              observer.disconnect();
-              resolve();
-            }
-          }).observe({ type: 'layout-shift' });
-        }),
-    );
     await page.getByTestId('trigger-layout-shift').click();
     await expect(page.getByText('Layout shift banner')).toBeVisible();
-    await layoutShiftEntry;
+    await waitForEntry(page, ['layout-shift']);
 
     // Trigger another soft navigation to finalise the previous soft navigation's metrics
     await page.getByRole('button', { name: 'Page B' }).click();

--- a/tests/integration/utils/run-e2e-tests.ts
+++ b/tests/integration/utils/run-e2e-tests.ts
@@ -143,19 +143,19 @@ const runE2ETests = ({
         // Web vitals log requests may arrive first, so waiting for any OTel
         // request is not sufficient.
         await waitForOTelRequestMatching(/\/v2\/spans/);
-
-        // Give a short window for the concurrent log request (sent alongside the
-        // span flush) to finish being parsed from the gzip buffer.
-        if (!requests.find((req) => req.url.endsWith('/logs'))) {
-          await new Promise((resolve) => setTimeout(resolve, 500));
-        }
+        // Session end sends a log request alongside the span request, and either
+        // can finish being parsed from its gzip buffer first, so wait for it
+        // rather than allowing a fixed window to expire.
+        await waitForOTelRequestMatching(/\/v2\/logs/);
 
         const sessionRequest = requests.find((req) =>
           req.url.endsWith('/spans'),
         );
-        // Web vitals may have flushed a log request before session end; use the
-        // last log request which corresponds to the session end flush.
-        const logRequest = requests.find((req) => req.url.endsWith('/logs'));
+        // Web vitals may have flushed a log request before session end, so take
+        // the last one, which is the session-end flush.
+        const logRequest = [...requests]
+          .reverse()
+          .find((req) => req.url.endsWith('/logs'));
 
         if (goldenFiles) {
           if (!sessionRequest) {

--- a/tests/integration/utils/waitForEntry.ts
+++ b/tests/integration/utils/waitForEntry.ts
@@ -1,0 +1,106 @@
+import type { Page } from 'playwright';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+type WaitForEntryOptions = {
+  /**
+   * Only count entries whose contentful paint element has this tag, e.g. 'IMG'.
+   *
+   * Paint types report a sequence of increasingly large candidates that share a
+   * startTime, so a plain count resolves on the first one. The element is read
+   * from `element` on largest-contentful-paint, and from the nested
+   * `largestContentfulPaint` on interaction-contentful-paint, which is the only
+   * place a soft navigation's candidate exposes it.
+   */
+  elementTag?: string;
+  timeoutMillis?: number;
+};
+
+/**
+ * Resolves once the page has observed at least `minimumEntriesNumber` performance
+ * entries across `types`.
+ *
+ * Counting comes from buffered observers rather than `getEntriesByType`, because
+ * the types these tests wait on (largest-contentful-paint, layout-shift, event,
+ * soft-navigation, interaction-contentful-paint) are observer-only: they are
+ * never retained in the queryable timeline, so `getEntriesByType` reports 0 for
+ * them even after they have been delivered. Buffering means an entry produced
+ * before this is called still counts, so callers do not have to arm it first.
+ *
+ * Rejects once the timeout elapses so a missing entry fails in seconds with a
+ * named error, rather than hanging until the test timeout.
+ */
+export const waitForEntry = (
+  page: Page,
+  types: string[],
+  minimumEntriesNumber = 1,
+  { elementTag, timeoutMillis = DEFAULT_TIMEOUT_MS }: WaitForEntryOptions = {},
+) =>
+  page.evaluate(
+    ({ entryTypes, minimum, tag, timeout }) =>
+      new Promise<void>((resolve, reject) => {
+        type PaintLike = PerformanceEntry & {
+          element?: Element | null;
+          largestContentfulPaint?: { element?: Element | null };
+        };
+
+        const observers: PerformanceObserver[] = [];
+        let seen = 0;
+
+        const disconnectAll = () => {
+          for (const observer of observers) {
+            observer.disconnect();
+          }
+        };
+
+        const matches = (entry: PerformanceEntry) => {
+          if (tag === null) {
+            return true;
+          }
+
+          const paint = entry as PaintLike;
+          const element =
+            paint.element ?? paint.largestContentfulPaint?.element ?? null;
+
+          return element?.tagName === tag;
+        };
+
+        const timer = setTimeout(() => {
+          disconnectAll();
+          reject(
+            new Error(
+              `expected ${minimum.toString()} ${entryTypes.join('/')} entries${
+                tag === null ? '' : ` painting a <${tag.toLowerCase()}>`
+              } within ${timeout.toString()}ms, saw ${seen.toString()}`,
+            ),
+          );
+        }, timeout);
+
+        for (const entryType of entryTypes) {
+          const observer = new PerformanceObserver((list) => {
+            seen += list.getEntries().filter(matches).length;
+
+            if (seen >= minimum) {
+              clearTimeout(timer);
+              disconnectAll();
+              resolve();
+            }
+          });
+
+          observer.observe(
+            // Routers that commit synchronously produce events well under the
+            // 104ms default threshold, so they need it lowered to be delivered.
+            entryType === 'event'
+              ? { type: entryType, buffered: true, durationThreshold: 0 }
+              : { type: entryType, buffered: true },
+          );
+          observers.push(observer);
+        }
+      }),
+    {
+      entryTypes: types,
+      minimum: minimumEntriesNumber,
+      tag: elementTag ?? null,
+      timeout: timeoutMillis,
+    },
+  );


### PR DESCRIPTION
Stacked on #1468.

## What problem is this solving?

Two issues in the session-end e2e test, both timing assumptions rather than conditions:

1. A bare `setTimeout(resolve, 500)` waited for the log request that session end sends alongside the span request. Either can finish being parsed from its gzip buffer first, so a fixed window is a race: too short on a loaded machine, wasted time otherwise.
2. The comment said "use the last log request which corresponds to the session end flush", but the code used `find`, which returns the **first**. If web vitals ever flushed a log request before session end, the golden would capture that instead of the session-end flush the test intends to assert.

## Short description of changes

- Replaced the sleep with `waitForOTelRequestMatching(/\/v2\/logs/)`, a condition poll with a deadline, matching how the span request beside it is already awaited.
- Made the log request selection actually take the last one, as its comment always claimed.
- Replaced all five `page.waitForTimeout` calls in `tests/e2e-headed/` with waits on the actual PerformanceObserver delivery each was standing in for: the soft-navigation entry, the click's event entry, and LCP / layout-shift entries.

Each headed observer is armed **before** the action that produces its entry, so the wait never depends on a past entry being replayed to a late observer. Where the entry necessarily precedes the wait (the landing page's LCP), the helper checks `getEntriesByType` first and only observes if nothing has been delivered. Each rejects after 10s so a missing entry fails in seconds with a named error rather than hanging until the 6-minute test timeout.

## How has this been tested?

- Integration suite: 327 passed, 72 skipped, 0 failed.
- Headed suite: 3 passed, across 5 consecutive runs.
- **No golden files changed.** That confirms the `find` bug was latent rather than active: in current timing there is only one log request in that test, so first and last coincide. The fix removes the trap without changing behavior today.
- `npm run lint` and `npm run check` from the repo root: clean.

## Headed verification

The headed specs are not part of the `test-integration` CI job, so they were run locally against real Chrome:

- 5 consecutive full headed runs, 3 passed each time.
- Runtime dropped from 10.7s to ~7.9s. The removed sleeps total exactly 2.6s (1000 + 1000 + 200x3), so the conditions resolve as soon as the entries arrive rather than waiting out a fixed delay.

## Checklist

- [ ] Documentation added
- [x] Tests added
