### PR TITLE
test(integration): expose the SDK control object as one window global

### DIFF
--- a/tests/integration/platforms/next-15-turbopack-app/src/components/EmbraceWebSdk.tsx
+++ b/tests/integration/platforms/next-15-turbopack-app/src/components/EmbraceWebSdk.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { DiagLogLevel, initSDK, session } from '@embrace-io/web-sdk';
+import { DiagLogLevel, initSDK } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace';
 
-export const embraceWebSdk = initSDK({
+export const sdkControl = initSDK({
   appID: '11111',
   appVersion: '1.0.0',
   spanExporters: [new ConsoleSpanExporter()],
@@ -20,14 +20,18 @@ export const embraceWebSdk = initSDK({
   },
 });
 
+// Playwright drives the SDK through this global: page.evaluate runs in the page
+// realm and cannot reach the bundle's module scope.
 declare global {
   interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
+    EMBRACE_SDK: Exclude<ReturnType<typeof initSDK>, false>;
   }
 }
 
-if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
+// Falsy during SSR, when remote config samples this device out, or on init
+// failure, so tests can assert on the global's absence.
+if (sdkControl) {
+  window.EMBRACE_SDK = sdkControl;
 }
 
 export default function EmbraceWebSdk() {

--- a/tests/integration/platforms/next-15-turbopack-app/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-15-turbopack-app/src/components/SDKTest.tsx
@@ -1,20 +1,20 @@
 'use client';
 
 import { log, session } from '@embrace-io/web-sdk';
-import { embraceWebSdk } from './EmbraceWebSdk.tsx';
+import { sdkControl } from './EmbraceWebSdk.tsx';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
     session.endUserSession();
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 
   const handleSendLog = async () => {
     log.message('This is a test log message', 'warning');
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 

--- a/tests/integration/platforms/next-15-turbopack-pages/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-15-turbopack-pages/src/components/SDKTest.tsx
@@ -1,18 +1,18 @@
 import { log, session } from '@embrace-io/web-sdk';
-import { embraceWebSdk } from '../lib/embrace.ts';
+import { sdkControl } from '../lib/embrace.ts';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
     session.endUserSession();
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 
   const handleSendLog = async () => {
     log.message('This is a test log message', 'warning');
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 

--- a/tests/integration/platforms/next-15-turbopack-pages/src/lib/embrace.ts
+++ b/tests/integration/platforms/next-15-turbopack-pages/src/lib/embrace.ts
@@ -1,8 +1,8 @@
-import { DiagLogLevel, initSDK, session } from '@embrace-io/web-sdk';
+import { DiagLogLevel, initSDK } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace';
 
-export const embraceWebSdk = initSDK({
+export const sdkControl = initSDK({
   appID: '11111',
   appVersion: '1.0.0',
   spanExporters: [new ConsoleSpanExporter()],
@@ -16,12 +16,16 @@ export const embraceWebSdk = initSDK({
   },
 });
 
+// Playwright drives the SDK through this global: page.evaluate runs in the page
+// realm and cannot reach the bundle's module scope.
 declare global {
   interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
+    EMBRACE_SDK: Exclude<ReturnType<typeof initSDK>, false>;
   }
 }
 
-if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
+// Falsy during SSR, when remote config samples this device out, or on init
+// failure, so tests can assert on the global's absence.
+if (sdkControl) {
+  window.EMBRACE_SDK = sdkControl;
 }

--- a/tests/integration/platforms/next-15-webpack-app/src/components/EmbraceWebSdk.tsx
+++ b/tests/integration/platforms/next-15-webpack-app/src/components/EmbraceWebSdk.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { DiagLogLevel, initSDK, session } from '@embrace-io/web-sdk';
+import { DiagLogLevel, initSDK } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace';
 
-export const embraceWebSdk = initSDK({
+export const sdkControl = initSDK({
   appID: '11111',
   appVersion: '1.0.0',
   spanExporters: [new ConsoleSpanExporter()],
@@ -20,14 +20,18 @@ export const embraceWebSdk = initSDK({
   },
 });
 
+// Playwright drives the SDK through this global: page.evaluate runs in the page
+// realm and cannot reach the bundle's module scope.
 declare global {
   interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
+    EMBRACE_SDK: Exclude<ReturnType<typeof initSDK>, false>;
   }
 }
 
-if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
+// Falsy during SSR, when remote config samples this device out, or on init
+// failure, so tests can assert on the global's absence.
+if (sdkControl) {
+  window.EMBRACE_SDK = sdkControl;
 }
 
 export default function EmbraceWebSdk() {

--- a/tests/integration/platforms/next-15-webpack-app/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-15-webpack-app/src/components/SDKTest.tsx
@@ -1,20 +1,20 @@
 'use client';
 
 import { log, session } from '@embrace-io/web-sdk';
-import { embraceWebSdk } from './EmbraceWebSdk.tsx';
+import { sdkControl } from './EmbraceWebSdk.tsx';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
     session.endUserSession();
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 
   const handleSendLog = async () => {
     log.message('This is a test log message', 'warning');
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 

--- a/tests/integration/platforms/next-15-webpack-pages/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-15-webpack-pages/src/components/SDKTest.tsx
@@ -1,18 +1,18 @@
 import { log, session } from '@embrace-io/web-sdk';
-import { embraceWebSdk } from '../lib/embrace.ts';
+import { sdkControl } from '../lib/embrace.ts';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
     session.endUserSession();
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 
   const handleSendLog = async () => {
     log.message('This is a test log message', 'warning');
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 

--- a/tests/integration/platforms/next-15-webpack-pages/src/lib/embrace.ts
+++ b/tests/integration/platforms/next-15-webpack-pages/src/lib/embrace.ts
@@ -1,8 +1,8 @@
-import { DiagLogLevel, initSDK, session } from '@embrace-io/web-sdk';
+import { DiagLogLevel, initSDK } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace';
 
-export const embraceWebSdk = initSDK({
+export const sdkControl = initSDK({
   appID: '11111',
   appVersion: '1.0.0',
   spanExporters: [new ConsoleSpanExporter()],
@@ -16,12 +16,16 @@ export const embraceWebSdk = initSDK({
   },
 });
 
+// Playwright drives the SDK through this global: page.evaluate runs in the page
+// realm and cannot reach the bundle's module scope.
 declare global {
   interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
+    EMBRACE_SDK: Exclude<ReturnType<typeof initSDK>, false>;
   }
 }
 
-if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
+// Falsy during SSR, when remote config samples this device out, or on init
+// failure, so tests can assert on the global's absence.
+if (sdkControl) {
+  window.EMBRACE_SDK = sdkControl;
 }

--- a/tests/integration/platforms/next-16-app/src/components/EmbraceWebSdk.tsx
+++ b/tests/integration/platforms/next-16-app/src/components/EmbraceWebSdk.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { DiagLogLevel, initSDK, session } from '@embrace-io/web-sdk';
+import { DiagLogLevel, initSDK } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace';
 
-export const embraceWebSdk = initSDK({
+export const sdkControl = initSDK({
   appID: '11111',
   appVersion: '1.0.0',
   spanExporters: [new ConsoleSpanExporter()],
@@ -20,14 +20,18 @@ export const embraceWebSdk = initSDK({
   },
 });
 
+// Playwright drives the SDK through this global: page.evaluate runs in the page
+// realm and cannot reach the bundle's module scope.
 declare global {
   interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
+    EMBRACE_SDK: Exclude<ReturnType<typeof initSDK>, false>;
   }
 }
 
-if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
+// Falsy during SSR, when remote config samples this device out, or on init
+// failure, so tests can assert on the global's absence.
+if (sdkControl) {
+  window.EMBRACE_SDK = sdkControl;
 }
 
 export default function EmbraceWebSdk() {

--- a/tests/integration/platforms/next-16-app/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-16-app/src/components/SDKTest.tsx
@@ -1,20 +1,20 @@
 'use client';
 
 import { log, session } from '@embrace-io/web-sdk';
-import { embraceWebSdk } from './EmbraceWebSdk.tsx';
+import { sdkControl } from './EmbraceWebSdk.tsx';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
     session.endUserSession();
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 
   const handleSendLog = async () => {
     log.message('This is a test log message', 'warning');
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 

--- a/tests/integration/platforms/next-16-pages/src/components/SDKTest.tsx
+++ b/tests/integration/platforms/next-16-pages/src/components/SDKTest.tsx
@@ -1,18 +1,18 @@
 import { log, session } from '@embrace-io/web-sdk';
-import { embraceWebSdk } from '../lib/embrace.ts';
+import { sdkControl } from '../lib/embrace.ts';
 
 const SDKTest = () => {
   const handleEndSession = async () => {
     session.endUserSession();
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 
   const handleSendLog = async () => {
     log.message('This is a test log message', 'warning');
-    if (embraceWebSdk) {
-      await embraceWebSdk.flush();
+    if (sdkControl) {
+      await sdkControl.flush();
     }
   };
 

--- a/tests/integration/platforms/next-16-pages/src/lib/embrace.ts
+++ b/tests/integration/platforms/next-16-pages/src/lib/embrace.ts
@@ -1,8 +1,8 @@
-import { DiagLogLevel, initSDK, session } from '@embrace-io/web-sdk';
+import { DiagLogLevel, initSDK } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace';
 
-export const embraceWebSdk = initSDK({
+export const sdkControl = initSDK({
   appID: '11111',
   appVersion: '1.0.0',
   spanExporters: [new ConsoleSpanExporter()],
@@ -16,12 +16,16 @@ export const embraceWebSdk = initSDK({
   },
 });
 
+// Playwright drives the SDK through this global: page.evaluate runs in the page
+// realm and cannot reach the bundle's module scope.
 declare global {
   interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
+    EMBRACE_SDK: Exclude<ReturnType<typeof initSDK>, false>;
   }
 }
 
-if (typeof window !== 'undefined') {
-  window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
+// Falsy during SSR, when remote config samples this device out, or on init
+// failure, so tests can assert on the global's absence.
+if (sdkControl) {
+  window.EMBRACE_SDK = sdkControl;
 }

--- a/tests/integration/platforms/vite-6/src/otel.ts
+++ b/tests/integration/platforms/vite-6/src/otel.ts
@@ -1,4 +1,4 @@
-import { DiagLogLevel, initSDK, session } from '@embrace-io/web-sdk';
+import { DiagLogLevel, initSDK } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace';
 
@@ -18,12 +18,18 @@ const sdkControl = initSDK({
   },
 });
 
+// Playwright drives the SDK through this global: page.evaluate runs in the page
+// realm and cannot reach the bundle's module scope.
 declare global {
   interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
+    EMBRACE_SDK: Exclude<ReturnType<typeof initSDK>, false>;
   }
 }
 
-window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
+// Falsy during SSR, when remote config samples this device out, or on init
+// failure, so tests can assert on the global's absence.
+if (sdkControl) {
+  window.EMBRACE_SDK = sdkControl;
+}
 
 export { sdkControl };

--- a/tests/integration/platforms/vite-7/src/otel.ts
+++ b/tests/integration/platforms/vite-7/src/otel.ts
@@ -1,4 +1,4 @@
-import { DiagLogLevel, initSDK, session } from '@embrace-io/web-sdk';
+import { DiagLogLevel, initSDK } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace';
 
@@ -17,12 +17,18 @@ const sdkControl = initSDK({
   },
 });
 
+// Playwright drives the SDK through this global: page.evaluate runs in the page
+// realm and cannot reach the bundle's module scope.
 declare global {
   interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
+    EMBRACE_SDK: Exclude<ReturnType<typeof initSDK>, false>;
   }
 }
 
-window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
+// Falsy during SSR, when remote config samples this device out, or on init
+// failure, so tests can assert on the global's absence.
+if (sdkControl) {
+  window.EMBRACE_SDK = sdkControl;
+}
 
 export { sdkControl };

--- a/tests/integration/platforms/vite-react-router/src/otel.ts
+++ b/tests/integration/platforms/vite-react-router/src/otel.ts
@@ -1,4 +1,4 @@
-import { DiagLogLevel, initSDK, session } from '@embrace-io/web-sdk';
+import { DiagLogLevel, initSDK } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace';
 
@@ -17,12 +17,18 @@ const sdkControl = initSDK({
   },
 });
 
+// Playwright drives the SDK through this global: page.evaluate runs in the page
+// realm and cannot reach the bundle's module scope.
 declare global {
   interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
+    EMBRACE_SDK: Exclude<ReturnType<typeof initSDK>, false>;
   }
 }
 
-window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
+// Falsy during SSR, when remote config samples this device out, or on init
+// failure, so tests can assert on the global's absence.
+if (sdkControl) {
+  window.EMBRACE_SDK = sdkControl;
+}
 
 export { sdkControl };

--- a/tests/integration/platforms/vite-test-harness/src/otel.ts
+++ b/tests/integration/platforms/vite-test-harness/src/otel.ts
@@ -1,4 +1,4 @@
-import { DiagLogLevel, initSDK, session } from '@embrace-io/web-sdk';
+import { DiagLogLevel, initSDK } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace';
 
@@ -16,12 +16,18 @@ const sdkControl = initSDK({
   },
 });
 
+// Playwright drives the SDK through this global: page.evaluate runs in the page
+// realm and cannot reach the bundle's module scope.
 declare global {
   interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
+    EMBRACE_SDK: Exclude<ReturnType<typeof initSDK>, false>;
   }
 }
 
-window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
+// Falsy during SSR, when remote config samples this device out, or on init
+// failure, so tests can assert on the global's absence.
+if (sdkControl) {
+  window.EMBRACE_SDK = sdkControl;
+}
 
 export { sdkControl };

--- a/tests/integration/platforms/webpack-5/src/otel.ts
+++ b/tests/integration/platforms/webpack-5/src/otel.ts
@@ -1,4 +1,4 @@
-import { DiagLogLevel, initSDK, session } from '@embrace-io/web-sdk';
+import { DiagLogLevel, initSDK } from '@embrace-io/web-sdk';
 import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace';
 
@@ -18,12 +18,18 @@ const sdkControl = initSDK({
   },
 });
 
+// Playwright drives the SDK through this global: page.evaluate runs in the page
+// realm and cannot reach the bundle's module scope.
 declare global {
   interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
+    EMBRACE_SDK: Exclude<ReturnType<typeof initSDK>, false>;
   }
 }
 
-window.EMBRACE_CURRENT_USER_SESSION_ID = session.getUserSessionId();
+// Falsy during SSR, when remote config samples this device out, or on init
+// failure, so tests can assert on the global's absence.
+if (sdkControl) {
+  window.EMBRACE_SDK = sdkControl;
+}
 
 export { sdkControl };

--- a/tests/integration/tests/e2e-headed/soft-navigation-native.spec.ts
+++ b/tests/integration/tests/e2e-headed/soft-navigation-native.spec.ts
@@ -19,8 +19,8 @@ const test = testWithMockApi.extend<SPAFixture>({
   loadHome: async ({ page }, use) => {
     await use(async () => {
       await page.goto(BASE_URL);
-      await page.waitForFunction(
-        () => window.EMBRACE_CURRENT_USER_SESSION_ID !== null,
+      await page.waitForFunction(() =>
+        window.EMBRACE_SDK?.session.getUserSessionId(),
       );
     });
   },

--- a/tests/integration/tests/e2e-headed/soft-navigation-polyfill.spec.ts
+++ b/tests/integration/tests/e2e-headed/soft-navigation-polyfill.spec.ts
@@ -23,8 +23,8 @@ const test = testWithMockApi.extend<SPAFixture>({
   loadHome: async ({ page }, use) => {
     await use(async () => {
       await page.goto(BASE_URL);
-      await page.waitForFunction(
-        () => window.EMBRACE_CURRENT_USER_SESSION_ID !== null,
+      await page.waitForFunction(() =>
+        window.EMBRACE_SDK?.session.getUserSessionId(),
       );
     });
   },

--- a/tests/integration/tests/e2e/vite-react-router-tests.spec.ts
+++ b/tests/integration/tests/e2e/vite-react-router-tests.spec.ts
@@ -11,8 +11,8 @@ const test = testWithMockApi.extend<SPAFixture>({
   loadHome: async ({ page }, use) => {
     await use(async () => {
       await page.goto(BASE_URL);
-      await page.waitForFunction(
-        () => window.EMBRACE_CURRENT_USER_SESSION_ID !== null,
+      await page.waitForFunction(() =>
+        window.EMBRACE_SDK?.session.getUserSessionId(),
       );
     });
   },

--- a/tests/integration/types.ts
+++ b/tests/integration/types.ts
@@ -1,9 +1,3 @@
-declare global {
-  interface Window {
-    EMBRACE_CURRENT_USER_SESSION_ID: string | null;
-  }
-}
-
 type SessionPartInfo = {
   endReason?: string;
 };

--- a/tests/integration/utils/run-e2e-tests.ts
+++ b/tests/integration/utils/run-e2e-tests.ts
@@ -207,7 +207,7 @@ const runE2ETests = ({
     );
 
     testE2E(
-      'it should init the SDK if it is sampled out by remote config',
+      'it should init on first load then skip init on reload once remote config samples the device out',
       async ({
         page,
         navigateAndWaitUntilReady,
@@ -218,20 +218,18 @@ const runE2ETests = ({
           threshold: 0,
         });
         await navigateAndWaitUntilReady(url, numberOfExpectedSpans);
-        let currentUserSessionId: string | null =
-          await getCurrentUserSessionId();
 
         // First load works as expected as we don't wait for the remote config to be applied
-        testE2E.expect(currentUserSessionId).toHaveLength(32);
+        testE2E.expect(await getCurrentUserSessionId()).toHaveLength(32);
 
         await page.reload();
 
-        // After reload, the session id should not be set as it is sampled out
-        currentUserSessionId = await page.evaluate(
-          () => window.EMBRACE_CURRENT_USER_SESSION_ID,
-          {},
+        // Sampled out, so initSDK bails and returns false before building a
+        // control object, leaving the harness with nothing to expose.
+        const sdkInitialized = await page.evaluate(
+          () => window.EMBRACE_SDK !== undefined,
         );
-        testE2E.expect(currentUserSessionId).toBeFalsy();
+        testE2E.expect(sdkInitialized).toBe(false);
       },
     );
 

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -41,6 +41,20 @@ const SIMULATED_REQUEST_REGEX = /simulated/;
 const URL_ATTRIBUTE_KEYS = new Set(['http.url', 'url.full']);
 const NEXTJS_URL_SUFFIX_REGEX = /\/_clientMiddlewareManifest\.json$/;
 
+// Every platform harness hangs its initSDK return value here, since
+// page.evaluate cannot reach the bundle's module scope. Typed from source
+// rather than the built package so a typecheck does not require a build.
+declare global {
+  interface Window {
+    EMBRACE_SDK: Exclude<
+      ReturnType<
+        typeof import('../../../packages/web-sdk/src/index.ts').initSDK
+      >,
+      false
+    >;
+  }
+}
+
 type EmbraceDataRequest = {
   url: string;
   headers: Record<string, string>;
@@ -260,8 +274,8 @@ const testWithMockApi = base.extend<TestWithMockApi>({
   },
   getCurrentUserSessionId: async ({ page }, use) => {
     await use(async () => {
-      const userSessionId = await page.evaluate(
-        () => window.EMBRACE_CURRENT_USER_SESSION_ID,
+      const userSessionId = await page.evaluate(() =>
+        window.EMBRACE_SDK.session.getUserSessionId(),
       );
 
       if (!userSessionId) {


### PR DESCRIPTION
## What problem is this solving?

Playwright can only reach the SDK through a `window` global, because `page.evaluate` runs in the page realm and cannot see the bundle's module scope. The harnesses exposed a hand-picked global per need (`EMBRACE_CURRENT_USER_SESSION_ID`), declared identically in eleven files, and read through the static `session` proxy.

That routing hides a failure mode: an unset proxy delegate no-ops to `null`, so "SDK never initialized" and "SDK initialized and returned null" are indistinguishable. One test was silently relying on it.

## Short description of changes

- Each harness exposes its `initSDK` return value as a single `window.EMBRACE_SDK`. Tests reach whatever they need through it (`EMBRACE_SDK.session.getUserSessionId()`), so new hooks need no harness change.
- Typed as `Exclude<ReturnType<typeof initSDK>, false>`, derived from the value the harness already imports. `SDKControl` is not exported from the package index, so it cannot be named directly.
- Assignment is guarded by `if (sdkControl)`: `initSDK` returns `false` during SSR, when remote config samples the device out, and on init failure. The global then stays undefined, which is what makes absence assertable.
- Normalized the local name to `sdkControl` in the six Next harnesses, where `embraceWebSdk` collided with the `EmbraceWebSdk` component in the same file.
- `getCurrentUserSessionId` is now a live read rather than an init-time snapshot.

### The test this corrected

`initSDK` returns `false` when remote config samples the device out (`initSDK.ts:206`). The sampling test asserted a falsy session id, which the no-op proxy returned whether or not the SDK had initialized, so it never tested sampling. It now asserts the SDK is absent, and is renamed to describe the arc it walks: init on first load, then skip init on reload.

## How has this been tested?

- `npm run lint` and `npm run check` from the repo root: clean.
- Full integration suite on the combined stack: 327 passed, 72 skipped, 0 failed.

## Checklist

- [ ] Documentation added
- [x] Tests added
