### PR TITLE
build(integration): typecheck the platform harnesses

### DIFF
--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "check": "tsc",
+    "check-platforms": "for d in platforms/*/; do npm run check --prefix \"$d\" || exit 1; done",
     "install-dependencies": "bash scripts/installE2EPlatformDependencies.sh && npx playwright install --with-deps",
     "build-platforms": "npx tsx --test \"tests/build-platform/*.test.ts\" --test-timeout=20000 --test-concurrency=1",
     "test": "npx playwright test",

--- a/tests/integration/platforms/next-15-turbopack-app/package.json
+++ b/tests/integration/platforms/next-15-turbopack-app/package.json
@@ -2,6 +2,7 @@
   "name": "next-15-turbopack-app",
   "private": true,
   "scripts": {
+    "check": "tsc --noEmit",
     "dev": "next dev --turbopack",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
     "build:clean": "emb-rm .next",

--- a/tests/integration/platforms/next-15-turbopack-pages/package.json
+++ b/tests/integration/platforms/next-15-turbopack-pages/package.json
@@ -2,6 +2,7 @@
   "name": "next-15-turbopack-pages",
   "private": true,
   "scripts": {
+    "check": "tsc --noEmit",
     "dev": "next dev --turbopack",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
     "build:clean": "emb-rm .next",

--- a/tests/integration/platforms/next-15-webpack-app/package.json
+++ b/tests/integration/platforms/next-15-webpack-app/package.json
@@ -2,6 +2,7 @@
   "name": "next-15-webpack-app",
   "private": true,
   "scripts": {
+    "check": "tsc --noEmit",
     "dev": "next dev",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
     "build:clean": "emb-rm .next",

--- a/tests/integration/platforms/next-15-webpack-pages/package.json
+++ b/tests/integration/platforms/next-15-webpack-pages/package.json
@@ -2,6 +2,7 @@
   "name": "next-15-webpack-pages",
   "private": true,
   "scripts": {
+    "check": "tsc --noEmit",
     "dev": "next dev",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
     "build:clean": "emb-rm .next",

--- a/tests/integration/platforms/next-16-app/package.json
+++ b/tests/integration/platforms/next-16-app/package.json
@@ -2,6 +2,7 @@
   "name": "next-16-app",
   "private": true,
   "scripts": {
+    "check": "tsc --noEmit",
     "dev": "next dev",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
     "build:clean": "emb-rm .next",

--- a/tests/integration/platforms/next-16-pages/package.json
+++ b/tests/integration/platforms/next-16-pages/package.json
@@ -2,6 +2,7 @@
   "name": "next-16-pages",
   "private": true,
   "scripts": {
+    "check": "tsc --noEmit",
     "dev": "next dev",
     "build": "npm run build:clean && npm run build:es2020 && npm run process-sourcemaps",
     "build:clean": "emb-rm .next",

--- a/tests/integration/platforms/vite-6/package.json
+++ b/tests/integration/platforms/vite-6/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check": "tsc -b --force",
     "dev": "vite",
     "build": "npm run build:clean && npm run build:es2015",
     "build:clean": "emb-rm dist .sonda",

--- a/tests/integration/platforms/vite-7/package.json
+++ b/tests/integration/platforms/vite-7/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check": "tsc -b --force",
     "dev": "vite",
     "build": "npm run build:clean && npm run build:es2015",
     "build:clean": "emb-rm dist .sonda",

--- a/tests/integration/platforms/vite-react-router/package.json
+++ b/tests/integration/platforms/vite-react-router/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check": "tsc -b --force",
     "dev": "vite",
     "build": "npm run build:clean && npm run build:es2015",
     "build:clean": "npx rimraf dist",

--- a/tests/integration/platforms/vite-test-harness/package.json
+++ b/tests/integration/platforms/vite-test-harness/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check": "tsc -b --force",
     "dev": "vite",
     "build": "vite build"
   },

--- a/tests/integration/platforms/webpack-5/package.json
+++ b/tests/integration/platforms/webpack-5/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check": "tsc --noEmit",
     "dev": "webpack serve --config webpack.config.es2015.mjs --mode development",
     "build": "npm run build:clean && npm run build:es2015",
     "build:clean": "emb-rm dist .sonda",

--- a/tests/integration/platforms/webpack-5/tsconfig.json
+++ b/tests/integration/platforms/webpack-5/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "jsx": "react-jsx",
     "strict": true,
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true

--- a/tests/integration/turbo.json
+++ b/tests/integration/turbo.json
@@ -7,8 +7,16 @@
       "inputs": ["platforms/*/package.json", "../../package-lock.json"],
       "outputs": ["platforms/*/node_modules/**"]
     },
-    "build-platforms": {
+    "check-platforms": {
       "dependsOn": ["^build", "install-dependencies"],
+      "inputs": [
+        "platforms/*/src/**",
+        "platforms/*/tsconfig*.json",
+        "platforms/*/package.json"
+      ]
+    },
+    "build-platforms": {
+      "dependsOn": ["^build", "install-dependencies", "check-platforms"],
       "outputs": ["platforms/**/.next", "platforms/**/dist/**"]
     },
     "test": {


### PR DESCRIPTION
## What problem is this solving?

The eleven integration platform harnesses had no typecheck coverage. `next build` typechecks the six Next apps, but the vite and webpack builds strip types without checking them, so a type error in those five harnesses only surfaced as a runtime test failure, or not at all.

This was not hypothetical: a broken import in a harness survived a full `npm run check` earlier in this stack, because `tests/integration/tsconfig.json` excludes `platforms/`.

## Short description of changes

- A `check` script per platform: `tsc --noEmit`, or `tsc -b --force` for the four vite apps that use project references. `--force` because a cached `tsbuildinfo` otherwise hides regressions.
- `check-platforms` in `tests/integration/package.json` runs all eleven, wired as a turbo task that `build-platforms` depends on, so the integration run gates on it.
- Fixed `webpack-5/tsconfig.json`, where `moduleResolution: "Node"` (node10) is a hard error under the repo's TypeScript 6.0.3. Changed to `"Bundler"`, matching the other ten platforms and how webpack 5 actually resolves.

Left out deliberately: adding `platforms/` to the integration tsconfig. Each app needs its own JSX, module-resolution and framework types, so one shared program does not fit; each platform's existing tsconfig is the right unit.

## How has this been tested?

- `check-platforms`: all 11 harnesses typecheck.
- `npm run lint` and `npm run check` from the repo root: clean.

## Checklist

- [ ] Documentation added
- [ ] Tests added
