### PR TITLE
build(web-sdk): map react types in a check-only tsconfig so isolated installs resolve them

### DIFF
--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -25,7 +25,7 @@
     "test:manual": "npm run test -- --manual",
     "test:coverage": "npm run test -- --config=web-test-runner.coverage.config.js",
     "test:multiBrowsers": "npm run test -- --config=web-test-runner.multi-browser.config.js",
-    "check": "tsc && eslint --max-warnings 0",
+    "check": "tsc -p tsconfig.check.json && eslint --max-warnings 0",
     "check:dist": "eslint --max-warnings 0 --config eslint.dist.config.ts",
     "validate": "tsx scripts/validate.ts",
     "docs": "npx typedoc --readme none && touch docs/.nojekyll",

--- a/packages/web-sdk/tsconfig.check.json
+++ b/packages/web-sdk/tsconfig.check.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://www.schemastore.org/tsconfig.json",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // react-router's declaration files import react's types without declaring
+    // @types/react. Package managers with an out-of-repo store (isolated installs)
+    // make the hoisted copy unreachable from there, so map it explicitly. This lives
+    // outside tsconfig.json because Biome's useImportExtensions misreads a path-mapped
+    // bare specifier as a local file and rewrites 'react' imports to 'react.ts'
+    "paths": {
+      "react": ["../../node_modules/@types/react"]
+    }
+  }
+}


### PR DESCRIPTION
## What problem is this solving?

react-router 7's declaration files import `react` types without declaring `@types/react`, relying on hoisting. Package managers that keep their store outside the repo (pnpm-style isolated installs) make the hoisted copy unreachable from there, so `tsc` fails the web-sdk `check` task with TS7016 in react-router's `.d.mts` files. npm's `install-strategy=linked` store lives inside the repo, so npm never hits this.

## Short description of changes

- Add `tsconfig.check.json` extending `tsconfig.json` with a `paths` mapping for `react` to the hoisted `@types/react`
- Point the `check` script's `tsc` at it. The mapping is kept out of `tsconfig.json` because Biome's `useImportExtensions` misreads a path-mapped bare specifier as a local file and rewrites `'react'` imports to `'react.ts'`

## How has this been tested?

`npm run build` (includes `check`) and `npm run lint` pass on clean installs from both npm (`npm ci`) and an isolated-store package manager; `lint:fix` rewrites nothing.

## Checklist

- [ ] Documentation added
- [ ] Tests added