### PR TITLE
EMBR-13505 fix(max-scroll-depth): reset part state in finally and omit percent when the measured range is stale

### DIFF
--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -1,5 +1,8 @@
 import { SeverityNumber } from '@opentelemetry/api-logs';
-import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
+import type {
+  InMemoryLogRecordExporter,
+  LogRecordProcessor,
+} from '@opentelemetry/sdk-logs';
 import * as chai from 'chai';
 import {
   setupTestLogExporter,
@@ -64,7 +67,19 @@ describe('MaxScrollDepthInstrumentation', () => {
       [scrollRoot, 'clientHeight', () => viewportHeightValue],
       [scrollRoot, 'scrollWidth', () => HORIZONTAL_SIZE],
       [scrollRoot, 'clientWidth', () => HORIZONTAL_SIZE],
-      [document, 'scrollingElement', () => scrollRootValue],
+      [
+        document,
+        'scrollingElement',
+        () => {
+          // Armed by failNextMeasurement(); this is measureDocument's first DOM
+          // read, so it's the cheapest seam to make measureDocument() throw.
+          if (failNextMeasurementArmed) {
+            failNextMeasurementArmed = false;
+            throw new Error('injected measureDocument failure');
+          }
+          return scrollRootValue;
+        },
+      ],
     ];
     for (const [target, prop, get] of targets) {
       originalDescriptors.push({
@@ -110,12 +125,36 @@ describe('MaxScrollDepthInstrumentation', () => {
       .getFinishedLogRecords()
       .filter((l) => l.eventName === 'max-scroll-depth');
 
+  // Armed by failNextEmit(); placed ahead of the exporter in the processor
+  // chain so it can block a single log from reaching it without a real export failure.
+  let failNextEmitArmed = false;
+  const failingProcessor: LogRecordProcessor = {
+    onEmit: () => {
+      if (failNextEmitArmed) {
+        failNextEmitArmed = false;
+        throw new Error('injected onEmit failure');
+      }
+    },
+    forceFlush: () => Promise.resolve(),
+    shutdown: () => Promise.resolve(),
+  };
+  const failNextEmit = () => {
+    failNextEmitArmed = true;
+  };
+
+  let failNextMeasurementArmed = false;
+  const failNextMeasurement = () => {
+    failNextMeasurementArmed = true;
+  };
+
   before(() => {
     setupTestTraceExporter();
-    memoryExporter = setupTestLogExporter();
+    memoryExporter = setupTestLogExporter([failingProcessor]);
   });
 
   beforeEach(() => {
+    failNextEmitArmed = false;
+    failNextMeasurementArmed = false;
     memoryExporter.reset();
     const limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
     userSessionManager = new EmbraceUserSessionManager({
@@ -231,6 +270,89 @@ describe('MaxScrollDepthInstrumentation', () => {
     });
   });
 
+  it('does not leak part state into the next session part when the emit throws', () => {
+    scroll({ scrollY: 900, viewportHeight: 100, documentHeight: 1000 }); // furthest point reached this part
+    scroll({ scrollY: 100, viewportHeight: 100, documentHeight: 1000 }); // user scrolls back up before the part ends
+    failNextEmit();
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    // The throwing emit produced no log, but the reset must still have run.
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes['max_scroll_depth.pixels']).to.equal(100);
+    expect(logs[0].attributes['max_scroll_depth.did_scroll']).to.equal(false);
+  });
+
+  it('clamps the carried position to the measured scrollable range on overscroll past the bottom', () => {
+    // Safari rubber-bands past the true bottom (900) of this document.
+    scroll({ scrollY: 960, viewportHeight: 100, documentHeight: 1000 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    // Part 2: the rubber band has snapped back to the real bottom; the user never scrolls.
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    setGeometry({ scrollY: 900, viewportHeight: 100, documentHeight: 1000 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(2);
+    expect(logs[1].attributes['max_scroll_depth.pixels']).to.equal(900);
+    expect(logs[1].attributes['max_scroll_depth.percent']).to.equal(100);
+    expect(logs[1].attributes['max_scroll_depth.did_scroll']).to.equal(false);
+  });
+
+  it('does not leak the ratchet across a disabled gap', () => {
+    scroll({ scrollY: 900, viewportHeight: 100, documentHeight: 1000 }); // furthest point reached this part
+    scroll({ scrollY: 50, viewportHeight: 100, documentHeight: 1000 }); // user scrolls back up before disabling
+    instrumentation.disable();
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    }); // disabled: no listener, no log
+
+    // Part 2: re-enabled, the user stays put at 50 for the whole part.
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    instrumentation.enable();
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes['max_scroll_depth.pixels']).to.equal(50);
+    expect(logs[0].attributes['max_scroll_depth.percent']).to.equal(6);
+    expect(logs[0].attributes['max_scroll_depth.did_scroll']).to.equal(false);
+  });
+
+  it('does not leak part state into the next session part when measureDocument throws', () => {
+    scroll({ scrollY: 900, viewportHeight: 100, documentHeight: 1000 }); // furthest point reached this part
+    scroll({ scrollY: 100, viewportHeight: 100, documentHeight: 1000 }); // user scrolls back up before the part ends
+    failNextMeasurement();
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    // The failed measurement produced no log, but the reset must still have run.
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes['max_scroll_depth.pixels']).to.equal(100);
+    expect(logs[0].attributes['max_scroll_depth.did_scroll']).to.equal(false);
+  });
+
   it('clamps a rubber-band negative scroll position to the top, including across part ends', () => {
     // Safari reports a negative scroll position during rubber-band overscroll
     // past the top of the document, which is still the top.
@@ -265,7 +387,7 @@ describe('MaxScrollDepthInstrumentation', () => {
     });
   });
 
-  it('clamps the percentage to 100 when the scroll position exceeds the scrollable range', () => {
+  it('omits percent when the scroll position exceeds the measured scrollable range', () => {
     scroll({ scrollY: 1000, viewportHeight: 100, documentHeight: 1000 });
 
     userSessionManager.endSessionPartInternal({
@@ -274,13 +396,29 @@ describe('MaxScrollDepthInstrumentation', () => {
 
     const logs = getMaxScrollDepthLogs();
     expect(logs).to.have.lengthOf(1);
-    expect(logs[0].attributes).to.deep.equal({
-      'emb.type': 'emb.otel_log',
-      'max_scroll_depth.pixels': 1000,
-      'max_scroll_depth.percent': 100,
-      'max_scroll_depth.did_scroll': true,
-      'max_scroll_depth.document_height': 1000,
+    expect(logs[0].attributes).to.not.have.property('max_scroll_depth.percent');
+    expect(logs[0].attributes['max_scroll_depth.pixels']).to.equal(1000);
+    expect(logs[0].attributes['max_scroll_depth.document_height']).to.equal(
+      1000,
+    );
+  });
+
+  it('omits percent when the document shrank below the furthest point reached', () => {
+    scroll({ scrollY: 1500, viewportHeight: 100, documentHeight: 2000 });
+    // The document shrinks before the part ends: the measured range (300) no
+    // longer describes the document the user scrolled.
+    setGeometry({ scrollY: 1500, viewportHeight: 100, documentHeight: 400 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
     });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.not.have.property('max_scroll_depth.percent');
+    expect(logs[0].attributes['max_scroll_depth.pixels']).to.equal(1500);
+    expect(logs[0].attributes['max_scroll_depth.document_height']).to.equal(
+      400,
+    );
   });
 
   it('keeps every attribute when there is no scrolling element', () => {

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -476,6 +476,33 @@ describe('MaxScrollDepthInstrumentation', () => {
     });
   });
 
+  it('clamps a rubber-band negative position to the top when the frame is unmeasurable', () => {
+    // With no measurement to bound the carried position, only the top can be
+    // clamped; a part ending mid-bounce must still hand the next one 0, not -50.
+    scroll({ scrollY: -50, viewportHeight: 0, documentHeight: 1000 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(2);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 0,
+      'max_scroll_depth.did_scroll': true,
+    });
+    expect(logs[1].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 0,
+      'max_scroll_depth.did_scroll': false,
+    });
+  });
+
   it('reports the depth of a restored scroll offset the user never scrolled to', () => {
     // A reload or back navigation restores the scroll position without firing a
     // scroll event, and that depth was still reached.

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -434,6 +434,25 @@ describe('MaxScrollDepthInstrumentation', () => {
     );
   });
 
+  it('omits percent when the document shrank to an unscrollable height', () => {
+    scroll({ scrollY: 500, viewportHeight: 100, documentHeight: 1000 });
+    // The document now fits the viewport and the browser has clamped the live
+    // position to 0; the 500 reached is far beyond a rubber-band, so it is stale.
+    setGeometry({ scrollY: 0, viewportHeight: 100, documentHeight: 100 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 500,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 100,
+    });
+  });
+
   it('keeps every attribute when there is no scrolling element', () => {
     // scrollingElement is null in quirks mode when the body is potentially
     // scrollable. <html> stands in for the document there and the window knows

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -387,7 +387,9 @@ describe('MaxScrollDepthInstrumentation', () => {
     });
   });
 
-  it('omits percent when the scroll position exceeds the measured scrollable range', () => {
+  it('clamps percent to 100 on overscroll past the bottom', () => {
+    // Safari rubber-bands past the true bottom (900) by up to a viewport; the
+    // user did reach the bottom, so the excess is not a stale range.
     scroll({ scrollY: 1000, viewportHeight: 100, documentHeight: 1000 });
 
     userSessionManager.endSessionPartInternal({
@@ -396,11 +398,13 @@ describe('MaxScrollDepthInstrumentation', () => {
 
     const logs = getMaxScrollDepthLogs();
     expect(logs).to.have.lengthOf(1);
-    expect(logs[0].attributes).to.not.have.property('max_scroll_depth.percent');
-    expect(logs[0].attributes['max_scroll_depth.pixels']).to.equal(1000);
-    expect(logs[0].attributes['max_scroll_depth.document_height']).to.equal(
-      1000,
-    );
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 1000,
+      'max_scroll_depth.percent': 100,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 1000,
+    });
   });
 
   it('omits percent when the document shrank below the furthest point reached', () => {

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -306,9 +306,22 @@ describe('MaxScrollDepthInstrumentation', () => {
 
     const logs = getMaxScrollDepthLogs();
     expect(logs).to.have.lengthOf(2);
-    expect(logs[1].attributes['max_scroll_depth.pixels']).to.equal(900);
-    expect(logs[1].attributes['max_scroll_depth.percent']).to.equal(100);
-    expect(logs[1].attributes['max_scroll_depth.did_scroll']).to.equal(false);
+    // Part 1 reports the overscrolled position itself, clamped to 100 percent.
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 960,
+      'max_scroll_depth.percent': 100,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 1000,
+    });
+    // Part 2 starts from the real bottom, not the 960 the rubber band reported.
+    expect(logs[1].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 900,
+      'max_scroll_depth.percent': 100,
+      'max_scroll_depth.did_scroll': false,
+      'max_scroll_depth.document_height': 1000,
+    });
   });
 
   it('does not leak the ratchet across a disabled gap', () => {
@@ -418,20 +431,22 @@ describe('MaxScrollDepthInstrumentation', () => {
 
   it('omits percent when the document shrank below the furthest point reached', () => {
     scroll({ scrollY: 1500, viewportHeight: 100, documentHeight: 2000 });
-    // The document shrinks before the part ends: the measured range (300) no
-    // longer describes the document the user scrolled.
-    setGeometry({ scrollY: 1500, viewportHeight: 100, documentHeight: 400 });
+    // The document shrinks before the part ends and the browser clamps the live
+    // position to the new bottom; the measured range (300) no longer describes
+    // the document the user scrolled.
+    setGeometry({ scrollY: 300, viewportHeight: 100, documentHeight: 400 });
     userSessionManager.endSessionPartInternal({
       reason: 'web_foreground_inactivity',
     });
 
     const logs = getMaxScrollDepthLogs();
     expect(logs).to.have.lengthOf(1);
-    expect(logs[0].attributes).to.not.have.property('max_scroll_depth.percent');
-    expect(logs[0].attributes['max_scroll_depth.pixels']).to.equal(1500);
-    expect(logs[0].attributes['max_scroll_depth.document_height']).to.equal(
-      400,
-    );
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 1500,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 400,
+    });
   });
 
   it('omits percent when the document shrank to an unscrollable height', () => {

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -319,7 +319,12 @@ describe('MaxScrollDepthInstrumentation', () => {
       reason: 'web_foreground_inactivity',
     }); // disabled: no listener, no log
 
-    // Part 2: re-enabled, the user stays put at 50 for the whole part.
+    // The user keeps scrolling while disabled; with no listener attached, neither
+    // the 700 nor the disable-time 50 may be credited to the next part.
+    setGeometry({ scrollY: 700, viewportHeight: 100, documentHeight: 1000 });
+    setGeometry({ scrollY: 20, viewportHeight: 100, documentHeight: 1000 });
+
+    // Part 2: re-enabled, the user stays put at 20 for the whole part.
     userSessionManager.startSessionPartInternal({ reason: 'init' });
     instrumentation.enable();
     userSessionManager.endSessionPartInternal({
@@ -328,9 +333,13 @@ describe('MaxScrollDepthInstrumentation', () => {
 
     const logs = getMaxScrollDepthLogs();
     expect(logs).to.have.lengthOf(1);
-    expect(logs[0].attributes['max_scroll_depth.pixels']).to.equal(50);
-    expect(logs[0].attributes['max_scroll_depth.percent']).to.equal(6);
-    expect(logs[0].attributes['max_scroll_depth.did_scroll']).to.equal(false);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 20,
+      'max_scroll_depth.percent': 2,
+      'max_scroll_depth.did_scroll': false,
+      'max_scroll_depth.document_height': 1000,
+    });
   });
 
   it('does not leak part state into the next session part when measureDocument throws', () => {

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -71,8 +71,8 @@ describe('MaxScrollDepthInstrumentation', () => {
         document,
         'scrollingElement',
         () => {
-          // Armed by failNextMeasurement(); this is measureDocument's first DOM
-          // read, so it's the cheapest seam to make measureDocument() throw.
+          // Armed by failNextMeasurement(); scrollingElement is the earliest
+          // measureDocument read this stub already owns, so it is the cheapest seam.
           if (failNextMeasurementArmed) {
             failNextMeasurementArmed = false;
             throw new Error('injected measureDocument failure');

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -1,5 +1,8 @@
 import { SeverityNumber } from '@opentelemetry/api-logs';
-import type { InMemoryLogRecordExporter } from '@opentelemetry/sdk-logs';
+import type {
+  InMemoryLogRecordExporter,
+  LogRecordProcessor,
+} from '@opentelemetry/sdk-logs';
 import * as chai from 'chai';
 import {
   setupTestLogExporter,
@@ -64,7 +67,19 @@ describe('MaxScrollDepthInstrumentation', () => {
       [scrollRoot, 'clientHeight', () => viewportHeightValue],
       [scrollRoot, 'scrollWidth', () => HORIZONTAL_SIZE],
       [scrollRoot, 'clientWidth', () => HORIZONTAL_SIZE],
-      [document, 'scrollingElement', () => scrollRootValue],
+      [
+        document,
+        'scrollingElement',
+        () => {
+          // Armed by failNextMeasurement(); scrollingElement is the earliest
+          // measureDocument read this stub already owns, so it is the cheapest seam.
+          if (failNextMeasurementArmed) {
+            failNextMeasurementArmed = false;
+            throw new Error('injected measureDocument failure');
+          }
+          return scrollRootValue;
+        },
+      ],
     ];
     for (const [target, prop, get] of targets) {
       originalDescriptors.push({
@@ -110,12 +125,36 @@ describe('MaxScrollDepthInstrumentation', () => {
       .getFinishedLogRecords()
       .filter((l) => l.eventName === 'max-scroll-depth');
 
+  // Armed by failNextEmit(); placed ahead of the exporter in the processor
+  // chain so it can block a single log from reaching it without a real export failure.
+  let failNextEmitArmed = false;
+  const failingProcessor: LogRecordProcessor = {
+    onEmit: () => {
+      if (failNextEmitArmed) {
+        failNextEmitArmed = false;
+        throw new Error('injected onEmit failure');
+      }
+    },
+    forceFlush: () => Promise.resolve(),
+    shutdown: () => Promise.resolve(),
+  };
+  const failNextEmit = () => {
+    failNextEmitArmed = true;
+  };
+
+  let failNextMeasurementArmed = false;
+  const failNextMeasurement = () => {
+    failNextMeasurementArmed = true;
+  };
+
   before(() => {
     setupTestTraceExporter();
-    memoryExporter = setupTestLogExporter();
+    memoryExporter = setupTestLogExporter([failingProcessor]);
   });
 
   beforeEach(() => {
+    failNextEmitArmed = false;
+    failNextMeasurementArmed = false;
     memoryExporter.reset();
     const limitManager = new EmbraceLimitManager(DEFAULT_LIMITS);
     userSessionManager = new EmbraceUserSessionManager({
@@ -231,6 +270,123 @@ describe('MaxScrollDepthInstrumentation', () => {
     });
   });
 
+  it('does not leak part state into the next session part when the emit throws', () => {
+    // The rubber band leaves the live position past the true bottom (900), so
+    // the seed left behind shows whether the reset kept the measurement it took.
+    scroll({ scrollY: 960, viewportHeight: 100, documentHeight: 1000 });
+    failNextEmit();
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    // Part 2 ends unmeasurable, so nothing bounds its depth at emit and the
+    // position carried out of the throwing emit is the only thing deciding it.
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    setGeometry({ scrollY: 0, viewportHeight: 0, documentHeight: 1000 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    // The throwing emit produced no log, but the reset must still have run.
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 900,
+      'max_scroll_depth.did_scroll': false,
+    });
+  });
+
+  it('clamps the carried position to the measured scrollable range on overscroll past the bottom', () => {
+    // Safari rubber-bands past the true bottom (900) of this document.
+    scroll({ scrollY: 960, viewportHeight: 100, documentHeight: 1000 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    // Part 2 ends unmeasurable, so nothing bounds its depth at emit and the
+    // position carried out of part 1 is the only thing deciding what it reports.
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    setGeometry({ scrollY: 900, viewportHeight: 0, documentHeight: 1000 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(2);
+    // Part 1 reports the real bottom, not the 960 the rubber band reported.
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 900,
+      'max_scroll_depth.percent': 100,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 1000,
+    });
+    // Part 2 was handed the clamped 900, so the 960 never reaches a second log.
+    expect(logs[1].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 900,
+      'max_scroll_depth.did_scroll': false,
+    });
+  });
+
+  it('does not leak the ratchet across a disabled gap', () => {
+    scroll({ scrollY: 900, viewportHeight: 100, documentHeight: 1000 }); // furthest point reached this part
+    scroll({ scrollY: 50, viewportHeight: 100, documentHeight: 1000 }); // user scrolls back up before disabling
+    instrumentation.disable();
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    }); // disabled: no listener, no log
+
+    // The user keeps scrolling while disabled. Real events here also prove the
+    // listener is gone: neither the 900 already tracked, nor the 700, nor the
+    // disable-time 50 may be credited to the next part.
+    scroll({ scrollY: 700, viewportHeight: 100, documentHeight: 1000 });
+    scroll({ scrollY: 20, viewportHeight: 100, documentHeight: 1000 });
+
+    // Part 2: re-enabled, the user stays put at 20 for the whole part.
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    instrumentation.enable();
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 20,
+      'max_scroll_depth.percent': 2,
+      'max_scroll_depth.did_scroll': false,
+      'max_scroll_depth.document_height': 1000,
+    });
+  });
+
+  it('does not leak part state into the next session part when measureDocument throws', () => {
+    scroll({ scrollY: 900, viewportHeight: 100, documentHeight: 1000 }); // furthest point reached this part
+    scroll({ scrollY: 100, viewportHeight: 100, documentHeight: 1000 }); // user scrolls back up before the part ends
+    failNextMeasurement();
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    // The failed measurement produced no log, but the reset must still have run.
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 100,
+      'max_scroll_depth.percent': 11,
+      'max_scroll_depth.did_scroll': false,
+      'max_scroll_depth.document_height': 1000,
+    });
+  });
+
   it('clamps a rubber-band negative scroll position to the top, including across part ends', () => {
     // Safari reports a negative scroll position during rubber-band overscroll
     // past the top of the document, which is still the top.
@@ -265,8 +421,32 @@ describe('MaxScrollDepthInstrumentation', () => {
     });
   });
 
-  it('clamps the percentage to 100 when the scroll position exceeds the scrollable range', () => {
+  it('reports the reachable bottom on overscroll past it', () => {
+    // The position sits past the true bottom (900) but within the document, so
+    // the user did reach the bottom and the excess is overscroll, not staleness.
     scroll({ scrollY: 1000, viewportHeight: 100, documentHeight: 1000 });
+
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    // The reported pixels sit at the true bottom of the scrollable range, not at
+    // the overscrolled offset, so percent reaches 100 without being capped.
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 900,
+      'max_scroll_depth.percent': 100,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 1000,
+    });
+  });
+
+  it('omits percent when the last reachable position is one pixel past the document', () => {
+    // One pixel beyond the whole document is past anything overscroll can reach
+    // inside it, which is the boundary the test above sits on the other side of.
+    scroll({ scrollY: 1001, viewportHeight: 100, documentHeight: 1000 });
 
     userSessionManager.endSessionPartInternal({
       reason: 'web_foreground_inactivity',
@@ -276,10 +456,124 @@ describe('MaxScrollDepthInstrumentation', () => {
     expect(logs).to.have.lengthOf(1);
     expect(logs[0].attributes).to.deep.equal({
       'emb.type': 'emb.otel_log',
-      'max_scroll_depth.pixels': 1000,
+      'max_scroll_depth.pixels': 1001,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 1000,
+    });
+  });
+
+  it('omits percent when a depth was reached in a document that no longer scrolls', () => {
+    scroll({ scrollY: 80, viewportHeight: 100, documentHeight: 300 });
+    // The document shrinks to fit the viewport, so it has no range at all. The
+    // 80 was reached, so reporting 0 percent beside it would contradict pixels.
+    setGeometry({ scrollY: 0, viewportHeight: 100, documentHeight: 100 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 80,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 100,
+    });
+  });
+
+  it('takes percent against the document measured at part end when it grew', () => {
+    scroll({ scrollY: 450, viewportHeight: 100, documentHeight: 1000 });
+    // A feed appends while the part is open. Growth cannot make the range stale,
+    // so percent rescales against the larger document rather than being omitted.
+    setGeometry({ scrollY: 450, viewportHeight: 100, documentHeight: 3000 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 450,
+      // scrollable range = 3000 - 100 = 2900; 450 / 2900 = 16%
+      'max_scroll_depth.percent': 16,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 3000,
+    });
+  });
+
+  it('keeps the tracked depth when enable is called again mid-part', () => {
+    // onEnable seeds the tracked depth, so the base class guard against
+    // re-entering it is what stops a redundant enable() erasing an open part.
+    scroll({ scrollY: 900, viewportHeight: 100, documentHeight: 1000 });
+    scroll({ scrollY: 100, viewportHeight: 100, documentHeight: 1000 });
+    instrumentation.enable();
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 900,
       'max_scroll_depth.percent': 100,
       'max_scroll_depth.did_scroll': true,
       'max_scroll_depth.document_height': 1000,
+    });
+  });
+
+  it('omits percent when the document shrank below the furthest point reached', () => {
+    scroll({ scrollY: 1500, viewportHeight: 100, documentHeight: 2000 });
+    // The document shrinks before the part ends and the browser rubber-bands the
+    // live position past the new bottom (300); the measured range no longer
+    // describes the document the user scrolled.
+    setGeometry({ scrollY: 380, viewportHeight: 100, documentHeight: 400 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    // Part 2 ends unmeasurable, so the position carried out of the stale emit is
+    // the only thing deciding what it reports.
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    setGeometry({ scrollY: 0, viewportHeight: 0, documentHeight: 400 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(2);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 1500,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 400,
+    });
+    // A range too stale to bound the depth at emit still bounds the seed, so the
+    // 380 does not carry and part 2 starts from the new bottom.
+    expect(logs[1].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 300,
+      'max_scroll_depth.did_scroll': false,
+    });
+  });
+
+  it('omits percent when the document shrank to an unscrollable height', () => {
+    scroll({ scrollY: 500, viewportHeight: 100, documentHeight: 1000 });
+    // The document now fits the viewport and the browser has clamped the live
+    // position to 0; the 500 reached is far beyond a rubber-band, so it is stale.
+    setGeometry({ scrollY: 0, viewportHeight: 100, documentHeight: 100 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 500,
+      'max_scroll_depth.did_scroll': true,
+      'max_scroll_depth.document_height': 100,
     });
   });
 
@@ -325,9 +619,36 @@ describe('MaxScrollDepthInstrumentation', () => {
     });
   });
 
+  it('clamps a rubber-band negative position to the top when the frame is unmeasurable', () => {
+    // With no measurement to bound the carried position, only the top can be
+    // clamped; a part ending mid-bounce must still hand the next one 0, not -50.
+    scroll({ scrollY: -50, viewportHeight: 0, documentHeight: 1000 });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    userSessionManager.endSessionPartInternal({
+      reason: 'web_foreground_inactivity',
+    });
+
+    const logs = getMaxScrollDepthLogs();
+    expect(logs).to.have.lengthOf(2);
+    expect(logs[0].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 0,
+      'max_scroll_depth.did_scroll': true,
+    });
+    expect(logs[1].attributes).to.deep.equal({
+      'emb.type': 'emb.otel_log',
+      'max_scroll_depth.pixels': 0,
+      'max_scroll_depth.did_scroll': false,
+    });
+  });
+
   it('reports the depth of a restored scroll offset the user never scrolled to', () => {
-    // A reload or back navigation restores the scroll position without firing a
-    // scroll event, and that depth was still reached.
+    // The position can already be past 0 with no scroll event delivered to this
+    // listener, and that depth was still reached.
     setGeometry({ scrollY: 800, viewportHeight: 100, documentHeight: 1000 });
 
     userSessionManager.endSessionPartInternal({

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -31,8 +31,6 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
 
     this._onScrollHandler = (): void => {
       try {
-        // The handler only reads scrollY; the layout-forcing document
-        // measurement is deferred to part end, once per part rather than per event.
         const scrollY = window.scrollY;
         if (scrollY > this._maxScrollY) {
           this._maxScrollY = scrollY;

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -81,6 +81,9 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
       // document geometry forces a layout reflow.
       // https://developer.chrome.com/docs/performance/insights/forced-reflow
       measurement = measureDocument();
+      const percent = measurement
+        ? this._scrollPercent(measurement)
+        : undefined;
 
       this.logger.emit({
         eventName: MAX_SCROLL_DEPTH_EVENT_NAME,
@@ -95,14 +98,9 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
           // the scroll position alone, so it stands on its own.
           ...(measurement
             ? {
-                // A depth beyond the range can come from overscroll, a shrunk
-                // document, or a carried-over position; omit percent rather than fabricate it.
-                ...(this._maxScrollY <= measurement.scrollableHeight
-                  ? {
-                      [ATTR_MAX_SCROLL_DEPTH_PERCENT]:
-                        this._scrollPercent(measurement),
-                    }
-                  : {}),
+                ...(percent === undefined
+                  ? {}
+                  : { [ATTR_MAX_SCROLL_DEPTH_PERCENT]: percent }),
                 [ATTR_MAX_SCROLL_DEPTH_DOCUMENT_HEIGHT]:
                   measurement.documentHeight,
               }
@@ -125,12 +123,31 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
       : Math.max(0, window.scrollY);
   }
 
-  private _scrollPercent({ scrollableHeight }: DocumentMeasurement): number {
+  private _scrollPercent({
+    scrollableHeight,
+    viewportHeight,
+  }: DocumentMeasurement): number | undefined {
+    // Rubber-band overscroll cannot carry the content further than its own
+    // viewport, so a larger excess means the document shrank since the depth was
+    // reached; the range no longer describes it, so omit rather than fabricate.
+    const overshoot = this._maxScrollY - scrollableHeight;
+    if (overshoot > viewportHeight) {
+      this._diag.debug('omitting max-scroll-depth percent, range is stale', {
+        maxScrollY: this._maxScrollY,
+        scrollableHeight,
+        viewportHeight,
+      });
+      return undefined;
+    }
+
     if (scrollableHeight === 0) {
       // The document fits the viewport, so there was no depth to reach.
       return 0;
     }
 
-    return Math.round((this._maxScrollY / scrollableHeight) * 100);
+    return Math.min(
+      100,
+      Math.round((this._maxScrollY / scrollableHeight) * 100),
+    );
   }
 }

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -13,7 +13,7 @@ import {
 import type { MaxScrollDepthInstrumentationArgs } from './types.ts';
 
 /*
-  Tracks how far the user scrolls during and emits telemetry when the session part ends
+  Tracks how far the user scrolls during a session part and emits telemetry when the part ends
 */
 export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
   private readonly _onScrollHandler: () => void;
@@ -31,7 +31,8 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
 
     this._onScrollHandler = (): void => {
       try {
-        // Reading scrollY here does not force a layout, so the work the listener does can stay minimal.
+        // The handler only reads scrollY; the layout-forcing document
+        // measurement is deferred to part end, once per part rather than per event.
         const scrollY = window.scrollY;
         if (scrollY > this._maxScrollY) {
           this._maxScrollY = scrollY;
@@ -62,46 +63,66 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
 
   public override onDisable(): void {
     window.removeEventListener('scroll', this._onScrollHandler);
+    // A disabled window must not credit its depth to whichever part is open
+    // when the instrumentation comes back on.
+    this._resetTracking(null);
   }
 
   private _emit(): void {
-    // The scroll position is readable at any time, so a document that loaded at
-    // a restored offset has already reached that depth even though no scroll
-    // event ever fired for it.
-    this._maxScrollY = Math.max(this._maxScrollY, window.scrollY);
+    let measurement: DocumentMeasurement | null = null;
 
-    // Measure once here rather than on every scroll event, since reading
-    // document geometry forces a layout reflow.
-    // https://developer.chrome.com/docs/performance/insights/forced-reflow
-    const measurement = measureDocument();
+    try {
+      // The scroll position is readable at any time, so an offset set before
+      // this listener attached (e.g. a scroll restoration racing SDK init) is
+      // still caught here.
+      this._maxScrollY = Math.max(this._maxScrollY, window.scrollY);
 
-    this.logger.emit({
-      eventName: MAX_SCROLL_DEPTH_EVENT_NAME,
-      severityNumber: SeverityNumber.INFO,
-      attributes: {
-        [KEY_EMB_TYPE]: EMB_TYPES.OTelLog,
-        [ATTR_MAX_SCROLL_DEPTH_PIXELS]: this._maxScrollY,
-        [ATTR_MAX_SCROLL_DEPTH_DID_SCROLL]: this._hasScrolled,
-        // Depth as a percentage needs a viewport, which a document or a frame
-        // can lack. Omit it and the height together in that case so consumers
-        // read absence rather than a fabricated 0. The pixel depth comes from
-        // the scroll position alone, so it stands on its own.
-        ...(measurement
-          ? {
-              [ATTR_MAX_SCROLL_DEPTH_PERCENT]: this._scrollPercent(measurement),
-              [ATTR_MAX_SCROLL_DEPTH_DOCUMENT_HEIGHT]:
-                measurement.documentHeight,
-            }
-          : {}),
-      },
-    });
+      // Measure once here rather than on every scroll event, since reading
+      // document geometry forces a layout reflow.
+      // https://developer.chrome.com/docs/performance/insights/forced-reflow
+      measurement = measureDocument();
 
-    // Initial state for the next part will be wherever the user left off the
-    // scroll position, clamped because Safari reports a negative position past
-    // the top of the document during rubber-band overscroll, which is still the
-    // top. https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
+      this.logger.emit({
+        eventName: MAX_SCROLL_DEPTH_EVENT_NAME,
+        severityNumber: SeverityNumber.INFO,
+        attributes: {
+          [KEY_EMB_TYPE]: EMB_TYPES.OTelLog,
+          [ATTR_MAX_SCROLL_DEPTH_PIXELS]: this._maxScrollY,
+          [ATTR_MAX_SCROLL_DEPTH_DID_SCROLL]: this._hasScrolled,
+          // Depth as a percentage needs a viewport, which a document or a frame
+          // can lack. Omit it and the height together in that case so consumers
+          // read absence rather than a fabricated 0. The pixel depth comes from
+          // the scroll position alone, so it stands on its own.
+          ...(measurement
+            ? {
+                // A depth beyond the range can come from overscroll, a shrunk
+                // document, or a carried-over position; omit percent rather than fabricate it.
+                ...(this._maxScrollY <= measurement.scrollableHeight
+                  ? {
+                      [ATTR_MAX_SCROLL_DEPTH_PERCENT]:
+                        this._scrollPercent(measurement),
+                    }
+                  : {}),
+                [ATTR_MAX_SCROLL_DEPTH_DOCUMENT_HEIGHT]:
+                  measurement.documentHeight,
+              }
+            : {}),
+        },
+      });
+    } finally {
+      this._resetTracking(measurement);
+    }
+  }
+
+  // Initial state for the next part is wherever the user left off, bounded by
+  // the measured range: Safari can report a position past either edge during
+  // rubber-band overscroll, which the next part's document cannot hold.
+  // https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
+  private _resetTracking(measurement: DocumentMeasurement | null): void {
     this._hasScrolled = false;
-    this._maxScrollY = Math.max(0, window.scrollY);
+    this._maxScrollY = measurement
+      ? Math.max(0, Math.min(window.scrollY, measurement.scrollableHeight))
+      : Math.max(0, window.scrollY);
   }
 
   private _scrollPercent({ scrollableHeight }: DocumentMeasurement): number {
@@ -110,12 +131,6 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
       return 0;
     }
 
-    // The furthest point reached can exceed the range measured at part end: the
-    // document may have shrunk since, or the position came from overscroll past
-    // the bottom.
-    return Math.min(
-      100,
-      Math.round((this._maxScrollY / scrollableHeight) * 100),
-    );
+    return Math.round((this._maxScrollY / scrollableHeight) * 100);
   }
 }

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -92,10 +92,8 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
           [KEY_EMB_TYPE]: EMB_TYPES.OTelLog,
           [ATTR_MAX_SCROLL_DEPTH_PIXELS]: this._maxScrollY,
           [ATTR_MAX_SCROLL_DEPTH_DID_SCROLL]: this._hasScrolled,
-          // Depth as a percentage needs a viewport, which a document or a frame
-          // can lack. Omit it and the height together in that case so consumers
-          // read absence rather than a fabricated 0. The pixel depth comes from
-          // the scroll position alone, so it stands on its own.
+          // Absent beats a fabricated 0: percent needs a viewport and a current
+          // range, the height needs a viewport, and pixels need neither.
           ...(measurement
             ? {
                 ...(percent === undefined

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -110,9 +110,8 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  // Initial state for the next part is wherever the user left off, bounded by
-  // the measured range: Safari can report a position past either edge during
-  // rubber-band overscroll, which the next part's document cannot hold.
+  // Seeds tracking from the live position. Safari reports a position past either
+  // edge mid-bounce, so it is bounded by the range when known, else only at the top.
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
   private _resetTracking(measurement: DocumentMeasurement | null): void {
     this._hasScrolled = false;

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -49,6 +49,9 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
   }
 
   public override onEnable(): void {
+    // Depth accrued before a disabled gap must not be credited to whichever
+    // part is open when tracking resumes, so the seed is taken here, not at disable.
+    this._resetTracking(null);
     window.addEventListener('scroll', this._onScrollHandler, { passive: true });
     this.setSessionPartListeners({
       end: () => {
@@ -63,9 +66,6 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
 
   public override onDisable(): void {
     window.removeEventListener('scroll', this._onScrollHandler);
-    // A disabled window must not credit its depth to whichever part is open
-    // when the instrumentation comes back on.
-    this._resetTracking(null);
   }
 
   private _emit(): void {

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -13,7 +13,7 @@ import {
 import type { MaxScrollDepthInstrumentationArgs } from './types.ts';
 
 /*
-  Tracks how far the user scrolls during and emits telemetry when the session part ends
+  Tracks how far the user scrolls during a session part and emits telemetry when the part ends
 */
 export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
   private readonly _onScrollHandler: () => void;
@@ -31,7 +31,6 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
 
     this._onScrollHandler = (): void => {
       try {
-        // Reading scrollY here does not force a layout, so the work the listener does can stay minimal.
         const scrollY = window.scrollY;
         if (scrollY > this._maxScrollY) {
           this._maxScrollY = scrollY;
@@ -48,6 +47,9 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
   }
 
   public override onEnable(): void {
+    // Depth accrued before a disabled gap must not be credited to whichever
+    // part is open when tracking resumes, so the seed is taken here, not at disable.
+    this._resetTracking(null);
     window.addEventListener('scroll', this._onScrollHandler, { passive: true });
     this.setSessionPartListeners({
       end: () => {
@@ -65,54 +67,87 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
   }
 
   private _emit(): void {
-    // The scroll position is readable at any time, so a document that loaded at
-    // a restored offset has already reached that depth even though no scroll
-    // event ever fired for it.
-    this._maxScrollY = Math.max(this._maxScrollY, window.scrollY);
+    let measurement: DocumentMeasurement | null = null;
 
-    // Measure once here rather than on every scroll event, since reading
-    // document geometry forces a layout reflow.
-    // https://developer.chrome.com/docs/performance/insights/forced-reflow
-    const measurement = measureDocument();
+    try {
+      // Scroll events are delivered at a rendering opportunity, so a position
+      // reached just before the part ended may not have arrived at the listener.
+      this._maxScrollY = Math.max(this._maxScrollY, window.scrollY);
 
-    this.logger.emit({
-      eventName: MAX_SCROLL_DEPTH_EVENT_NAME,
-      severityNumber: SeverityNumber.INFO,
-      attributes: {
-        [KEY_EMB_TYPE]: EMB_TYPES.OTelLog,
-        [ATTR_MAX_SCROLL_DEPTH_PIXELS]: this._maxScrollY,
-        [ATTR_MAX_SCROLL_DEPTH_DID_SCROLL]: this._hasScrolled,
-        // Depth as a percentage needs a viewport, which a document or a frame
-        // can lack. Omit it and the height together in that case so consumers
-        // read absence rather than a fabricated 0. The pixel depth comes from
-        // the scroll position alone, so it stands on its own.
-        ...(measurement
-          ? {
-              [ATTR_MAX_SCROLL_DEPTH_PERCENT]: this._scrollPercent(measurement),
-              [ATTR_MAX_SCROLL_DEPTH_DOCUMENT_HEIGHT]:
-                measurement.documentHeight,
-            }
-          : {}),
-      },
-    });
+      // Measure once here rather than on every scroll event, since reading
+      // document geometry forces a layout reflow.
+      // https://developer.chrome.com/docs/performance/insights/forced-reflow
+      measurement = measureDocument();
+      const percent = measurement
+        ? this._scrollPercent(measurement)
+        : undefined;
 
-    // Initial state for the next part will be wherever the user left off the
-    // scroll position, clamped because Safari reports a negative position past
-    // the top of the document during rubber-band overscroll, which is still the
-    // top. https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
-    this._hasScrolled = false;
-    this._maxScrollY = Math.max(0, window.scrollY);
+      // Overscroll moves the position past the range without the content
+      // following, so the depth is bounded once a range is known to describe the
+      // document. A range too stale to carry a percent bounds nothing.
+      if (measurement && percent !== undefined) {
+        this._maxScrollY = Math.min(
+          this._maxScrollY,
+          measurement.scrollableHeight,
+        );
+      }
+
+      this.logger.emit({
+        eventName: MAX_SCROLL_DEPTH_EVENT_NAME,
+        severityNumber: SeverityNumber.INFO,
+        attributes: {
+          [KEY_EMB_TYPE]: EMB_TYPES.OTelLog,
+          [ATTR_MAX_SCROLL_DEPTH_PIXELS]: this._maxScrollY,
+          [ATTR_MAX_SCROLL_DEPTH_DID_SCROLL]: this._hasScrolled,
+          // Absent beats a fabricated 0: percent needs a viewport and a current
+          // range, the height needs a viewport, and pixels need neither.
+          ...(measurement
+            ? {
+                ...(percent === undefined
+                  ? {}
+                  : { [ATTR_MAX_SCROLL_DEPTH_PERCENT]: percent }),
+                [ATTR_MAX_SCROLL_DEPTH_DOCUMENT_HEIGHT]:
+                  measurement.documentHeight,
+              }
+            : {}),
+        },
+      });
+    } finally {
+      this._resetTracking(measurement);
+    }
   }
 
-  private _scrollPercent({ scrollableHeight }: DocumentMeasurement): number {
+  // Seeds tracking from the live position. Safari reports a position past either
+  // edge mid-bounce, so it is bounded by the range when known, else only at the top.
+  // https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
+  private _resetTracking(measurement: DocumentMeasurement | null): void {
+    const scrollY = window.scrollY;
+    this._maxScrollY = measurement
+      ? Math.max(0, Math.min(scrollY, measurement.scrollableHeight))
+      : Math.max(0, scrollY);
+    this._hasScrolled = false;
+  }
+
+  private _scrollPercent({
+    documentHeight,
+    scrollableHeight,
+  }: DocumentMeasurement): number | undefined {
+    // The depth has to be explicable by the document measured here: within it
+    // while it still scrolls, and nowhere at all once it does not. Beyond that
+    // the document shrank and the range describes a different one.
+    const reachableBound = scrollableHeight === 0 ? 0 : documentHeight;
+    if (this._maxScrollY > reachableBound) {
+      this._diag.debug(
+        `omitting max-scroll-depth percent, range is stale: reached ${String(this._maxScrollY)} past a bound of ${String(reachableBound)}`,
+      );
+      return undefined;
+    }
+
     if (scrollableHeight === 0) {
       // The document fits the viewport, so there was no depth to reach.
       return 0;
     }
 
-    // The furthest point reached can exceed the range measured at part end: the
-    // document may have shrunk since, or the position came from overscroll past
-    // the bottom.
     return Math.min(
       100,
       Math.round((this._maxScrollY / scrollableHeight) * 100),


### PR DESCRIPTION
## What problem is this solving?

Known issues 1 and 2 from #1442's review catalogue: a throwing part-end emit skips the state reset, so the next session part reports the previous part's `pixels` with `did_scroll = true` for a user who never scrolled; and `percent` is fabricated when the numerator (accumulated across the session part) and denominator (measured at part end) describe different documents.

## Short description of changes

- The part-end state reset moved into a `finally` that covers the whole measurement-and-emit path, so neither a throwing emit nor a throwing geometry read can leak one part's depth into the next.
- `percent` is omitted when the range cannot describe the depth: when the furthest point reached is past the whole measured document, or when any depth at all was reached in a document that no longer scrolls. The second case previously reported `percent: 0` beside a non-zero `pixels`, which contradicted itself on a single record. `document_height` is still emitted in both, a shape consumers did not see before.
- `pixels` reports the furthest *reachable* depth: it is clamped to the measured range whenever that range was trusted enough to carry a `percent`, so `pixels` never exceeds the range `percent` was taken against and the two cannot contradict each other on one record. They are not the same ratio, and are not meant to be: `percent` is taken against `document_height - viewport_height`, and `viewport_height` is not on the wire. A stale range is trusted for neither, so it clamps nothing and `pixels` stays raw there, where it can exceed `document_height`.
- Two adjacent leaks in the same class: the position carried into the next part is clamped to the measured range, and the tracked state is seeded when tracking resumes in `enable()`, so the peak accrued before a disabled gap is dropped and tracking restarts from the position live at `enable()`.
- Comment corrections: the `scrollY`-layout claim (false in Blink per the canonical forces-layout list), the restored-offset no-scroll-event claim (restores do fire scroll events; the emit-time read is justified by scroll events being delivered at a rendering opportunity, not by restoration), and one statement of the attribute presence contract. The staleness gate is expressed as the document bound it always was rather than as an iOS rubber-band magnitude, which is equivalent wherever the document still scrolls and needs no browser-behaviour claim to justify; the unscrollable case is where it deliberately differs, and that difference is the fix in bullet 2.

Residual, documented rather than fixed: an overshoot of one viewport or less past the new range still clamps `percent` to 100, and is undetectable downstream because the clamped record is identical to a genuine scroll to the bottom of the shrunken document; separating it from a released rubber-band needs a shrink signal, not a part-end measurement. `pixels` carried from a previous part can still describe a document that since changed (full invalidation needs a navigation signal, soft-nav epic); document growth mid-part understates `percent` by the metric's definition. `measureDocument`'s fits-exactly/shorter-than-viewport conflation is EMBR-13507.

## How has this been tested?

New pinning tests: throwing emit, throwing geometry read, overscrolled carry, movement during a disabled gap, shrink below the furthest point, shrink to unscrollable, a depth reached in a document that no longer scrolls, both sides of the stale-range boundary, document growth, a redundant `enable()` mid-part, and the unmeasurable-frame top clamp. The throwing-emit and shrink cases each carry into a second, unmeasurable part, so they pin which reset branch ran rather than only that a reset ran: replacing the `finally`'s measurement with `null` fails all three carry tests. The instrumentation's test file (22 tests), `npm run lint`, and `npm run check` pass.

## Checklist

- [ ] Documentation added
- [x] Tests added
