### PR TITLE
EMBR-13729 perf(instrumentation-dom-state): cap the part-end tree walk at 50k elements

### DIFF
--- a/packages/web-sdk/src/instrumentations/InstrumentationAbstract/InstrumentationAbstract.ts
+++ b/packages/web-sdk/src/instrumentations/InstrumentationAbstract/InstrumentationAbstract.ts
@@ -7,7 +7,7 @@ import type {
   TracerProvider,
 } from '@opentelemetry/api';
 import { diag, metrics, trace } from '@opentelemetry/api';
-import type { Logger, LoggerProvider } from '@opentelemetry/api-logs';
+import type { Logger } from '@opentelemetry/api-logs';
 import { logs } from '@opentelemetry/api-logs';
 import type {
   Instrumentation,
@@ -15,6 +15,7 @@ import type {
   InstrumentationModuleDefinition,
   SpanCustomizationHook,
 } from '@opentelemetry/instrumentation';
+import type { LoggerProvider } from '@opentelemetry/sdk-logs';
 
 // copied directly from https://github.com/open-telemetry/opentelemetry-js/blob/90afa2850c0690f7a18ecc511c04927a3183490b/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
 // to avoid importing internal and experimental code. Some unused blocks removed.

--- a/packages/web-sdk/src/instrumentations/InstrumentationAbstract/InstrumentationAbstract.ts
+++ b/packages/web-sdk/src/instrumentations/InstrumentationAbstract/InstrumentationAbstract.ts
@@ -7,7 +7,7 @@ import type {
   TracerProvider,
 } from '@opentelemetry/api';
 import { diag, metrics, trace } from '@opentelemetry/api';
-import type { Logger } from '@opentelemetry/api-logs';
+import type { Logger, LoggerProvider } from '@opentelemetry/api-logs';
 import { logs } from '@opentelemetry/api-logs';
 import type {
   Instrumentation,
@@ -15,7 +15,6 @@ import type {
   InstrumentationModuleDefinition,
   SpanCustomizationHook,
 } from '@opentelemetry/instrumentation';
-import type { LoggerProvider } from '@opentelemetry/sdk-logs';
 
 // copied directly from https://github.com/open-telemetry/opentelemetry-js/blob/90afa2850c0690f7a18ecc511c04927a3183490b/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
 // to avoid importing internal and experimental code. Some unused blocks removed.

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
@@ -17,6 +17,7 @@ import {
   EmbraceUserSessionManager,
 } from '../../../managers/index.ts';
 import { OTelPerformanceManager } from '../../../utils/index.ts';
+import { DOM_STATE_MAX_TRAVERSED_ELEMENTS } from './constants.ts';
 import { DOMStateInstrumentation } from './DOMStateInstrumentation.ts';
 
 const { expect } = chai;
@@ -606,6 +607,32 @@ describe('DOMStateInstrumentation', () => {
       'dom_state.images_above_fold.timestamp',
     );
     expect(logs[1].attributes).to.have.property('dom_state.element_count');
+  });
+
+  it('omits the tree shape when the element count exceeds the traversal ceiling', () => {
+    // The walk runs synchronously on the pagehide path, so a pathological tree
+    // forfeits its tree keys rather than spend the unload budget.
+    const container = document.createElement('div');
+    container.innerHTML = '<i></i>'.repeat(DOM_STATE_MAX_TRAVERSED_ELEMENTS);
+    document.body.appendChild(container);
+    restorers.push(() => {
+      container.remove();
+    });
+    createInstrumentation();
+
+    endSessionPart();
+
+    const logs = getDomStateLogs();
+    expect(logs).to.have.lengthOf(2);
+    expect(logs[1].attributes).to.have.property(
+      'dom_state.phase',
+      'session_part_end',
+    );
+    expect(logs[1].attributes).to.not.have.property('dom_state.element_count');
+    expect(logs[1].attributes).to.not.have.property('dom_state.average_depth');
+    // The document box does not depend on the walk, so it still reports.
+    expect(logs[1].attributes).to.have.property('dom_state.document_height');
+    expect(logs[1].attributes).to.have.property('dom_state.document_width');
   });
 
   it('still emits the part-end log when the document root is gone', () => {

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
@@ -635,6 +635,29 @@ describe('DOMStateInstrumentation', () => {
     expect(logs[1].attributes).to.have.property('dom_state.document_width');
   });
 
+  it('reports the tree shape when the element count sits exactly at the ceiling', () => {
+    // Pins the ceiling as an inclusive max: only genuinely larger trees
+    // forfeit their keys.
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    restorers.push(() => {
+      container.remove();
+    });
+    const remaining =
+      DOM_STATE_MAX_TRAVERSED_ELEMENTS - measureExpected().count;
+    container.innerHTML = '<i></i>'.repeat(remaining);
+    createInstrumentation();
+
+    endSessionPart();
+
+    const logs = getDomStateLogs();
+    expect(logs).to.have.lengthOf(2);
+    expect(logs[1].attributes).to.have.property(
+      'dom_state.element_count',
+      DOM_STATE_MAX_TRAVERSED_ELEMENTS,
+    );
+  });
+
   it('still emits the part-end log when the document root is gone', () => {
     // document.documentElement is typed non-nullable but is null once the root
     // element is removed, taking the scroll root with it. The part still ends,

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
@@ -623,21 +623,17 @@ describe('DOMStateInstrumentation', () => {
     endSessionPart();
 
     const logs = getDomStateLogs();
-    expect(logs).to.have.lengthOf(2);
-    expect(logs[1].attributes).to.have.property(
-      'dom_state.phase',
-      'session_part_end',
-    );
-    expect(logs[1].attributes).to.not.have.property('dom_state.element_count');
-    expect(logs[1].attributes).to.not.have.property('dom_state.average_depth');
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.not.have.property('dom_state.element_count');
+    expect(logs[0].attributes).to.not.have.property('dom_state.average_depth');
     // The flag is what tells "too large to measure" apart from "no root".
-    expect(logs[1].attributes).to.have.property(
+    expect(logs[0].attributes).to.have.property(
       'dom_state.traversal_limit_reached',
       true,
     );
     // The document box does not depend on the walk, so it still reports.
-    expect(logs[1].attributes).to.have.property('dom_state.document_height');
-    expect(logs[1].attributes).to.have.property('dom_state.document_width');
+    expect(logs[0].attributes).to.have.property('dom_state.document_height');
+    expect(logs[0].attributes).to.have.property('dom_state.document_width');
   });
 
   it('reports the tree shape when the element count sits exactly at the ceiling', () => {
@@ -656,12 +652,12 @@ describe('DOMStateInstrumentation', () => {
     endSessionPart();
 
     const logs = getDomStateLogs();
-    expect(logs).to.have.lengthOf(2);
-    expect(logs[1].attributes).to.have.property(
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.have.property(
       'dom_state.element_count',
       DOM_STATE_MAX_TRAVERSED_ELEMENTS,
     );
-    expect(logs[1].attributes).to.not.have.property(
+    expect(logs[0].attributes).to.not.have.property(
       'dom_state.traversal_limit_reached',
     );
   });

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
@@ -662,6 +662,81 @@ describe('DOMStateInstrumentation', () => {
     );
   });
 
+  it('omits the tree shape when a deep chain alone exceeds the ceiling', () => {
+    // The wide tree trips the bail on the about-to-queue term; a chain has one
+    // child per node, so only the visited count can trip the ceiling here.
+    const container = document.createElement('div');
+    // Hidden so the document measurement's forced layout never has to build a
+    // 50k-deep layout tree; the walk itself only reads children.
+    container.style.display = 'none';
+    document.body.appendChild(container);
+    restorers.push(() => {
+      container.remove();
+    });
+    // Unclosed <div> tags nest under the parser, chunked to stay inside engine
+    // parser-depth caps; per-node appendChild pays O(depth) in cycle checks.
+    let leaf: Element = container;
+    let remaining = DOM_STATE_MAX_TRAVERSED_ELEMENTS;
+    while (remaining > 0) {
+      const chunk = Math.min(400, remaining);
+      leaf.innerHTML = '<div>'.repeat(chunk);
+      remaining -= chunk;
+      while (leaf.firstElementChild) {
+        leaf = leaf.firstElementChild;
+      }
+    }
+    createInstrumentation();
+
+    endSessionPart();
+
+    const logs = getDomStateLogs();
+    expect(logs).to.have.lengthOf(1);
+    expect(logs[0].attributes).to.not.have.property('dom_state.element_count');
+    expect(logs[0].attributes).to.not.have.property('dom_state.average_depth');
+    expect(logs[0].attributes).to.have.property(
+      'dom_state.traversal_limit_reached',
+      true,
+    );
+  });
+
+  it('shifts the average depth by the hand-computed contribution of an attached chain', () => {
+    createInstrumentation();
+    endSessionPart();
+    const before = getDomStateLogs()[0].attributes;
+    const beforeCount = before['dom_state.element_count'] as number;
+    const beforeTotalDepth =
+      (before['dom_state.average_depth'] as number) * beforeCount;
+
+    // <body> sits at depth 2, so a chain of N hung off it occupies depths 3
+    // through N + 2: a contribution of N * (N + 5) / 2 computed by hand, so it
+    // cannot share a semantic drift with the recursive oracle.
+    const chainLength = 4;
+    const chainRoot = document.createElement('div');
+    document.body.appendChild(chainRoot);
+    restorers.push(() => {
+      chainRoot.remove();
+    });
+    let parent: HTMLElement = chainRoot;
+    for (let i = 1; i < chainLength; i++) {
+      const child = document.createElement('div');
+      parent.appendChild(child);
+      parent = child;
+    }
+    userSessionManager.startSessionPartInternal({ reason: 'init' });
+    endSessionPart();
+
+    const after = getDomStateLogs()[1].attributes;
+    expect(after).to.have.property(
+      'dom_state.element_count',
+      beforeCount + chainLength,
+    );
+    expect(after['dom_state.average_depth']).to.be.closeTo(
+      (beforeTotalDepth + (chainLength * (chainLength + 5)) / 2) /
+        (beforeCount + chainLength),
+      1e-9,
+    );
+  });
+
   it('still emits the part-end log when the document root is gone', () => {
     // document.documentElement is typed non-nullable but is null once the root
     // element is removed, taking the scroll root with it. The part still ends,

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
@@ -630,6 +630,11 @@ describe('DOMStateInstrumentation', () => {
     );
     expect(logs[1].attributes).to.not.have.property('dom_state.element_count');
     expect(logs[1].attributes).to.not.have.property('dom_state.average_depth');
+    // The flag is what tells "too large to measure" apart from "no root".
+    expect(logs[1].attributes).to.have.property(
+      'dom_state.traversal_limit_reached',
+      true,
+    );
     // The document box does not depend on the walk, so it still reports.
     expect(logs[1].attributes).to.have.property('dom_state.document_height');
     expect(logs[1].attributes).to.have.property('dom_state.document_width');
@@ -656,6 +661,9 @@ describe('DOMStateInstrumentation', () => {
       'dom_state.element_count',
       DOM_STATE_MAX_TRAVERSED_ELEMENTS,
     );
+    expect(logs[1].attributes).to.not.have.property(
+      'dom_state.traversal_limit_reached',
+    );
   });
 
   it('still emits the part-end log when the document root is gone', () => {
@@ -673,6 +681,9 @@ describe('DOMStateInstrumentation', () => {
     // Nothing to walk and nothing to measure, so no key is fabricated from zero.
     expect(logs[0].attributes).to.not.have.property('dom_state.element_count');
     expect(logs[0].attributes).to.not.have.property('dom_state.average_depth');
+    expect(logs[0].attributes).to.not.have.property(
+      'dom_state.traversal_limit_reached',
+    );
     expect(logs[0].attributes).to.not.have.property(
       'dom_state.document_height',
     );

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
@@ -225,11 +225,9 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
     });
   }
 
-  // Iterative depth-first traversal that computes element count and summed
-  // depth in one pass. The root passed in sits at depth 1. Runs synchronously
-  // on the pagehide path, so it avoids per-node allocations (parallel stacks
-  // instead of entry objects) and bails at the ceiling rather than spend the
-  // unload budget on a pathological tree.
+  // The root passed in sits at depth 1. Runs synchronously on the pagehide
+  // path, so it uses parallel stacks over per-node entry objects and bails at
+  // the ceiling rather than spend the unload budget on a pathological tree.
   private _traverse(root: Element): {
     elementCount: number;
     totalDepth: number;
@@ -245,11 +243,21 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
       element = elements.pop(), depth = depths.pop()
     ) {
       elementCount++;
-      if (elementCount > DOM_STATE_MAX_TRAVERSED_ELEMENTS) {
-        return null;
-      }
       totalDepth += depth;
       const { children } = element;
+      // Popped, queued and about-to-queue are disjoint, so their sum is a
+      // lower bound on the tree size: exceeding the ceiling here proves the
+      // tree is over it before the frontier is pushed, keeping the bail cost
+      // bounded by the ceiling even on wide trees.
+      if (
+        elementCount + elements.length + children.length >
+        DOM_STATE_MAX_TRAVERSED_ELEMENTS
+      ) {
+        this._diag.debug(
+          'dom-state tree walk bailed: the tree exceeds the traversal ceiling',
+        );
+        return null;
+      }
       for (let i = 0; i < children.length; i++) {
         elements.push(children[i]);
         depths.push(depth + 1);

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
@@ -14,6 +14,7 @@ import {
   ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_TIMESTAMP,
   ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_VIEWPORT_HEIGHT,
   ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_VIEWPORT_WIDTH,
+  ATTR_DOM_STATE_TRAVERSAL_LIMIT_REACHED,
   DOM_STATE_EVENT_NAME,
   DOM_STATE_MAX_TRAVERSED_ELEMENTS,
 } from './constants.ts';
@@ -178,7 +179,9 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
             // The traversal counts its root, so elementCount is at least 1.
             [ATTR_DOM_STATE_AVERAGE_DEPTH]: tree.totalDepth / tree.elementCount,
           }
-        : {}),
+        : root
+          ? { [ATTR_DOM_STATE_TRAVERSAL_LIMIT_REACHED]: true }
+          : {}),
       ...(measurement
         ? {
             [ATTR_DOM_STATE_DOCUMENT_HEIGHT]: measurement.documentHeight,

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
@@ -173,15 +173,16 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
       [KEY_EMB_TYPE]: EMB_TYPES.OTelLog,
       // Nothing to walk and nothing to measure both drop their keys rather than
       // report a zero, so the part still gets a log for whatever remains.
-      ...(tree
-        ? {
-            [ATTR_DOM_STATE_ELEMENT_COUNT]: tree.elementCount,
-            // The traversal counts its root, so elementCount is at least 1.
-            [ATTR_DOM_STATE_AVERAGE_DEPTH]: tree.totalDepth / tree.elementCount,
-          }
-        : root
+      ...(tree === null
+        ? {}
+        : tree.limitReached
           ? { [ATTR_DOM_STATE_TRAVERSAL_LIMIT_REACHED]: true }
-          : {}),
+          : {
+              [ATTR_DOM_STATE_ELEMENT_COUNT]: tree.elementCount,
+              // The traversal counts its root, so elementCount is at least 1.
+              [ATTR_DOM_STATE_AVERAGE_DEPTH]:
+                tree.totalDepth / tree.elementCount,
+            }),
       ...(measurement
         ? {
             [ATTR_DOM_STATE_DOCUMENT_HEIGHT]: measurement.documentHeight,
@@ -229,12 +230,13 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
   }
 
   // The root passed in sits at depth 1. Runs synchronously on the pagehide
-  // path, so it uses parallel stacks over per-node entry objects and bails at
-  // the ceiling rather than spend the unload budget on a pathological tree.
-  private _traverse(root: Element): {
-    elementCount: number;
-    totalDepth: number;
-  } | null {
+  // path, so it allocates nothing per node and bails at the ceiling rather
+  // than spend the unload budget on a pathological tree.
+  private _traverse(
+    root: Element,
+  ):
+    | { limitReached: false; elementCount: number; totalDepth: number }
+    | { limitReached: true } {
     let elementCount = 0;
     let totalDepth = 0;
 
@@ -248,18 +250,16 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
       elementCount++;
       totalDepth += depth;
       const { children } = element;
-      // Popped, queued and about-to-queue are disjoint, so their sum is a
-      // lower bound on the tree size: exceeding the ceiling here proves the
-      // tree is over it before the frontier is pushed, keeping the bail cost
-      // bounded by the ceiling even on wide trees.
+      // Popped, queued and about-to-queue are disjoint, so their sum lower-bounds the
+      // tree size; checking before the push bounds the bail cost even on wide trees.
       if (
         elementCount + elements.length + children.length >
         DOM_STATE_MAX_TRAVERSED_ELEMENTS
       ) {
         this._diag.debug(
-          'dom-state tree walk bailed: the tree exceeds the traversal ceiling',
+          `dom-state tree walk bailed: the tree exceeds the ${String(DOM_STATE_MAX_TRAVERSED_ELEMENTS)}-element traversal ceiling`,
         );
-        return null;
+        return { limitReached: true };
       }
       for (let i = 0; i < children.length; i++) {
         elements.push(children[i]);
@@ -267,6 +267,6 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
       }
     }
 
-    return { elementCount, totalDepth };
+    return { limitReached: false, elementCount, totalDepth };
   }
 }

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
@@ -229,9 +229,10 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
     });
   }
 
-  // The root passed in sits at depth 1. Runs synchronously on the pagehide
-  // path, so it allocates nothing per node and bails at the ceiling rather
-  // than spend the unload budget on a pathological tree.
+  // Iterative depth-first traversal that computes element count and summed depth
+  // in one pass. The root passed in sits at depth 1. Runs synchronously on the
+  // pagehide path, so it bails at the ceiling rather than spend the unload
+  // budget on a pathological tree.
   private _traverse(
     root: Element,
   ):
@@ -240,20 +241,17 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
     let elementCount = 0;
     let totalDepth = 0;
 
-    const elements: Element[] = [root];
-    const depths: number[] = [1];
-    for (
-      let element = elements.pop(), depth = depths.pop();
-      element !== undefined && depth !== undefined;
-      element = elements.pop(), depth = depths.pop()
-    ) {
+    const stack: Array<{ element: Element; depth: number }> = [
+      { element: root, depth: 1 },
+    ];
+    for (let entry = stack.pop(); entry !== undefined; entry = stack.pop()) {
       elementCount++;
-      totalDepth += depth;
-      const { children } = element;
+      totalDepth += entry.depth;
+      const { children } = entry.element;
       // Popped, queued and about-to-queue are disjoint, so their sum lower-bounds the
       // tree size; checking before the push bounds the bail cost even on wide trees.
       if (
-        elementCount + elements.length + children.length >
+        elementCount + stack.length + children.length >
         DOM_STATE_MAX_TRAVERSED_ELEMENTS
       ) {
         this._diag.debug(
@@ -262,8 +260,7 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
         return { limitReached: true };
       }
       for (let i = 0; i < children.length; i++) {
-        elements.push(children[i]);
-        depths.push(depth + 1);
+        stack.push({ element: children[i], depth: entry.depth + 1 });
       }
     }
 

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
@@ -15,6 +15,7 @@ import {
   ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_VIEWPORT_HEIGHT,
   ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_VIEWPORT_WIDTH,
   DOM_STATE_EVENT_NAME,
+  DOM_STATE_MAX_TRAVERSED_ELEMENTS,
 } from './constants.ts';
 import type { DOMStateInstrumentationArgs } from './types.ts';
 
@@ -224,24 +225,34 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
     });
   }
 
-  // Iterative depth-first traversal that computes element count and summed depth
-  // in one pass. The root passed in sits at depth 1.
+  // Iterative depth-first traversal that computes element count and summed
+  // depth in one pass. The root passed in sits at depth 1. Runs synchronously
+  // on the pagehide path, so it avoids per-node allocations (parallel stacks
+  // instead of entry objects) and bails at the ceiling rather than spend the
+  // unload budget on a pathological tree.
   private _traverse(root: Element): {
     elementCount: number;
     totalDepth: number;
-  } {
+  } | null {
     let elementCount = 0;
     let totalDepth = 0;
 
-    const stack: Array<{ element: Element; depth: number }> = [
-      { element: root, depth: 1 },
-    ];
-    for (let entry = stack.pop(); entry !== undefined; entry = stack.pop()) {
+    const elements: Element[] = [root];
+    const depths: number[] = [1];
+    for (
+      let element = elements.pop(), depth = depths.pop();
+      element !== undefined && depth !== undefined;
+      element = elements.pop(), depth = depths.pop()
+    ) {
       elementCount++;
-      totalDepth += entry.depth;
-      const { children } = entry.element;
+      if (elementCount > DOM_STATE_MAX_TRAVERSED_ELEMENTS) {
+        return null;
+      }
+      totalDepth += depth;
+      const { children } = element;
       for (let i = 0; i < children.length; i++) {
-        stack.push({ element: children[i], depth: entry.depth + 1 });
+        elements.push(children[i]);
+        depths.push(depth + 1);
       }
     }
 

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/constants.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/constants.ts
@@ -1,4 +1,5 @@
 export const DOM_STATE_EVENT_NAME = 'dom-state';
+export const DOM_STATE_MAX_TRAVERSED_ELEMENTS = 50_000;
 
 export const ATTR_DOM_STATE_AVERAGE_DEPTH = 'dom_state.average_depth';
 export const ATTR_DOM_STATE_DOCUMENT_HEIGHT = 'dom_state.document_height';

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/constants.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/constants.ts
@@ -1,4 +1,6 @@
 export const DOM_STATE_EVENT_NAME = 'dom-state';
+// A full walk at this ceiling measures ~5-11ms in desktop engines, affordable
+// on the unload path; typical pages hold 1-2k elements.
 export const DOM_STATE_MAX_TRAVERSED_ELEMENTS = 50_000;
 
 export const ATTR_DOM_STATE_AVERAGE_DEPTH = 'dom_state.average_depth';

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/constants.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/constants.ts
@@ -5,6 +5,8 @@ export const ATTR_DOM_STATE_AVERAGE_DEPTH = 'dom_state.average_depth';
 export const ATTR_DOM_STATE_DOCUMENT_HEIGHT = 'dom_state.document_height';
 export const ATTR_DOM_STATE_DOCUMENT_WIDTH = 'dom_state.document_width';
 export const ATTR_DOM_STATE_ELEMENT_COUNT = 'dom_state.element_count';
+export const ATTR_DOM_STATE_TRAVERSAL_LIMIT_REACHED =
+  'dom_state.traversal_limit_reached';
 
 export const ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_COUNT =
   'dom_state.images_above_fold.count';


### PR DESCRIPTION
> Stacked on #1442; merge that first.

## What problem is this solving?

The part-end tree walk in `DOMStateInstrumentation` is unbounded. It runs synchronously on the `visibilitychange` / `pagehide` path, where the browser grants only a short budget, so a pathological tree spends unload time the keepalive flush needs. Measured, an unbounded walk grows linearly: ~17-22 ms at 131k nodes, worse from there.

## Short description of changes

- Cap the walk at `DOM_STATE_MAX_TRAVERSED_ELEMENTS` (50,000): far above the 1-2k elements a typical page holds, so it only guards pathology. The bail tests the frontier (visited + queued + about-to-queue is a lower bound on tree size) before pushing children, so the cost stays bounded by the ceiling even on very wide trees, and a tree of exactly the ceiling still reports.
- Past the ceiling the part-end log drops `dom_state.element_count` / `dom_state.average_depth` (absence over fabricated zeros, keeping the document box) and stamps `dom_state.traversal_limit_reached: true`, so the backend can tell "too large to measure" from "no document root". The walk returns its bail reason itself, so the flag cannot drift from the walk's outcome. A `diag.debug` breadcrumb names the ceiling on the bail.
- `dom_state.traversal_limit_reached` is a new attribute key, so it needs the backend allowlist mapping before it shows up in exported telemetry.

## How has this been tested?

Tests pin the boundary from every side: past the ceiling via width and via depth (the two bail terms), exactly at the ceiling, missing root, plus a hand-computed average-depth shift that cannot share drift with the test oracle. Benchmarks in Chromium and WebKit over realistic, wide, deep-chain and balanced trees: the bail caps the walk at ~5-6 ms no matter how large the tree; the whole part-end handler at exactly the ceiling measures ~5-11 ms, which is where the ceiling's rationale in `constants.ts` comes from. The dom-state unit suite, `npm run lint` and `npm run check` pass.

## Checklist

- [ ] Documentation added
- [x] Tests added
