### PR TITLE
EMBR-13512 fix(processors): honor pre-stamped user session ids instead of overwriting them at emit

### DIFF
--- a/packages/web-sdk/src/processors/UserSessionLogRecordProcessor/UserSessionLogRecordProcessor.test.ts
+++ b/packages/web-sdk/src/processors/UserSessionLogRecordProcessor/UserSessionLogRecordProcessor.test.ts
@@ -149,6 +149,42 @@ describe('UserSessionLogRecordProcessor', () => {
     );
   });
 
+  it('should honor a user_session_id already stamped by an earlier processor instead of overwriting it with the live value', () => {
+    // A record held across a user-session rollover and stamped at capture must
+    // keep the id of the user session it describes, not the one emitting it.
+    ({ memoryExporter, logger } = setup(createMockUserSessionManager()));
+
+    logger.emit({
+      body: 'test log',
+      attributes: { 'emb.user_session_id': 'USER_SESSION_SNAPSHOT' },
+    });
+
+    const finishedLogs = memoryExporter.getFinishedLogRecords();
+    expect(finishedLogs).to.have.lengthOf(1);
+    expect(finishedLogs[0].attributes['emb.user_session_id']).to.equal(
+      'USER_SESSION_SNAPSHOT',
+    );
+  });
+
+  it('should honor a user_session_previous_id already stamped by an earlier processor instead of overwriting it with the live value', () => {
+    ({ memoryExporter, logger } = setup(
+      createMockUserSessionManager(mockAttributes, {
+        getPreviousUserSessionId: () => 'PREVIOUS_LIVE',
+      }),
+    ));
+
+    logger.emit({
+      body: 'test log',
+      attributes: { 'emb.user_session_previous_id': 'PREVIOUS_SNAPSHOT' },
+    });
+
+    const finishedLogs = memoryExporter.getFinishedLogRecords();
+    expect(finishedLogs).to.have.lengthOf(1);
+    expect(finishedLogs[0].attributes['emb.user_session_previous_id']).to.equal(
+      'PREVIOUS_SNAPSHOT',
+    );
+  });
+
   it('should pass customer-set session.id and session.previous_id through untouched', () => {
     ({ memoryExporter, logger } = setup(
       createMockUserSessionManager(mockAttributes, {

--- a/packages/web-sdk/src/processors/UserSessionLogRecordProcessor/UserSessionLogRecordProcessor.ts
+++ b/packages/web-sdk/src/processors/UserSessionLogRecordProcessor/UserSessionLogRecordProcessor.ts
@@ -24,10 +24,14 @@ export class UserSessionLogRecordProcessor implements LogRecordProcessor {
   }
 
   public onEmit(logRecord: SdkLogRecord) {
-    const userSessionId = this._userSessionManager.getUserSessionId() ?? '';
+    const userSessionId =
+      logRecord.attributes[KEY_EMB_USER_SESSION_ID] ??
+      this._userSessionManager.getUserSessionId() ??
+      '';
     const previousUserSessionId =
-      this._userSessionManager.getPreviousUserSessionId() ?? '';
-    // If the log record already has a session part id, we use that
+      logRecord.attributes[KEY_EMB_USER_SESSION_PREVIOUS_ID] ??
+      this._userSessionManager.getPreviousUserSessionId() ??
+      '';
     const sessionPartId =
       logRecord.attributes[KEY_EMB_SESSION_PART_ID] ??
       this._userSessionManager.getSessionPartId() ??


### PR DESCRIPTION
## What problem is this solving?

`UserSessionLogRecordProcessor` overwrites `emb.user_session_id` and `emb.user_session_previous_id` with the live manager values on every emit, while `emb.session_part_id` already honors a pre-set value. A log record stamped at capture time and emitted later (the hold-and-flush pattern, EMBR-13512) would come out torn: capture-time part id paired with emit-time user-session ids.

## Short description of changes

Give the two user-session id keys the same guard the part id key has: a value already on the record wins, the live manager value only fills records that arrive unstamped. Unstamped records behave exactly as before.

## How has this been tested?

Two tests pin the guard (pre-stamped ids survive emit); the existing tests pin that unstamped records still get the live values, empty-string fallbacks included. Full web-sdk suite, lint and check pass.

## Checklist

- [ ] Documentation added
- [x] Tests added
