### PR TITLE
EMBR-13582 fix(instrumentation-document-load): collect from an unbuffered navigation observer

### DIFF
--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -233,8 +233,9 @@ class FakePerformanceObserver {
     }
   }
 
-  /* The notification an engine sends once `loadEventEnd` has been written. */
-  public notifyLoadEventComplete(entry: object): void {
+  /* The engine's one notification for the document. It may carry the entry in
+   * any state, which is why collection re-checks loadEventEnd. */
+  public notify(entry: object): void {
     if (this._notificationConsumed) {
       return;
     }
@@ -305,6 +306,12 @@ describe('DocumentLoad Instrumentation', () => {
   before(() => {
     propagation.setGlobalPropagator(new W3CTraceContextPropagator());
   });
+
+  const documentLoadSpans = () =>
+    exporter.getFinishedSpans().filter((s) => s.name === 'documentLoad');
+
+  const afterPendingTasks = () =>
+    new Promise((resolve) => setTimeout(resolve, 10));
 
   describe('constructor', () => {
     it('should construct an instance', () => {
@@ -1225,12 +1232,6 @@ describe('DocumentLoad Instrumentation', () => {
       });
     };
 
-    const documentLoadSpans = () =>
-      exporter.getFinishedSpans().filter((s) => s.name === 'documentLoad');
-
-    const afterPendingTasks = () =>
-      new Promise((resolve) => setTimeout(resolve, 10));
-
     /* There is one entry per document and the browser mutates it in place, so
      * completing the load fills in loadEventEnd on the object already there. */
     type MutableNavigationTiming = {
@@ -1240,7 +1241,13 @@ describe('DocumentLoad Instrumentation', () => {
 
     const completeLoadEvent = () => {
       timelineEntry.loadEventEnd = entries.loadEventEnd;
-      FakePerformanceObserver.latest().notifyLoadEventComplete(timelineEntry);
+      FakePerformanceObserver.latest().notify(timelineEntry);
+    };
+
+    /* The engine spends its notification while the load is still in flight, so
+     * loadEventEnd is still zero on the entry it delivers. */
+    const notifyMidLoad = () => {
+      FakePerformanceObserver.latest().notify(timelineEntry);
     };
 
     beforeEach(() => {
@@ -1261,6 +1268,42 @@ describe('DocumentLoad Instrumentation', () => {
       plugin.enable();
 
       assert.strictEqual(documentLoadSpans().length, 0);
+    });
+
+    it('should stay subscribed when notified before loadEventEnd is written', () => {
+      plugin.enable();
+      const observer = FakePerformanceObserver.latest();
+
+      notifyMidLoad();
+
+      assert.strictEqual(documentLoadSpans().length, 0);
+      // Hanging up here would lose the page load: the finished entry is only
+      // ever delivered by a later notification on this same observer.
+      assert.isFalse(observer.isDisconnected);
+    });
+
+    it('should collect on the notification that follows an unfinished one', () => {
+      plugin.enable();
+
+      notifyMidLoad();
+      completeLoadEvent();
+
+      assert.strictEqual(documentLoadSpans().length, 1);
+    });
+
+    it('should not end the documentLoad span at time origin when notified mid load', () => {
+      const perf = new OTelPerformanceManager();
+      plugin.enable();
+
+      notifyMidLoad();
+      completeLoadEvent();
+
+      // Collecting off the unfinished entry would read loadEventEnd as 0 and
+      // end the span at time origin, before its own start.
+      assert.strictEqual(
+        hrTimeToMilliseconds(documentLoadSpans()[0].endTime),
+        perf.epochMillisFromOrigin(entries.loadEventEnd),
+      );
     });
 
     /* A buffered subscription is answered with the incomplete entry, which in
@@ -1339,8 +1382,8 @@ describe('DocumentLoad Instrumentation', () => {
       completeLoadEvent();
       plugin.disable();
 
-      // Re-enabling sees the completed entry on the timeline, so a deferred
-      // read reaches collection a second time.
+      // Re-enabling sees the completed entry and defers a second read, which
+      // reaches collection again and is stopped by the collect-once guard.
       plugin.enable();
       await afterPendingTasks();
 
@@ -1385,12 +1428,6 @@ describe('DocumentLoad Instrumentation', () => {
       spyEntries.restore();
     });
 
-    const documentLoadSpans = () =>
-      exporter.getFinishedSpans().filter((s) => s.name === 'documentLoad');
-
-    const afterPendingTasks = () =>
-      new Promise((resolve) => setTimeout(resolve, 10));
-
     /* The notification fired before a late SDK init subscribed, so the
      * finished entry is read off the timeline instead of observed. */
     it('should not subscribe an observer', () => {
@@ -1399,8 +1436,8 @@ describe('DocumentLoad Instrumentation', () => {
       assert.strictEqual(FakePerformanceObserver.instances.length, 0);
     });
 
-    /* onEnable runs from the constructor, before the tracer provider is wired
-     * on, so a synchronous collect would record nothing. */
+    /* Under registerGlobally: false the tracer provider is wired after the
+     * constructor runs, so a synchronous collect would record nothing. */
     it('should not collect synchronously while enabling', (done) => {
       plugin.enable();
 
@@ -1416,6 +1453,41 @@ describe('DocumentLoad Instrumentation', () => {
       plugin.enable();
       plugin.disable();
 
+      await afterPendingTasks();
+
+      assert.strictEqual(documentLoadSpans().length, 0);
+    });
+  });
+
+  /* WebKit reports no navigation entry at all for about:blank, popups and
+   * srcdoc iframes, so an empty timeline is a real case, not a defensive one. */
+  describe('when the document has no navigation entry', () => {
+    let spyEntries: sinon.SinonStub;
+
+    beforeEach(() => {
+      spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([]);
+      spyEntries.withArgs('resource').returns([]);
+      spyEntries.withArgs('paint').returns([]);
+    });
+
+    afterEach(() => {
+      spyEntries.restore();
+    });
+
+    /* The constructor runs inside initSDK's try block, so throwing here fails
+     * the whole SDK init and takes every other instrumentation with it. */
+    it('should construct without throwing when enabled', () => {
+      assert.doesNotThrow(() => {
+        const instance = new DocumentLoadInstrumentation({ enabled: true });
+        instance.disable();
+      });
+    });
+
+    it('should collect nothing when the observer notifies', async () => {
+      plugin.enable();
+
+      FakePerformanceObserver.latest().notify({});
       await afterPendingTasks();
 
       assert.strictEqual(documentLoadSpans().length, 0);

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -190,23 +190,15 @@ const ensureNetworkEventsExists = (
 };
 
 /*
- * Stands in for the real PerformanceObserver so tests control what the
- * navigation entry observer is told and when.
- *
- * The navigation entry reaches the timeline within a few milliseconds of
- * navigation start, long before `loadEventEnd` is written, and engines expose
- * it through two separate paths: a `buffered: true` replay of whatever the
- * buffer currently holds, and a notification once the load event completes.
+ * Models the two paths an engine exposes the navigation entry through: a
+ * buffered replay of whatever the buffer holds, and a notification once the
+ * load event completes.
  */
 class FakePerformanceObserver {
   public static supportedEntryTypes: string[] = ['navigation'];
   public static instances: FakePerformanceObserver[] = [];
-  /*
-   * WebKit answers a buffered subscription with the entry as it stands, and
-   * that answer consumes the observer's only notification, so the completed
-   * entry never arrives. Chromium and Gecko send both, which is exactly why a
-   * buffered subscription hides this fault everywhere except Safari.
-   */
+  /* In WebKit a buffered replay consumes the observer's one notification, so
+   * the completed entry never arrives. Chromium and Gecko send both. */
   public static webkitSemantics = false;
 
   public observedOptions: PerformanceObserverInit | null = null;
@@ -235,7 +227,8 @@ class FakePerformanceObserver {
       const [buffered] = window.performance.getEntriesByType('navigation');
       if (buffered) {
         this._notificationConsumed = FakePerformanceObserver.webkitSemantics;
-        this._deliver(buffered);
+        // Engines replay buffered entries in a later task, never inside observe().
+        setTimeout(() => this._deliver(buffered), 0);
       }
     }
   }
@@ -334,11 +327,7 @@ describe('DocumentLoad Instrumentation', () => {
       spyEntries.restore();
     });
 
-    /*
-     * The buffered replay of a completed entry is what lets an SDK that
-     * initializes after the load event still report the document load, so
-     * readyState takes no part in deciding when to collect.
-     */
+    /* The entry alone decides when to collect; readyState takes no part. */
     ['complete', 'loading', 'interactive'].forEach((readyState) => {
       it(`should collect from the replayed entry when readyState is ${readyState}`, (done) => {
         Object.defineProperty(window.document, 'readyState', {
@@ -554,10 +543,8 @@ describe('DocumentLoad Instrumentation', () => {
     });
 
     /*
-     * An entry with no loadEventEnd is one the browser has not finished
-     * writing, so it is never the signal to collect. Waiting costs nothing:
-     * the completed entry follows whenever the load event completes, and if it
-     * never completes there is no document load to report.
+     * A missing loadEventEnd means the browser has not finished writing the
+     * entry, and a load that never completes has nothing to report.
      */
     it('should not export any spans', (done) => {
       plugin.enable();
@@ -1116,11 +1103,8 @@ describe('DocumentLoad Instrumentation', () => {
     const afterPendingTasks = () =>
       new Promise((resolve) => setTimeout(resolve, 10));
 
-    /*
-     * One entry per document, mutated in place by the browser. It starts with
-     * loadEventEnd unwritten, and the load event completing fills it in on the
-     * very object already sitting on the timeline.
-     */
+    /* There is one entry per document and the browser mutates it in place, so
+     * completing the load fills in loadEventEnd on the object already there. */
     type MutableNavigationTiming = {
       -readonly [K in keyof PerformanceNavigationTiming]: PerformanceNavigationTiming[K];
     };
@@ -1151,11 +1135,8 @@ describe('DocumentLoad Instrumentation', () => {
       assert.strictEqual(documentLoadSpans().length, 0);
     });
 
-    /*
-     * Subscribing with buffered: true is answered with the incomplete entry,
-     * and in WebKit that answer consumes the observer's only notification, so
-     * the completed entry never arrives and the page load is lost.
-     */
+    /* A buffered subscription is answered with the incomplete entry, which in
+     * WebKit consumes the one notification and loses the page load. */
     it('should subscribe without the buffered flag', () => {
       plugin.enable();
 
@@ -1174,13 +1155,23 @@ describe('DocumentLoad Instrumentation', () => {
       assert.strictEqual(documentLoadSpans().length, 1);
     });
 
-    it('should collect under WebKit semantics, where a buffered replay would consume the notification', () => {
+    it('should collect under WebKit semantics, where a buffered replay would consume the notification', async () => {
+      const perf = new OTelPerformanceManager();
       FakePerformanceObserver.webkitSemantics = true;
 
       plugin.enable();
+      // Let any replay land first: engines replay the entry while the load is
+      // still in flight, well before loadEventEnd is written.
+      await afterPendingTasks();
       completeLoadEvent();
 
       assert.strictEqual(documentLoadSpans().length, 1);
+      // Collected after completion, so the span carries the real loadEventEnd
+      // rather than the wall clock fallback an incomplete entry would give.
+      assert.strictEqual(
+        hrTimeToMilliseconds(documentLoadSpans()[0].endTime),
+        perf.epochMillisFromOrigin(entries.loadEventEnd),
+      );
     });
 
     it('should disconnect the observer once it has collected', () => {
@@ -1251,20 +1242,31 @@ describe('DocumentLoad Instrumentation', () => {
       spyEntries.restore();
     });
 
-    /*
-     * The load-complete notification has already fired by the time a late SDK
-     * init subscribes, so the completed entry has to be read off the timeline
-     * instead of waited for.
-     */
-    it('should collect from the timeline without creating an observer', () => {
+    const documentLoadSpans = () =>
+      exporter.getFinishedSpans().filter((s) => s.name === 'documentLoad');
+
+    /* The notification fired before a late SDK init subscribed, so only a
+     * buffered replay can still deliver the entry. */
+    it('should subscribe with the buffered flag', () => {
       plugin.enable();
 
-      assert.strictEqual(
-        exporter.getFinishedSpans().filter((s) => s.name === 'documentLoad')
-          .length,
-        1,
-      );
-      assert.strictEqual(FakePerformanceObserver.instances.length, 0);
+      assert.deepStrictEqual(FakePerformanceObserver.latest().observedOptions, {
+        type: 'navigation',
+        buffered: true,
+      });
+    });
+
+    /* onEnable runs from the constructor, before the tracer provider is wired
+     * on, so a synchronous collect would record nothing. */
+    it('should not collect synchronously while enabling', (done) => {
+      plugin.enable();
+
+      assert.strictEqual(documentLoadSpans().length, 0);
+
+      setTimeout(() => {
+        assert.strictEqual(documentLoadSpans().length, 1);
+        done();
+      });
     });
   });
 });

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -6,6 +6,7 @@
 import type { Attributes, HrTime } from '@opentelemetry/api';
 import { context, propagation, trace } from '@opentelemetry/api';
 import {
+  hrTimeToMilliseconds,
   TRACE_PARENT_HEADER,
   W3CTraceContextPropagator,
 } from '@opentelemetry/core';
@@ -23,8 +24,10 @@ import {
 import { assert } from 'chai';
 import type { SinonStubbedFunction } from 'sinon';
 import * as sinon from 'sinon';
+import { OTelPerformanceManager } from '../../../utils/index.ts';
 import { DocumentLoadInstrumentation } from '../index.ts';
 import { EventNames } from './enums/EventNames.ts';
+import { getPerformanceNavigationEntries } from './utils.ts';
 
 const exporter = new InMemorySpanExporter();
 const spanProcessor = new SimpleSpanProcessor({ exporter });
@@ -186,10 +189,92 @@ const ensureNetworkEventsExists = (
   }
 };
 
+/*
+ * Stands in for the real PerformanceObserver so tests control what the
+ * navigation entry observer is told and when.
+ *
+ * The navigation entry reaches the timeline within a few milliseconds of
+ * navigation start, long before `loadEventEnd` is written, and engines expose
+ * it through two separate paths: a `buffered: true` replay of whatever the
+ * buffer currently holds, and a notification once the load event completes.
+ */
+class FakePerformanceObserver {
+  public static supportedEntryTypes: string[] = ['navigation'];
+  public static instances: FakePerformanceObserver[] = [];
+  /*
+   * WebKit answers a buffered subscription with the entry as it stands, and
+   * that answer consumes the observer's only notification, so the completed
+   * entry never arrives. Chromium and Gecko send both, which is exactly why a
+   * buffered subscription hides this fault everywhere except Safari.
+   */
+  public static webkitSemantics = false;
+
+  public observedOptions: PerformanceObserverInit | null = null;
+  public isDisconnected = false;
+  private _notificationConsumed = false;
+  private readonly _callback: PerformanceObserverCallback;
+
+  public constructor(callback: PerformanceObserverCallback) {
+    this._callback = callback;
+    FakePerformanceObserver.instances.push(this);
+  }
+
+  public static latest(): FakePerformanceObserver {
+    const observer =
+      FakePerformanceObserver.instances[
+        FakePerformanceObserver.instances.length - 1
+      ];
+    assert.isOk(observer, 'expected an observer to have been created');
+    return observer;
+  }
+
+  public observe(options: PerformanceObserverInit): void {
+    this.observedOptions = options;
+
+    if (options.buffered) {
+      const [buffered] = window.performance.getEntriesByType('navigation');
+      if (buffered) {
+        this._notificationConsumed = FakePerformanceObserver.webkitSemantics;
+        this._deliver(buffered);
+      }
+    }
+  }
+
+  /* The notification an engine sends once `loadEventEnd` has been written. */
+  public notifyLoadEventComplete(entry: object): void {
+    if (this._notificationConsumed) {
+      return;
+    }
+    this._deliver(entry);
+  }
+
+  public disconnect(): void {
+    this.isDisconnected = true;
+  }
+
+  public takeRecords(): PerformanceEntryList {
+    return [];
+  }
+
+  private _deliver(entry: object): void {
+    // A disconnected observer never hears from the timeline again.
+    if (this.isDisconnected) {
+      return;
+    }
+    this._callback(
+      {
+        getEntries: () => [entry],
+      } as unknown as PerformanceObserverEntryList,
+      this as unknown as PerformanceObserver,
+    );
+  }
+}
+
 describe('DocumentLoad Instrumentation', () => {
   let plugin: DocumentLoadInstrumentation;
   let contextManager: StackContextManager;
   const sandbox = sinon.createSandbox();
+  let realPerformanceObserver: typeof globalThis.PerformanceObserver;
 
   beforeEach(() => {
     contextManager = new StackContextManager().enable();
@@ -199,6 +284,12 @@ describe('DocumentLoad Instrumentation', () => {
       value: 'complete',
     });
     sandbox.replaceGetter(navigator, 'userAgent', () => userAgent);
+    realPerformanceObserver = globalThis.PerformanceObserver;
+    FakePerformanceObserver.instances = [];
+    FakePerformanceObserver.webkitSemantics = false;
+    FakePerformanceObserver.supportedEntryTypes = ['navigation'];
+    (globalThis as Record<string, unknown>)['PerformanceObserver'] =
+      FakePerformanceObserver;
     plugin = new DocumentLoadInstrumentation({
       enabled: false,
     });
@@ -214,6 +305,8 @@ describe('DocumentLoad Instrumentation', () => {
       value: 'complete',
     });
     plugin.disable();
+    (globalThis as Record<string, unknown>)['PerformanceObserver'] =
+      realPerformanceObserver;
   });
 
   before(() => {
@@ -229,7 +322,7 @@ describe('DocumentLoad Instrumentation', () => {
     });
   });
 
-  describe('when document readyState is complete', () => {
+  describe('when the document has already finished loading', () => {
     let spyEntries: SinonStubbedFunction<PerformanceEntry[]>;
     beforeEach(() => {
       spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
@@ -240,51 +333,37 @@ describe('DocumentLoad Instrumentation', () => {
     afterEach(() => {
       spyEntries.restore();
     });
-    it('should start collecting the performance immediately', (done) => {
-      plugin.enable();
-      setTimeout(() => {
-        assert.strictEqual(window.document.readyState, 'complete');
-        assert.strictEqual(spyEntries.callCount, 3);
-        done();
+
+    /*
+     * The buffered replay of a completed entry is what lets an SDK that
+     * initializes after the load event still report the document load, so
+     * readyState takes no part in deciding when to collect.
+     */
+    ['complete', 'loading', 'interactive'].forEach((readyState) => {
+      it(`should collect from the replayed entry when readyState is ${readyState}`, (done) => {
+        Object.defineProperty(window.document, 'readyState', {
+          writable: true,
+          value: readyState,
+        });
+
+        plugin.enable();
+
+        setTimeout(() => {
+          const documentLoadSpans = exporter
+            .getFinishedSpans()
+            .filter((s) => s.name === 'documentLoad');
+          assert.strictEqual(documentLoadSpans.length, 1);
+          done();
+        });
       });
     });
-  });
 
-  describe('when document readyState is not complete', () => {
-    let spyEntries: SinonStubbedFunction<PerformanceEntry[]>;
-    beforeEach(() => {
-      Object.defineProperty(window.document, 'readyState', {
-        writable: true,
-        value: 'loading',
-      });
-
-      spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
-      spyEntries.withArgs('navigation').returns([entries]);
-      spyEntries.withArgs('resource').returns([]);
-      spyEntries.withArgs('paint').returns([]);
-    });
-    afterEach(() => {
-      spyEntries.restore();
-    });
-
-    it('should collect performance after document load event', (done) => {
+    it('should not register a load event listener', () => {
       const spy = sandbox.spy(window, 'addEventListener');
-      plugin.enable();
-      assert.ok(spy.args.some((args) => args[0] === 'load'));
-      assert.ok(spyEntries.callCount === 0);
 
-      window.dispatchEvent(
-        new CustomEvent('load', {
-          bubbles: true,
-          cancelable: false,
-          composed: true,
-          detail: {},
-        }),
-      );
-      setTimeout(() => {
-        assert.strictEqual(spyEntries.callCount, 3);
-        done();
-      });
+      plugin.enable();
+
+      assert.isFalse(spy.args.some((args) => args[0] === 'load'));
     });
   });
 
@@ -474,17 +553,17 @@ describe('DocumentLoad Instrumentation', () => {
       spyEntries.restore();
     });
 
-    it('should still export rootSpan and fetchSpan', (done) => {
+    /*
+     * An entry with no loadEventEnd is one the browser has not finished
+     * writing, so it is never the signal to collect. Waiting costs nothing:
+     * the completed entry follows whenever the load event completes, and if it
+     * never completes there is no document load to report.
+     */
+    it('should not export any spans', (done) => {
       plugin.enable();
 
       setTimeout(() => {
-        const rootSpan = exporter.getFinishedSpans()[0];
-        const fetchSpan = exporter.getFinishedSpans()[1];
-
-        assert.strictEqual(rootSpan.name, 'documentFetch');
-        assert.strictEqual(fetchSpan.name, 'documentLoad');
-
-        assert.strictEqual(exporter.getFinishedSpans().length, 2);
+        assert.strictEqual(exporter.getFinishedSpans().length, 0);
         done();
       });
     });
@@ -999,6 +1078,193 @@ describe('DocumentLoad Instrumentation', () => {
         );
         done();
       });
+    });
+  });
+
+  describe('getPerformanceNavigationEntries', () => {
+    it('should read the timing fields off the timeline entry', () => {
+      const spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([entries]);
+
+      const result = getPerformanceNavigationEntries();
+
+      assert.strictEqual(result[PTN.FETCH_START], entries.fetchStart);
+      assert.strictEqual(result[PTN.LOAD_EVENT_END], entries.loadEventEnd);
+    });
+
+    it('should return no entries when the timeline has no navigation entry', () => {
+      const spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([]);
+
+      assert.deepStrictEqual(getPerformanceNavigationEntries(), {});
+    });
+  });
+
+  describe('navigation entry observer', () => {
+    let spyEntries: sinon.SinonStub;
+
+    const setReadyState = (value: string) => {
+      Object.defineProperty(window.document, 'readyState', {
+        writable: true,
+        value,
+      });
+    };
+
+    const documentLoadSpans = () =>
+      exporter.getFinishedSpans().filter((s) => s.name === 'documentLoad');
+
+    const afterPendingTasks = () =>
+      new Promise((resolve) => setTimeout(resolve, 10));
+
+    /*
+     * One entry per document, mutated in place by the browser. It starts with
+     * loadEventEnd unwritten, and the load event completing fills it in on the
+     * very object already sitting on the timeline.
+     */
+    type MutableNavigationTiming = {
+      -readonly [K in keyof PerformanceNavigationTiming]: PerformanceNavigationTiming[K];
+    };
+    let timelineEntry: MutableNavigationTiming;
+
+    const completeLoadEvent = () => {
+      timelineEntry.loadEventEnd = entries.loadEventEnd;
+      FakePerformanceObserver.latest().notifyLoadEventComplete(timelineEntry);
+    };
+
+    beforeEach(() => {
+      timelineEntry = { ...entries, loadEventEnd: 0 };
+      spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([timelineEntry]);
+      spyEntries.withArgs('resource').returns([]);
+      spyEntries.withArgs('paint').returns([]);
+      // Collection must be driven by the entry, not by readyState or load.
+      setReadyState('loading');
+    });
+
+    afterEach(() => {
+      spyEntries.restore();
+    });
+
+    it('should not collect before the load event completes', () => {
+      plugin.enable();
+
+      assert.strictEqual(documentLoadSpans().length, 0);
+    });
+
+    /*
+     * Subscribing with buffered: true is answered with the incomplete entry,
+     * and in WebKit that answer consumes the observer's only notification, so
+     * the completed entry never arrives and the page load is lost.
+     */
+    it('should subscribe without the buffered flag', () => {
+      plugin.enable();
+
+      assert.deepStrictEqual(FakePerformanceObserver.latest().observedOptions, {
+        type: 'navigation',
+        buffered: false,
+      });
+    });
+
+    it('should collect when the load event completes', () => {
+      plugin.enable();
+      assert.strictEqual(documentLoadSpans().length, 0);
+
+      completeLoadEvent();
+
+      assert.strictEqual(documentLoadSpans().length, 1);
+    });
+
+    it('should collect under WebKit semantics, where a buffered replay would consume the notification', () => {
+      FakePerformanceObserver.webkitSemantics = true;
+
+      plugin.enable();
+      completeLoadEvent();
+
+      assert.strictEqual(documentLoadSpans().length, 1);
+    });
+
+    it('should disconnect the observer once it has collected', () => {
+      plugin.enable();
+      const observer = FakePerformanceObserver.latest();
+
+      completeLoadEvent();
+
+      assert.isTrue(observer.isDisconnected);
+    });
+
+    it('should end the documentLoad span at the delivered entry loadEventEnd', () => {
+      const perf = new OTelPerformanceManager();
+      plugin.enable();
+
+      completeLoadEvent();
+
+      const [documentLoad] = documentLoadSpans();
+      assert.strictEqual(
+        hrTimeToMilliseconds(documentLoad.endTime),
+        perf.epochMillisFromOrigin(entries.loadEventEnd),
+      );
+    });
+
+    it('should collect nothing when the notification arrives after disable', async () => {
+      plugin.enable();
+
+      plugin.disable();
+      completeLoadEvent();
+      await afterPendingTasks();
+
+      assert.strictEqual(documentLoadSpans().length, 0);
+    });
+
+    it('should collect only once across an enable, disable, enable cycle', () => {
+      plugin.enable();
+      completeLoadEvent();
+      plugin.disable();
+
+      // Re-enabling now finds the finished entry already on the timeline.
+      plugin.enable();
+
+      assert.strictEqual(documentLoadSpans().length, 1);
+    });
+
+    it('should collect nothing when the navigation entry type is unobservable', async () => {
+      FakePerformanceObserver.supportedEntryTypes = [];
+
+      plugin.enable();
+      await afterPendingTasks();
+
+      assert.strictEqual(FakePerformanceObserver.instances.length, 0);
+      assert.strictEqual(documentLoadSpans().length, 0);
+    });
+  });
+
+  describe('when the load event has already finished', () => {
+    let spyEntries: sinon.SinonStub;
+
+    beforeEach(() => {
+      spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([entries]);
+      spyEntries.withArgs('resource').returns([]);
+      spyEntries.withArgs('paint').returns([]);
+    });
+
+    afterEach(() => {
+      spyEntries.restore();
+    });
+
+    /*
+     * The load-complete notification has already fired by the time a late SDK
+     * init subscribes, so the completed entry has to be read off the timeline
+     * instead of waited for.
+     */
+    it('should collect from the timeline without creating an observer', () => {
+      plugin.enable();
+
+      assert.strictEqual(
+        exporter.getFinishedSpans().filter((s) => s.name === 'documentLoad')
+          .length,
+        1,
+      );
+      assert.strictEqual(FakePerformanceObserver.instances.length, 0);
     });
   });
 });

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -313,6 +313,27 @@ describe('DocumentLoad Instrumentation', () => {
       });
       assert.ok(plugin instanceof DocumentLoadInstrumentation);
     });
+
+    /*
+     * The SDK enables through the constructor and wires the tracer provider
+     * afterwards, so collection has to outlast that gap to be recorded.
+     */
+    it('should collect when enabled through the constructor', async () => {
+      const spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([entries]);
+      spyEntries.withArgs('resource').returns([]);
+      spyEntries.withArgs('paint').returns([]);
+
+      plugin = new DocumentLoadInstrumentation({ enabled: true });
+      plugin.setTracerProvider(provider);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      assert.strictEqual(
+        exporter.getFinishedSpans().filter((s) => s.name === 'documentLoad')
+          .length,
+        1,
+      );
+    });
   });
 
   describe('when the document has already finished loading', () => {
@@ -556,6 +577,52 @@ describe('DocumentLoad Instrumentation', () => {
     });
   });
 
+  describe('when the navigation entry is missing timing fields', () => {
+    let spyEntries: SinonStubbedFunction<PerformanceEntry[]>;
+
+    const stubNavigationEntry = (
+      missingField: keyof PerformanceNavigationTiming,
+    ) => {
+      const incomplete: Partial<PerformanceNavigationTiming> = { ...entries };
+      delete incomplete[missingField];
+      spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([incomplete]);
+      spyEntries.withArgs('resource').returns([]);
+      spyEntries.withArgs('paint').returns([]);
+    };
+
+    afterEach(() => {
+      spyEntries.restore();
+    });
+
+    /* Every span hangs off the documentLoad span, which needs a start time. */
+    it('should export no spans when fetchStart is missing', (done) => {
+      stubNavigationEntry('fetchStart');
+
+      plugin.enable();
+
+      setTimeout(() => {
+        assert.strictEqual(exporter.getFinishedSpans().length, 0);
+        done();
+      });
+    });
+
+    it('should end the documentFetch span at the current time when responseEnd is missing', (done) => {
+      stubNavigationEntry('responseEnd');
+
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'documentFetch');
+        assert.isOk(fetchSpan);
+        assert.isAbove(hrTimeToMilliseconds(fetchSpan.endTime), 0);
+        done();
+      });
+    });
+  });
+
   const shouldExportCorrectSpan = () => {
     it('should export correct span with events', (done) => {
       plugin.enable();
@@ -746,6 +813,22 @@ describe('DocumentLoad Instrumentation', () => {
         done();
       });
     });
+
+    it('should still create the spans if the resourceFetch function throws error', (done) => {
+      plugin = new DocumentLoadInstrumentation({
+        enabled: false,
+        applyCustomAttributesOnSpan: {
+          resourceFetch: (_span) => {
+            throw new Error('test error');
+          },
+        },
+      });
+      plugin.enable();
+      setTimeout(() => {
+        assert.strictEqual(exporter.getFinishedSpans().length, 4);
+        done();
+      });
+    });
   });
 
   describe('resource attributes and quality flags', () => {
@@ -850,6 +933,58 @@ describe('DocumentLoad Instrumentation', () => {
         assert.strictEqual(
           resourceSpan.attributes['http.request.prevented'],
           true,
+        );
+        done();
+      });
+    });
+
+    /*
+     * Safari omits size fields outright rather than reporting them as 0, so the
+     * quality flags have to read an absent field as no data.
+     */
+    it('should treat absent size and timing fields as zero', (done) => {
+      const resourceWithoutSizes: Partial<(typeof resources)[0]> = {
+        ...resources[0],
+        fetchStart: 20.985,
+      };
+      delete resourceWithoutSizes.transferSize;
+      delete resourceWithoutSizes.encodedBodySize;
+      delete resourceWithoutSizes.decodedBodySize;
+      delete resourceWithoutSizes.responseEnd;
+      spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([entries]);
+      spyEntries.withArgs('resource').returns([resourceWithoutSizes]);
+      spyEntries.withArgs('paint').returns([]);
+
+      plugin.enable();
+      setTimeout(() => {
+        const resourceSpan = exporter.getFinishedSpans()[1];
+        assert.strictEqual(
+          resourceSpan.attributes['http.request.incomplete'],
+          true,
+        );
+        assert.isUndefined(
+          resourceSpan.attributes['http.response.cache_revalidated'],
+        );
+        done();
+      });
+    });
+
+    /* A resource with no fetchStart has no start time, so it gets no span. */
+    it('should skip a resource whose fetchStart is missing', (done) => {
+      const resourceWithoutFetchStart: Partial<(typeof resources)[0]> = {
+        ...resources[0],
+      };
+      delete resourceWithoutFetchStart.fetchStart;
+      spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([entries]);
+      spyEntries.withArgs('resource').returns([resourceWithoutFetchStart]);
+      spyEntries.withArgs('paint').returns([]);
+
+      plugin.enable();
+      setTimeout(() => {
+        assert.isUndefined(
+          exporter.getFinishedSpans().find((s) => s.name === 'resourceFetch'),
         );
         done();
       });
@@ -1206,13 +1341,15 @@ describe('DocumentLoad Instrumentation', () => {
       assert.strictEqual(documentLoadSpans().length, 0);
     });
 
-    it('should collect only once across an enable, disable, enable cycle', () => {
+    it('should collect only once across an enable, disable, enable cycle', async () => {
       plugin.enable();
       completeLoadEvent();
       plugin.disable();
 
-      // Re-enabling now finds the finished entry already on the timeline.
+      // Re-enabling subscribes with buffered set, so the finished entry is
+      // replayed and reaches collection a second time.
       plugin.enable();
+      await afterPendingTasks();
 
       assert.strictEqual(documentLoadSpans().length, 1);
     });

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -350,7 +350,7 @@ describe('DocumentLoad Instrumentation', () => {
 
     /* The entry alone decides when to collect; readyState takes no part. */
     ['complete', 'loading', 'interactive'].forEach((readyState) => {
-      it(`should collect from the replayed entry when readyState is ${readyState}`, (done) => {
+      it(`should collect from the timeline entry when readyState is ${readyState}`, (done) => {
         Object.defineProperty(window.document, 'readyState', {
           writable: true,
           value: readyState,
@@ -1213,13 +1213,6 @@ describe('DocumentLoad Instrumentation', () => {
       assert.strictEqual(result[PTN.FETCH_START], entries.fetchStart);
       assert.strictEqual(result[PTN.LOAD_EVENT_END], entries.loadEventEnd);
     });
-
-    it('should return no entries when the timeline has no navigation entry', () => {
-      const spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
-      spyEntries.withArgs('navigation').returns([]);
-
-      assert.deepStrictEqual(getPerformanceNavigationEntries(), {});
-    });
   });
 
   describe('navigation entry observer', () => {
@@ -1346,22 +1339,35 @@ describe('DocumentLoad Instrumentation', () => {
       completeLoadEvent();
       plugin.disable();
 
-      // Re-enabling subscribes with buffered set, so the finished entry is
-      // replayed and reaches collection a second time.
+      // Re-enabling sees the completed entry on the timeline, so a deferred
+      // read reaches collection a second time.
       plugin.enable();
       await afterPendingTasks();
 
       assert.strictEqual(documentLoadSpans().length, 1);
     });
 
-    it('should collect nothing when the navigation entry type is unobservable', async () => {
+    it('should warn and collect nothing when the navigation entry type is unobservable', async () => {
       FakePerformanceObserver.supportedEntryTypes = [];
+      const warnings: string[] = [];
+      plugin = new DocumentLoadInstrumentation({
+        enabled: false,
+        diag: {
+          verbose: () => {},
+          debug: () => {},
+          info: () => {},
+          warn: (message: string) => warnings.push(message),
+          error: () => {},
+        },
+      });
+      plugin.setTracerProvider(provider);
 
       plugin.enable();
       await afterPendingTasks();
 
       assert.strictEqual(FakePerformanceObserver.instances.length, 0);
       assert.strictEqual(documentLoadSpans().length, 0);
+      assert.strictEqual(warnings.length, 1);
     });
   });
 
@@ -1382,15 +1388,15 @@ describe('DocumentLoad Instrumentation', () => {
     const documentLoadSpans = () =>
       exporter.getFinishedSpans().filter((s) => s.name === 'documentLoad');
 
-    /* The notification fired before a late SDK init subscribed, so only a
-     * buffered replay can still deliver the entry. */
-    it('should subscribe with the buffered flag', () => {
+    const afterPendingTasks = () =>
+      new Promise((resolve) => setTimeout(resolve, 10));
+
+    /* The notification fired before a late SDK init subscribed, so the
+     * finished entry is read off the timeline instead of observed. */
+    it('should not subscribe an observer', () => {
       plugin.enable();
 
-      assert.deepStrictEqual(FakePerformanceObserver.latest().observedOptions, {
-        type: 'navigation',
-        buffered: true,
-      });
+      assert.strictEqual(FakePerformanceObserver.instances.length, 0);
     });
 
     /* onEnable runs from the constructor, before the tracer provider is wired
@@ -1404,6 +1410,15 @@ describe('DocumentLoad Instrumentation', () => {
         assert.strictEqual(documentLoadSpans().length, 1);
         done();
       });
+    });
+
+    it('should collect nothing when disabled before the deferred read runs', async () => {
+      plugin.enable();
+      plugin.disable();
+
+      await afterPendingTasks();
+
+      assert.strictEqual(documentLoadSpans().length, 0);
     });
   });
 });

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -567,7 +567,10 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
 
     // buffered must stay false: mid-load, WebKit answers a buffered
     // subscription with the unfinished entry and counts it as the observer's
-    // one notification, so the finalized entry never arrives.
+    // one notification, so the finalized entry never arrives. Measured on
+    // Safari 26.6 and Playwright WebKit, 2026-08-13; the performance-timeline
+    // spec does not say whether a replay preempts a later notification, so
+    // treat neither engine's choice as guaranteed.
     this._navigationObserver = createPerformanceObserver(
       'navigation',
       () => {

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -127,14 +127,26 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
       return;
     }
 
+    // Latched before collecting, not after: a throw part way through has
+    // already emitted spans, so retrying on a later trigger would duplicate
+    // them. Both triggers reach this method, so the catch covers both.
     this._performanceCollected = true;
-    this._collectPerformance(getPerformanceNavigationEntries());
-    this._disconnectObserver();
+
+    try {
+      this._collectPerformance(getPerformanceNavigationEntries());
+    } catch (e) {
+      this._diag.error('failed to collect the document load', e);
+    } finally {
+      this._disconnectObserver();
+    }
   }
 
-  /* loadEventEnd is written only after every load event handler returns. */
+  /* loadEventEnd is written only after every load event handler returns. WebKit
+   * reports no navigation entry at all for about:blank, popups and srcdoc
+   * iframes, so the entry is optional rather than guaranteed. */
   private _isLoadEventFinished(): boolean {
-    return performance.getEntriesByType('navigation')[0].loadEventEnd > 0;
+    const [navigationTiming] = performance.getEntriesByType('navigation');
+    return (navigationTiming?.loadEventEnd ?? 0) > 0;
   }
 
   private _disconnectObserver(): void {
@@ -157,6 +169,11 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
         entries,
       );
       if (!rootSpan) {
+        // The only point where the SDK knows for certain that the page load is
+        // being dropped, and collection is latched so nothing will retry.
+        this._diag.warn(
+          'navigation entry has no fetchStart, document load will not be collected',
+        );
         return;
       }
       context.with(trace.setSpan(context.active(), rootSpan), () => {
@@ -542,9 +559,10 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
 
   public override onEnable(): void {
     // An unbuffered subscription registered after the load event is never
-    // notified, so collect straight away instead of observing. Deferred because
-    // onEnable runs from the constructor, before the tracer provider is wired:
-    // spans started synchronously would go unrecorded.
+    // notified, so collect straight away instead of observing. Deferred one
+    // microtask because under registerGlobally: false the tracer provider
+    // arrives from registerInstrumentations later in the same task as this
+    // constructor, and spans started before it go to a no-op tracer.
     if (this._isLoadEventFinished()) {
       queueMicrotask(() => {
         if (this._isEnabled) {

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -114,18 +114,41 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
   }
 
   /**
-   * Collects information about performance and creates appropriate spans
+   * The single entry point for collection, safe to call from any trigger and at
+   * most once in effect.
+   *
+   * The one navigation entry per document is mutated in place as the load
+   * progresses, so collecting before the load event finishes would record
+   * zeroed timings. Returning early instead leaves the observer subscribed for
+   * a later notification.
    */
-  private _collectPerformance(): void {
-    if (this._performanceCollected) {
+  private _collectIfLoadEventFinished(): void {
+    if (this._performanceCollected || !this._isLoadEventFinished()) {
       return;
     }
-    this._performanceCollected = true;
 
+    this._performanceCollected = true;
+    this._collectPerformance(getPerformanceNavigationEntries());
+    this._disconnectObserver();
+  }
+
+  /* loadEventEnd is written only after every load event handler returns. */
+  private _isLoadEventFinished(): boolean {
+    return performance.getEntriesByType('navigation')[0].loadEventEnd > 0;
+  }
+
+  private _disconnectObserver(): void {
+    this._navigationObserver?.disconnect();
+    this._navigationObserver = null;
+  }
+
+  /**
+   * Collects information about performance and creates appropriate spans
+   */
+  private _collectPerformance(entries: PerformanceEntries): void {
     const metaElement = Array.from(document.getElementsByTagName('meta')).find(
       (e) => e.getAttribute('name') === TRACE_PARENT_HEADER,
     );
-    const entries = getPerformanceNavigationEntries();
     const traceparent = metaElement?.content || '';
     context.with(propagation.extract(ROOT_CONTEXT, { traceparent }), () => {
       const rootSpan = this._startSpan(
@@ -517,46 +540,39 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
     }
   }
 
-  private _stopObserving(): void {
-    this._navigationObserver?.disconnect();
-    this._navigationObserver = null;
-  }
-
-  /* loadEventEnd is written immediately after the load event handlers finish. */
-  private _hasLoadEventCompleted(): boolean {
-    const [navigationTiming] = performance.getEntriesByType(
-      'navigation',
-    ) as PerformanceNavigationTiming[];
-
-    return (navigationTiming?.loadEventEnd ?? 0) > 0;
-  }
-
   public override onEnable(): void {
-    this._stopObserving();
+    // An unbuffered subscription registered after the load event is never
+    // notified, so collect straight away instead of observing. Deferred because
+    // onEnable runs from the constructor, before the tracer provider is wired:
+    // spans started synchronously would go unrecorded.
+    if (this._isLoadEventFinished()) {
+      queueMicrotask(() => {
+        if (this._isEnabled) {
+          this._collectIfLoadEventFinished();
+        }
+      });
+      return;
+    }
 
-    /*
-     * Collection always waits for an observer notification: onEnable runs from
-     * the constructor, before the tracer provider is wired on, so spans started
-     * synchronously here would go unrecorded.
-     *
-     * Buffering is only safe once the load has completed. Mid-flight, WebKit
-     * answers a buffered subscription with the incomplete entry and counts that
-     * as the observer's one notification, losing the load entirely.
-     */
-    const buffered = this._hasLoadEventCompleted();
+    // buffered must stay false: mid-load, WebKit answers a buffered
+    // subscription with the unfinished entry and counts it as the observer's
+    // one notification, so the finalized entry never arrives.
+    this._navigationObserver = createPerformanceObserver(
+      'navigation',
+      () => {
+        this._collectIfLoadEventFinished();
+      },
+      { buffered: false, diag: this._diag },
+    );
 
-    this._navigationObserver =
-      createPerformanceObserver<PerformanceNavigationTiming>(
-        'navigation',
-        () => {
-          this._stopObserving();
-          this._collectPerformance();
-        },
-        { buffered, diag: this._diag },
+    if (!this._navigationObserver) {
+      this._diag.warn(
+        'navigation entries are not observable, document load will not be collected',
       );
+    }
   }
 
   public override onDisable(): void {
-    this._stopObserving();
+    this._disconnectObserver();
   }
 }

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -101,11 +101,6 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
     }
   }
 
-  protected override init() {
-    this._diag.debug('Initializing document load instrumentation');
-    return undefined;
-  }
-
   /**
    * Adds spans for all resources
    * @param rootSpan

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -35,6 +35,7 @@ import {
   ATTR_USER_AGENT_ORIGINAL,
 } from '@opentelemetry/semantic-conventions/incubating';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/index.ts';
+import { createPerformanceObserver } from '../../../utils/index.ts';
 import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
 import { AttributeNames } from './enums/AttributeNames.ts';
 import type {
@@ -71,7 +72,7 @@ const ATTR_HTTP_REQUEST_INCOMPLETE = 'http.request.incomplete'; // Request start
 const ATTR_HTTP_REQUEST_PREVENTED = 'http.request.prevented'; // Request never started (blocked)
 
 export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<DocumentLoadInstrumentationConfig> {
-  private readonly _onDocumentLoaded: () => void;
+  private _navigationObserver: PerformanceObserver | null = null;
   private _performanceCollected = false;
 
   public constructor({
@@ -94,13 +95,6 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
         ignoreNetworkEvents,
       },
     });
-
-    this._onDocumentLoaded = () => {
-      // Timeout needed because performance metrics for loadEnd aren't available until after the load event
-      window.setTimeout(() => {
-        this._collectPerformance();
-      }, 0);
-    };
 
     if (this._config.enabled) {
       this.enable();
@@ -380,17 +374,6 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
   }
 
   /**
-   * Executes callback {_onDocumentLoaded} when the page is loaded
-   */
-  private _waitForPageLoad() {
-    if (window.document.readyState === 'complete') {
-      this._onDocumentLoaded();
-    } else {
-      window.addEventListener('load', this._onDocumentLoaded);
-    }
-  }
-
-  /**
    * Adds custom attributes to span if configured
    * Used for both documentFetch and documentLoad spans
    */
@@ -539,12 +522,55 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
     }
   }
 
+  private _stopObserving(): void {
+    this._navigationObserver?.disconnect();
+    this._navigationObserver = null;
+  }
+
+  /* loadEventEnd is written immediately after the load event handlers finish. */
+  private _hasLoadEventCompleted(): boolean {
+    const [navigationTiming] = performance.getEntriesByType('navigation');
+
+    return (
+      !!navigationTiming &&
+      (navigationTiming as PerformanceNavigationTiming).loadEventEnd > 0
+    );
+  }
+
   public override onEnable(): void {
-    window.removeEventListener('load', this._onDocumentLoaded);
-    this._waitForPageLoad();
+    this._stopObserving();
+
+    // A load that already completed is never announced again, so its entry has
+    // to be read off the timeline rather than waited for.
+    if (this._hasLoadEventCompleted()) {
+      this._collectPerformance();
+      return;
+    }
+
+    /*
+     * The entry is on the timeline but the browser has not written
+     * loadEventEnd yet. An observer without the buffered flag is notified
+     * exactly once, when the load event completes, and serves purely as that
+     * signal: the values are read back off the timeline entry the browser has
+     * since filled in.
+     *
+     * buffered: true must not be used here. It is answered with the entry as
+     * it currently stands, and in WebKit that answer consumes the observer's
+     * only notification, so the completed entry never arrives and the whole
+     * document load goes unreported.
+     */
+    this._navigationObserver =
+      createPerformanceObserver<PerformanceNavigationTiming>(
+        'navigation',
+        () => {
+          this._stopObserving();
+          this._collectPerformance();
+        },
+        { buffered: false, diag: this._diag },
+      );
   }
 
   public override onDisable(): void {
-    window.removeEventListener('load', this._onDocumentLoaded);
+    this._stopObserving();
   }
 }

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -114,26 +114,22 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
   }
 
   /**
-   * The single entry point for collection, safe to call from any trigger and at
-   * most once in effect.
-   *
    * The one navigation entry per document is mutated in place as the load
-   * progresses, so collecting before the load event finishes would record
-   * zeroed timings. Returning early instead leaves the observer subscribed for
-   * a later notification.
+   * progresses, so collecting early would end the documentLoad span at time
+   * origin. Returning early leaves the observer subscribed for a later
+   * notification.
    */
   private _collectIfLoadEventFinished(): void {
     if (this._performanceCollected || !this._isLoadEventFinished()) {
       return;
     }
 
-    // Latched before collecting, not after: a throw part way through has
-    // already emitted spans, so retrying on a later trigger would duplicate
-    // them. Both triggers reach this method, so the catch covers both.
+    // Latched before collecting so a throw part way through cannot emit a
+    // second set of spans on a later trigger.
     this._performanceCollected = true;
 
     try {
-      this._collectPerformance(getPerformanceNavigationEntries());
+      this._collectPerformance();
     } catch (e) {
       this._diag.error('failed to collect the document load', e);
     } finally {
@@ -141,9 +137,8 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
     }
   }
 
-  /* loadEventEnd is written only after every load event handler returns. WebKit
-   * reports no navigation entry at all for about:blank, popups and srcdoc
-   * iframes, so the entry is optional rather than guaranteed. */
+  /* loadEventEnd is written only after every load handler returns. WebKit
+   * reports no entry at all for about:blank, popups and srcdoc iframes. */
   private _isLoadEventFinished(): boolean {
     const [navigationTiming] = performance.getEntriesByType('navigation');
     return (navigationTiming?.loadEventEnd ?? 0) > 0;
@@ -157,10 +152,11 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
   /**
    * Collects information about performance and creates appropriate spans
    */
-  private _collectPerformance(entries: PerformanceEntries): void {
+  private _collectPerformance(): void {
     const metaElement = Array.from(document.getElementsByTagName('meta')).find(
       (e) => e.getAttribute('name') === TRACE_PARENT_HEADER,
     );
+    const entries = getPerformanceNavigationEntries();
     const traceparent = metaElement?.content || '';
     context.with(propagation.extract(ROOT_CONTEXT, { traceparent }), () => {
       const rootSpan = this._startSpan(
@@ -169,8 +165,6 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
         entries,
       );
       if (!rootSpan) {
-        // The only point where the SDK knows for certain that the page load is
-        // being dropped, and collection is latched so nothing will retry.
         this._diag.warn(
           'navigation entry has no fetchStart, document load will not be collected',
         );
@@ -559,10 +553,9 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
 
   public override onEnable(): void {
     // An unbuffered subscription registered after the load event is never
-    // notified, so collect straight away instead of observing. Deferred one
+    // notified, so collect straight away instead of observing. Deferred a
     // microtask because under registerGlobally: false the tracer provider
-    // arrives from registerInstrumentations later in the same task as this
-    // constructor, and spans started before it go to a no-op tracer.
+    // arrives later in this same task, and earlier spans reach a no-op tracer.
     if (this._isLoadEventFinished()) {
       queueMicrotask(() => {
         if (this._isEnabled) {

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -529,36 +529,27 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
 
   /* loadEventEnd is written immediately after the load event handlers finish. */
   private _hasLoadEventCompleted(): boolean {
-    const [navigationTiming] = performance.getEntriesByType('navigation');
+    const [navigationTiming] = performance.getEntriesByType(
+      'navigation',
+    ) as PerformanceNavigationTiming[];
 
-    return (
-      !!navigationTiming &&
-      (navigationTiming as PerformanceNavigationTiming).loadEventEnd > 0
-    );
+    return (navigationTiming?.loadEventEnd ?? 0) > 0;
   }
 
   public override onEnable(): void {
     this._stopObserving();
 
-    // A load that already completed is never announced again, so its entry has
-    // to be read off the timeline rather than waited for.
-    if (this._hasLoadEventCompleted()) {
-      this._collectPerformance();
-      return;
-    }
-
     /*
-     * The entry is on the timeline but the browser has not written
-     * loadEventEnd yet. An observer without the buffered flag is notified
-     * exactly once, when the load event completes, and serves purely as that
-     * signal: the values are read back off the timeline entry the browser has
-     * since filled in.
+     * Collection always waits for an observer notification: onEnable runs from
+     * the constructor, before the tracer provider is wired on, so spans started
+     * synchronously here would go unrecorded.
      *
-     * buffered: true must not be used here. It is answered with the entry as
-     * it currently stands, and in WebKit that answer consumes the observer's
-     * only notification, so the completed entry never arrives and the whole
-     * document load goes unreported.
+     * Buffering is only safe once the load has completed. Mid-flight, WebKit
+     * answers a buffered subscription with the incomplete entry and counts that
+     * as the observer's one notification, losing the load entirely.
      */
+    const buffered = this._hasLoadEventCompleted();
+
     this._navigationObserver =
       createPerformanceObserver<PerformanceNavigationTiming>(
         'navigation',
@@ -566,7 +557,7 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
           this._stopObserving();
           this._collectPerformance();
         },
-        { buffered: false, diag: this._diag },
+        { buffered, diag: this._diag },
       );
   }
 

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
@@ -9,15 +9,24 @@ import { hasKey, PerformanceTimingNames } from '@opentelemetry/sdk-trace-web';
 import type { PerformanceManager } from '../../../utils/index.ts';
 import { EventNames } from './enums/EventNames.ts';
 
+/**
+ * Reads the timing fields off the document's navigation timing entry. There is
+ * one such entry per document and the browser mutates it in place as the load
+ * progresses, so reading it after the load event completes is what yields the
+ * completed values.
+ */
 export const getPerformanceNavigationEntries = (): PerformanceEntries => {
   const entries: PerformanceEntries = {};
-  const performanceNavigationTiming =
-    window.performance.getEntriesByType('navigation')[0];
+  const [navigationTiming] = window.performance.getEntriesByType('navigation');
+
+  if (!navigationTiming) {
+    return entries;
+  }
 
   const keys = Object.values(PerformanceTimingNames);
   keys.forEach((key: PerformanceTimingNames) => {
-    if (hasKey(performanceNavigationTiming, key)) {
-      const value = performanceNavigationTiming[key];
+    if (hasKey(navigationTiming, key)) {
+      const value = navigationTiming[key];
       if (typeof value === 'number') {
         entries[key] = value;
       }

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
@@ -12,6 +12,9 @@ import { EventNames } from './enums/EventNames.ts';
 export const getPerformanceNavigationEntries = (): PerformanceEntries => {
   const entries: PerformanceEntries = {};
   const [navigationTiming] = performance.getEntriesByType('navigation');
+  if (!navigationTiming) {
+    return entries;
+  }
 
   const keys = Object.values(PerformanceTimingNames);
   keys.forEach((key: PerformanceTimingNames) => {

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
@@ -9,19 +9,9 @@ import { hasKey, PerformanceTimingNames } from '@opentelemetry/sdk-trace-web';
 import type { PerformanceManager } from '../../../utils/index.ts';
 import { EventNames } from './enums/EventNames.ts';
 
-/**
- * Reads the timing fields off the document's navigation timing entry. There is
- * one such entry per document and the browser mutates it in place as the load
- * progresses, so reading it after the load event completes is what yields the
- * completed values.
- */
 export const getPerformanceNavigationEntries = (): PerformanceEntries => {
   const entries: PerformanceEntries = {};
-  const [navigationTiming] = window.performance.getEntriesByType('navigation');
-
-  if (!navigationTiming) {
-    return entries;
-  }
+  const [navigationTiming] = performance.getEntriesByType('navigation');
 
   const keys = Object.values(PerformanceTimingNames);
   keys.forEach((key: PerformanceTimingNames) => {
@@ -45,7 +35,7 @@ export const addSpanPerformancePaintEvents = (
   span: Span,
   perf: PerformanceManager,
 ) => {
-  const performancePaintTiming = window.performance.getEntriesByType('paint');
+  const performancePaintTiming = performance.getEntriesByType('paint');
   performancePaintTiming.forEach(({ name, startTime }) => {
     if (hasKey(performancePaintNames, name)) {
       span.addEvent(

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
@@ -11,15 +11,16 @@ import { EventNames } from './enums/EventNames.ts';
 
 export const getPerformanceNavigationEntries = (): PerformanceEntries => {
   const entries: PerformanceEntries = {};
-  const [navigationTiming] = performance.getEntriesByType('navigation');
-  if (!navigationTiming) {
+  const performanceNavigationTiming =
+    window.performance.getEntriesByType('navigation')[0];
+  if (!performanceNavigationTiming) {
     return entries;
   }
 
   const keys = Object.values(PerformanceTimingNames);
   keys.forEach((key: PerformanceTimingNames) => {
-    if (hasKey(navigationTiming, key)) {
-      const value = navigationTiming[key];
+    if (hasKey(performanceNavigationTiming, key)) {
+      const value = performanceNavigationTiming[key];
       if (typeof value === 'number') {
         entries[key] = value;
       }
@@ -38,7 +39,7 @@ export const addSpanPerformancePaintEvents = (
   span: Span,
   perf: PerformanceManager,
 ) => {
-  const performancePaintTiming = performance.getEntriesByType('paint');
+  const performancePaintTiming = window.performance.getEntriesByType('paint');
   performancePaintTiming.forEach(({ name, startTime }) => {
     if (hasKey(performancePaintNames, name)) {
       span.addEvent(

--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -2027,6 +2027,17 @@ describe('isolated instances', () => {
       logExporters: [logExporter],
       spanExporters: [spanExporter],
       registerGlobally: false,
+      // The instance's own default instrumentations emit on their own schedule,
+      // so leaving them on makes a zero-signal assertion depend on whether they
+      // land before or after the flush.
+      defaultInstrumentationConfig: {
+        omit: new Set([
+          'document-load',
+          'loaf',
+          'web-vital',
+          'max-scroll-depth',
+        ]),
+      },
     });
 
     void expect(result).not.to.be.false;

--- a/packages/web-sdk/src/utils/performanceObserver/performanceObserver.ts
+++ b/packages/web-sdk/src/utils/performanceObserver/performanceObserver.ts
@@ -14,8 +14,9 @@ export function isEntryTypeSupported(type: string): boolean {
  * Each entry is passed individually to `processEntry`. Errors thrown by `processEntry` are caught
  * and logged via `diag` (if provided) so that one bad entry does not block the rest.
  *
- * Note: The observer is created with the "buffered" option set to true, so it will receive entries
- * that were recorded before the observer was created.
+ * Note: "buffered" defaults to true, so the observer receives entries that were recorded before it
+ * was created. Callers may override it, and should when a replay of an unfinished entry would be
+ * mistaken for the final one.
  * buffered: true is not supported when observing multiple entry types, so if you need to observe
  * multiple types, you should create separate observers for each type with buffered: true.
  * See https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe#entrytypes

--- a/packages/web-sdk/src/utils/performanceObserver/performanceObserver.ts
+++ b/packages/web-sdk/src/utils/performanceObserver/performanceObserver.ts
@@ -14,9 +14,8 @@ export function isEntryTypeSupported(type: string): boolean {
  * Each entry is passed individually to `processEntry`. Errors thrown by `processEntry` are caught
  * and logged via `diag` (if provided) so that one bad entry does not block the rest.
  *
- * Note: "buffered" defaults to true, so the observer receives entries that were recorded before it
- * was created. Callers may override it, and should when a replay of an unfinished entry would be
- * mistaken for the final one.
+ * Note: "buffered" defaults to true, so the observer will receive entries that were recorded
+ * before the observer was created. Callers may override it.
  * buffered: true is not supported when observing multiple entry types, so if you need to observe
  * multiple types, you should create separate observers for each type with buffered: true.
  * See https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe#entrytypes


### PR DESCRIPTION
## What problem is this solving?

`DocumentLoadInstrumentation` waited for navigation timing with a `readyState` check, a `load` listener and a `setTimeout(…, 0)`. The timeout guessed when the browser writes `loadEventEnd` instead of waiting for a signal, and `onDisable()` could not cancel it, so disabling mid-load still emitted spans. Safari reported no document load, fetch or resource spans at all.

## Short description of changes

- `onEnable` branches on `loadEventEnd`: already finished, collect on a microtask; still loading, subscribe a `navigation` PerformanceObserver with `buffered: false`.
- `_collectIfLoadEventFinished()` is the single entry point for both triggers. It re-checks `loadEventEnd`, so a zeroed entry can never produce a span with zeroed timings, and disconnects the observer once it has collected.
- `onDisable()` is now just `disconnect()`, so disabling is exact.
- The navigation entry is treated as optional. WebKit reports none at all for `about:blank`, popups and `srcdoc` iframes, and this code runs from the constructor inside `initSDK`'s try block, so an unguarded read there would fail the whole SDK init rather than just this instrumentation.
- Collection is wrapped so a throw is reported through `diag` and the observer is still disconnected. The one path that knowingly drops a page load, a navigation entry with no `fetchStart`, now warns instead of going silent.

`buffered` must stay `false`: mid-load, WebKit answers a buffered subscription with the unfinished entry and counts it as the observer's one notification, so the finalized entry never arrives.

The microtask covers an unrelated race. Under `registerGlobally: false` the tracer provider arrives from `registerInstrumentations` later in the same task as the constructor, so collecting synchronously would start spans on a no-op tracer. Under the default `registerGlobally: true` the global provider is already installed before instrumentations are constructed.

Behavior change: nothing is collected if `loadEventEnd` never becomes non-zero, where before a span ended at wall clock. That needs the load event to never fire, in which case the old listener never ran either.

## How has this been tested?

- 50 unit tests, including a fake `PerformanceObserver` modelling WebKit's buffered semantics. Both `buffered: false` and the microtask fail tests if removed.
- The `loadEventEnd` re-check and the optional-entry guard were each confirmed by deleting them and watching tests fail, so neither can be dropped silently.
- Confirmed in real Safari 26.6, not only Playwright's WebKit build.
- `npm run check` and `npm run lint` from the repo root.

Integration coverage for the mid-load path needs a `server/` page fixture and delayed-subresource endpoint, not included here.

## Checklist

- [ ] Documentation added
- [x] Tests added
