### PR TITLE
refactor(instrumentation-document-load): stop guarding resource fields that are always numbers

### DIFF
--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -945,38 +945,6 @@ describe('DocumentLoad Instrumentation', () => {
       });
     });
 
-    /*
-     * Safari omits size fields outright rather than reporting them as 0, so the
-     * quality flags have to read an absent field as no data.
-     */
-    it('should treat absent size and timing fields as zero', (done) => {
-      const resourceWithoutSizes: Partial<(typeof resources)[0]> = {
-        ...resources[0],
-        fetchStart: 20.985,
-      };
-      delete resourceWithoutSizes.transferSize;
-      delete resourceWithoutSizes.encodedBodySize;
-      delete resourceWithoutSizes.decodedBodySize;
-      delete resourceWithoutSizes.responseEnd;
-      spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
-      spyEntries.withArgs('navigation').returns([entries]);
-      spyEntries.withArgs('resource').returns([resourceWithoutSizes]);
-      spyEntries.withArgs('paint').returns([]);
-
-      plugin.enable();
-      setTimeout(() => {
-        const resourceSpan = exporter.getFinishedSpans()[1];
-        assert.strictEqual(
-          resourceSpan.attributes['http.request.incomplete'],
-          true,
-        );
-        assert.isUndefined(
-          resourceSpan.attributes['http.response.cache_revalidated'],
-        );
-        done();
-      });
-    });
-
     /* A resource with no fetchStart has no start time, so it gets no span. */
     it('should skip a resource whose fetchStart is missing', (done) => {
       const resourceWithoutFetchStart: Partial<(typeof resources)[0]> = {

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -338,30 +338,12 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
       );
     }
 
-    // Validate size fields exist and aren't negative
-    if (
-      typeof resource.encodedBodySize === 'number' &&
-      resource.encodedBodySize >= 0
-    ) {
-      span.setAttribute(ATTR_HTTP_RESPONSE_BODY_SIZE, resource.encodedBodySize);
-    }
-
-    if (
-      typeof resource.transferSize === 'number' &&
-      resource.transferSize >= 0
-    ) {
-      span.setAttribute(ATTR_HTTP_RESPONSE_SIZE, resource.transferSize);
-    }
-
-    if (
-      typeof resource.decodedBodySize === 'number' &&
-      resource.decodedBodySize >= 0
-    ) {
-      span.setAttribute(
-        ATTR_HTTP_RESPONSE_DECODED_BODY_SIZE,
-        resource.decodedBodySize,
-      );
-    }
+    span.setAttribute(ATTR_HTTP_RESPONSE_BODY_SIZE, resource.encodedBodySize);
+    span.setAttribute(ATTR_HTTP_RESPONSE_SIZE, resource.transferSize);
+    span.setAttribute(
+      ATTR_HTTP_RESPONSE_DECODED_BODY_SIZE,
+      resource.decodedBodySize,
+    );
 
     this._addResourceDiagnosticAttributes(span, resource);
 
@@ -457,25 +439,15 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
   }
 
   private _hasNoSizeData(resource: EmbracePerformanceResourceTiming): boolean {
-    const transferSize =
-      typeof resource.transferSize === 'number' ? resource.transferSize : 0;
-    const decodedBodySize =
-      typeof resource.decodedBodySize === 'number'
-        ? resource.decodedBodySize
-        : 0;
-    const encodedBodySize =
-      typeof resource.encodedBodySize === 'number'
-        ? resource.encodedBodySize
-        : 0;
-
-    return transferSize === 0 && decodedBodySize === 0 && encodedBodySize === 0;
+    return (
+      resource.transferSize === 0 &&
+      resource.decodedBodySize === 0 &&
+      resource.encodedBodySize === 0
+    );
   }
 
   private _hasTimingData(resource: EmbracePerformanceResourceTiming): boolean {
-    const responseEnd =
-      typeof resource.responseEnd === 'number' ? resource.responseEnd : 0;
-
-    return resource.fetchStart > 0 && responseEnd > 0;
+    return resource.fetchStart > 0 && resource.responseEnd > 0;
   }
 
   private _isCorsRestricted(
@@ -487,13 +459,10 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
   private _isFetchIncomplete(
     resource: EmbracePerformanceResourceTiming,
   ): boolean {
-    const responseEnd =
-      typeof resource.responseEnd === 'number' ? resource.responseEnd : 0;
-
     return (
       this._hasNoSizeData(resource) &&
       resource.fetchStart > 0 &&
-      responseEnd === 0
+      resource.responseEnd === 0
     );
   }
 
@@ -514,12 +483,8 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
   private _isCacheValidated(
     resource: EmbracePerformanceResourceTiming,
   ): boolean {
-    const transferSize =
-      typeof resource.transferSize === 'number' ? resource.transferSize : 0;
-    const deliveryType =
-      typeof resource.deliveryType === 'string' ? resource.deliveryType : '';
-
-    return transferSize === 300 && deliveryType !== 'cache';
+    // deliveryType is Chromium only, so an engine without it never reads 'cache'.
+    return resource.transferSize === 300 && resource.deliveryType !== 'cache';
   }
 
   /**
@@ -531,8 +496,10 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
    * - Request incomplete (started but didn't complete - network error, aborted)
    * - Request prevented (never started - blocked by CSP, browser, extension)
    *
-   * Only a resource that produced a span reaches here, which already required a
-   * numeric fetchStart, so the checks below can read it without a guard.
+   * The size and timing fields read below are always numbers: a cross-origin
+   * resource with no Timing-Allow-Origin reports them as 0 rather than omitting
+   * them, and a resource only reaches here once it has produced a span, which
+   * required a numeric fetchStart.
    */
   private _addResourceDiagnosticAttributes(
     span: Span,

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -472,12 +472,10 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
   }
 
   private _hasTimingData(resource: EmbracePerformanceResourceTiming): boolean {
-    const fetchStart =
-      typeof resource.fetchStart === 'number' ? resource.fetchStart : 0;
     const responseEnd =
       typeof resource.responseEnd === 'number' ? resource.responseEnd : 0;
 
-    return fetchStart > 0 && responseEnd > 0;
+    return resource.fetchStart > 0 && responseEnd > 0;
   }
 
   private _isCorsRestricted(
@@ -489,21 +487,20 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
   private _isFetchIncomplete(
     resource: EmbracePerformanceResourceTiming,
   ): boolean {
-    const fetchStart =
-      typeof resource.fetchStart === 'number' ? resource.fetchStart : 0;
     const responseEnd =
       typeof resource.responseEnd === 'number' ? resource.responseEnd : 0;
 
-    return this._hasNoSizeData(resource) && fetchStart > 0 && responseEnd === 0;
+    return (
+      this._hasNoSizeData(resource) &&
+      resource.fetchStart > 0 &&
+      responseEnd === 0
+    );
   }
 
   private _isFetchPrevented(
     resource: EmbracePerformanceResourceTiming,
   ): boolean {
-    const fetchStart =
-      typeof resource.fetchStart === 'number' ? resource.fetchStart : 0;
-
-    return this._hasNoSizeData(resource) && fetchStart === 0;
+    return this._hasNoSizeData(resource) && resource.fetchStart === 0;
   }
 
   /**
@@ -533,6 +530,9 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
    * - Cache revalidation (304 Not Modified responses)
    * - Request incomplete (started but didn't complete - network error, aborted)
    * - Request prevented (never started - blocked by CSP, browser, extension)
+   *
+   * Only a resource that produced a span reaches here, which already required a
+   * numeric fetchStart, so the checks below can read it without a guard.
    */
   private _addResourceDiagnosticAttributes(
     span: Span,


### PR DESCRIPTION
> Stacked on #1491. Review that one first.

## What problem is this solving?

The resource quality flags guard every size and timing field with `typeof resource.x === 'number' ? resource.x : 0`, but none of those fallbacks can run. The three size fields are Baseline since March 2023 and report `0` for a cross-origin resource rather than being omitted; `responseEnd` is Baseline since 2017 and needs no `Timing-Allow-Origin`. `fetchStart` is stricter still: only a resource that produced a span reaches these checks, and that already required a numeric `fetchStart`.

The guards arrived with the feature that added the flags (#860), not from a bug report.

## Short description of changes

- Read the fields directly in the five quality-flag helpers, and set the three size attributes unconditionally. A conformant entry always passed the old check, so nothing changes on the wire.
- Drop the test that deleted those fields from a resource, a state no supported browser produces.

`deliveryType` keeps its check: Chromium only, and typed optional.

## How has this been tested?

44 unit tests pass. The file reaches 100% line and branch coverage, the removed guards having been its only partial branches.

## Checklist

- [ ] Documentation added
- [ ] Tests added
