### PR TITLE
EMBR-13621 fix(instrumentation-server-timing): read server timings from an observer notification

### DIFF
--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
@@ -39,9 +39,9 @@ const makeNavigationEntry = (
  * arrives. Engines replay a buffered entry in a later task, never inside
  * observe(), which is what keeps the read out of the constructor.
  */
-class FakeNavigationObserver {
+class FakePerformanceObserver {
   public static supportedEntryTypes: string[] = ['navigation'];
-  public static instances: FakeNavigationObserver[] = [];
+  public static instances: FakePerformanceObserver[] = [];
 
   public observedOptions: PerformanceObserverInit | null = null;
   public isDisconnected = false;
@@ -49,7 +49,16 @@ class FakeNavigationObserver {
 
   public constructor(callback: PerformanceObserverCallback) {
     this._callback = callback;
-    FakeNavigationObserver.instances.push(this);
+    FakePerformanceObserver.instances.push(this);
+  }
+
+  public static latest(): FakePerformanceObserver {
+    const observer =
+      FakePerformanceObserver.instances[
+        FakePerformanceObserver.instances.length - 1
+      ];
+    expect(observer, 'expected an observer to have been created').to.be.ok;
+    return observer;
   }
 
   public observe(options: PerformanceObserverInit): void {
@@ -128,10 +137,10 @@ describe('ServerTimingInstrumentation', () => {
     addEventListenerSpy = sinon.spy(window, 'addEventListener');
 
     realPerformanceObserver = globalThis.PerformanceObserver;
-    FakeNavigationObserver.instances = [];
-    FakeNavigationObserver.supportedEntryTypes = ['navigation'];
+    FakePerformanceObserver.instances = [];
+    FakePerformanceObserver.supportedEntryTypes = ['navigation'];
     (globalThis as Record<string, unknown>)['PerformanceObserver'] =
-      FakeNavigationObserver;
+      FakePerformanceObserver;
 
     Object.defineProperty(window.document, 'readyState', {
       writable: true,
@@ -254,8 +263,7 @@ describe('ServerTimingInstrumentation', () => {
         limitManager,
       });
 
-      const [observer] = FakeNavigationObserver.instances;
-      expect(observer.observedOptions).to.deep.equal({
+      expect(FakePerformanceObserver.latest().observedOptions).to.deep.equal({
         type: 'navigation',
         buffered: true,
       });
@@ -401,7 +409,7 @@ describe('ServerTimingInstrumentation', () => {
 
     /* Nothing else re-triggers the read, so this is the one chance to say so. */
     it('warns and emits nothing when the navigation entry type is unobservable', () => {
-      FakeNavigationObserver.supportedEntryTypes = [];
+      FakePerformanceObserver.supportedEntryTypes = [];
       getEntriesByTypeStub
         .withArgs('navigation')
         .returns([makeNavigationEntry([makeServerTimingEntry()])]);
@@ -421,7 +429,7 @@ describe('ServerTimingInstrumentation', () => {
 
       deliverNavigationEntry();
 
-      expect(FakeNavigationObserver.instances).to.have.length(0);
+      expect(FakePerformanceObserver.instances).to.have.length(0);
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(0);
       expect(warnings.join(' ')).to.contain('navigation');
 

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
@@ -196,10 +196,10 @@ describe('ServerTimingInstrumentation', () => {
     });
 
     /*
-     * onEnable runs from the constructor, before the SDK wires the logger
-     * provider onto the instrumentation, so anything emitted synchronously
-     * there goes to a logger that records nothing and is lost for good: the
-     * collection guard latches and never retries.
+     * Under registerGlobally: false the logger provider is wired onto the
+     * instrumentation after the constructor returns, so anything emitted
+     * synchronously there goes to a logger that records nothing and is lost for
+     * good: the collection guard latches and never retries.
      */
     it('does not emit while constructing', () => {
       getEntriesByTypeStub
@@ -234,6 +234,31 @@ describe('ServerTimingInstrumentation', () => {
         ([event]) => event === 'load',
       );
       expect(loadListenerAdded).to.be.false;
+
+      instrumentation.disable();
+    });
+
+    /*
+     * The opposite of DocumentLoadInstrumentation, which must subscribe
+     * unbuffered. Server timings are complete on the entry from the start, and
+     * the SDK usually starts after it was buffered, so dropping the replay
+     * would mean never being notified.
+     */
+    it('subscribes with the buffered flag', () => {
+      getEntriesByTypeStub
+        .withArgs('navigation')
+        .returns([makeNavigationEntry([makeServerTimingEntry()])]);
+
+      const instrumentation = new ServerTimingInstrumentation({
+        perf,
+        limitManager,
+      });
+
+      const [observer] = FakeNavigationObserver.instances;
+      expect(observer.observedOptions).to.deep.equal({
+        type: 'navigation',
+        buffered: true,
+      });
 
       instrumentation.disable();
     });
@@ -352,6 +377,8 @@ describe('ServerTimingInstrumentation', () => {
         limitManager,
       });
 
+      deliverNavigationEntry();
+
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(0);
 
       instrumentation.disable();
@@ -365,7 +392,38 @@ describe('ServerTimingInstrumentation', () => {
         limitManager,
       });
 
+      deliverNavigationEntry();
+
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(0);
+
+      instrumentation.disable();
+    });
+
+    /* Nothing else re-triggers the read, so this is the one chance to say so. */
+    it('warns and emits nothing when the navigation entry type is unobservable', () => {
+      FakeNavigationObserver.supportedEntryTypes = [];
+      getEntriesByTypeStub
+        .withArgs('navigation')
+        .returns([makeNavigationEntry([makeServerTimingEntry()])]);
+      const warnings: string[] = [];
+
+      const instrumentation = new ServerTimingInstrumentation({
+        perf,
+        limitManager,
+        diag: {
+          verbose: () => {},
+          debug: () => {},
+          info: () => {},
+          warn: (message: string) => warnings.push(message),
+          error: () => {},
+        },
+      });
+
+      deliverNavigationEntry();
+
+      expect(FakeNavigationObserver.instances).to.have.length(0);
+      expect(memoryExporter.getFinishedLogRecords()).to.have.length(0);
+      expect(warnings.join(' ')).to.contain('navigation');
 
       instrumentation.disable();
     });

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
@@ -34,6 +34,52 @@ const makeNavigationEntry = (
 ): PerformanceNavigationTiming =>
   ({ serverTiming }) as unknown as PerformanceNavigationTiming;
 
+/*
+ * Stands in for PerformanceObserver so tests control when the navigation entry
+ * arrives. Engines replay a buffered entry in a later task, never inside
+ * observe(), which is what keeps the read out of the constructor.
+ */
+class FakeNavigationObserver {
+  public static supportedEntryTypes: string[] = ['navigation'];
+  public static instances: FakeNavigationObserver[] = [];
+
+  public observedOptions: PerformanceObserverInit | null = null;
+  public isDisconnected = false;
+  private readonly _callback: PerformanceObserverCallback;
+
+  public constructor(callback: PerformanceObserverCallback) {
+    this._callback = callback;
+    FakeNavigationObserver.instances.push(this);
+  }
+
+  public observe(options: PerformanceObserverInit): void {
+    this.observedOptions = options;
+    const [entry] = window.performance.getEntriesByType('navigation');
+
+    if (options.buffered && entry) {
+      setTimeout(() => {
+        if (this.isDisconnected) {
+          return;
+        }
+        this._callback(
+          {
+            getEntries: () => [entry],
+          } as unknown as PerformanceObserverEntryList,
+          this as unknown as PerformanceObserver,
+        );
+      }, 0);
+    }
+  }
+
+  public disconnect(): void {
+    this.isDisconnected = true;
+  }
+
+  public takeRecords(): PerformanceEntryList {
+    return [];
+  }
+}
+
 describe('ServerTimingInstrumentation', () => {
   let memoryExporter: InMemoryLogRecordExporter;
   let perf: MockPerformanceManager;
@@ -41,6 +87,7 @@ describe('ServerTimingInstrumentation', () => {
   let getEntriesByTypeStub: sinon.SinonStub;
   let addEventListenerSpy: sinon.SinonSpy;
   let limitManager: EmbraceLimitManager;
+  let realPerformanceObserver: typeof globalThis.PerformanceObserver;
 
   before(() => {
     memoryExporter = setupTestLogExporter();
@@ -80,13 +127,24 @@ describe('ServerTimingInstrumentation', () => {
     });
     addEventListenerSpy = sinon.spy(window, 'addEventListener');
 
+    realPerformanceObserver = globalThis.PerformanceObserver;
+    FakeNavigationObserver.instances = [];
+    FakeNavigationObserver.supportedEntryTypes = ['navigation'];
+    (globalThis as Record<string, unknown>)['PerformanceObserver'] =
+      FakeNavigationObserver;
+
     Object.defineProperty(window.document, 'readyState', {
       writable: true,
       value: 'complete',
     });
   });
 
+  /* Lets the queued buffered replay run. */
+  const deliverNavigationEntry = () => clock.tick(0);
+
   afterEach(() => {
+    (globalThis as Record<string, unknown>)['PerformanceObserver'] =
+      realPerformanceObserver;
     sinon.restore();
     Object.defineProperty(window.performance, 'getEntriesByType', {
       value: Performance.prototype.getEntriesByType,
@@ -99,8 +157,8 @@ describe('ServerTimingInstrumentation', () => {
     });
   });
 
-  describe('when document.readyState is complete', () => {
-    it('reads immediately and emits one log per server timing entry', () => {
+  describe('collecting server timings', () => {
+    it('emits one log per server timing entry', () => {
       getEntriesByTypeStub.withArgs('navigation').returns([
         makeNavigationEntry([
           makeServerTimingEntry({ name: 'db', duration: 78, description: '' }),
@@ -116,6 +174,7 @@ describe('ServerTimingInstrumentation', () => {
         perf,
         limitManager,
       });
+      deliverNavigationEntry();
 
       const logs = memoryExporter.getFinishedLogRecords();
       expect(logs).to.have.length(2);
@@ -132,6 +191,31 @@ describe('ServerTimingInstrumentation', () => {
       expect(logs[1].attributes['emb.server_timing.description']).to.equal(
         'HIT',
       );
+
+      instrumentation.disable();
+    });
+
+    /*
+     * onEnable runs from the constructor, before the SDK wires the logger
+     * provider onto the instrumentation, so anything emitted synchronously
+     * there goes to a logger that records nothing and is lost for good: the
+     * collection guard latches and never retries.
+     */
+    it('does not emit while constructing', () => {
+      getEntriesByTypeStub
+        .withArgs('navigation')
+        .returns([makeNavigationEntry([makeServerTimingEntry()])]);
+
+      const instrumentation = new ServerTimingInstrumentation({
+        perf,
+        limitManager,
+      });
+
+      expect(memoryExporter.getFinishedLogRecords()).to.have.length(0);
+
+      deliverNavigationEntry();
+
+      expect(memoryExporter.getFinishedLogRecords()).to.have.length(1);
 
       instrumentation.disable();
     });
@@ -155,47 +239,43 @@ describe('ServerTimingInstrumentation', () => {
     });
   });
 
-  describe('when document.readyState is not complete', () => {
-    beforeEach(() => {
-      Object.defineProperty(window.document, 'readyState', {
-        writable: true,
-        value: 'loading',
+  describe('regardless of when the SDK starts', () => {
+    /*
+     * Server timings come from the response headers, so they are readable long
+     * before the load event and readyState takes no part in deciding when to
+     * collect them.
+     */
+    ['complete', 'loading', 'interactive'].forEach((readyState) => {
+      it(`emits logs when readyState is ${readyState}`, () => {
+        Object.defineProperty(window.document, 'readyState', {
+          writable: true,
+          value: readyState,
+        });
+        getEntriesByTypeStub.withArgs('navigation').returns([
+          makeNavigationEntry([
+            makeServerTimingEntry({
+              name: 'api',
+              duration: 42,
+              description: 'ok',
+            }),
+          ]),
+        ]);
+
+        const instrumentation = new ServerTimingInstrumentation({
+          perf,
+          limitManager,
+        });
+        deliverNavigationEntry();
+
+        const logs = memoryExporter.getFinishedLogRecords();
+        expect(logs).to.have.length(1);
+        expect(logs[0].attributes['emb.server_timing.name']).to.equal('api');
+
+        instrumentation.disable();
       });
     });
 
-    it('attaches a load listener and emits logs when load fires', () => {
-      getEntriesByTypeStub.withArgs('navigation').returns([
-        makeNavigationEntry([
-          makeServerTimingEntry({
-            name: 'api',
-            duration: 42,
-            description: 'ok',
-          }),
-        ]),
-      ]);
-
-      const instrumentation = new ServerTimingInstrumentation({
-        perf,
-        limitManager,
-      });
-
-      expect(memoryExporter.getFinishedLogRecords()).to.have.length(0);
-
-      const loadListenerAdded = addEventListenerSpy.args.some(
-        ([event]) => event === 'load',
-      );
-      expect(loadListenerAdded).to.be.true;
-
-      window.dispatchEvent(new Event('load'));
-
-      const logs = memoryExporter.getFinishedLogRecords();
-      expect(logs).to.have.length(1);
-      expect(logs[0].attributes['emb.server_timing.name']).to.equal('api');
-
-      instrumentation.disable();
-    });
-
-    it('emits no logs when disable() is called before load fires', () => {
+    it('emits no logs when disabled before the entry arrives', () => {
       getEntriesByTypeStub
         .withArgs('navigation')
         .returns([makeNavigationEntry([makeServerTimingEntry()])]);
@@ -206,7 +286,7 @@ describe('ServerTimingInstrumentation', () => {
       });
       instrumentation.disable();
 
-      window.dispatchEvent(new Event('load'));
+      deliverNavigationEntry();
 
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(0);
     });
@@ -229,6 +309,7 @@ describe('ServerTimingInstrumentation', () => {
         perf,
         limitManager: customLimitManager,
       });
+      deliverNavigationEntry();
 
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(2);
 
@@ -246,11 +327,13 @@ describe('ServerTimingInstrumentation', () => {
         perf,
         limitManager,
       });
+      deliverNavigationEntry();
 
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(1);
 
       instrumentation.disable();
       instrumentation.enable();
+      deliverNavigationEntry();
 
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(1);
 

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
@@ -1,5 +1,6 @@
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/index.ts';
+import { createPerformanceObserver } from '../../../utils/index.ts';
 import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
 import {
   KEY_EMB_SERVER_TIMING_DESCRIPTION,
@@ -10,7 +11,7 @@ import {
 import type { ServerTimingInstrumentationArgs } from './types.ts';
 
 export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
-  private readonly _onLoad: () => void;
+  private _navigationObserver: PerformanceObserver | null = null;
   private _performanceCollected = false;
 
   public constructor({
@@ -27,28 +28,40 @@ export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
       config: {},
     });
 
-    this._onLoad = () => {
-      this._readServerTiming();
-    };
-
     if (this._config.enabled) {
       this.enable();
     }
   }
 
+  private _stopObserving(): void {
+    this._navigationObserver?.disconnect();
+    this._navigationObserver = null;
+  }
+
   public override onEnable(): void {
-    window.removeEventListener('load', this._onLoad);
+    this._stopObserving();
 
-    if (window.document.readyState === 'complete') {
-      this._readServerTiming();
-      return;
-    }
-
-    window.addEventListener('load', this._onLoad);
+    /*
+     * Server timings arrive in the response headers, so they are on the
+     * navigation entry before any script runs and there is nothing to wait for
+     * beyond the entry itself. The observer is what keeps the read out of the
+     * constructor: onEnable runs from there, before the SDK wires the logger
+     * provider on, and logs emitted synchronously at that point are lost for
+     * good because the collection guard latches.
+     */
+    this._navigationObserver =
+      createPerformanceObserver<PerformanceNavigationTiming>(
+        'navigation',
+        () => {
+          this._stopObserving();
+          this._readServerTiming();
+        },
+        { diag: this._diag },
+      );
   }
 
   public override onDisable(): void {
-    window.removeEventListener('load', this._onLoad);
+    this._stopObserving();
   }
 
   private _readServerTiming(): void {

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
@@ -73,13 +73,9 @@ export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
     const navEntries = performance.getEntriesByType(
       'navigation',
     ) as PerformanceNavigationTiming[];
-    const serverTiming = navEntries[0]?.serverTiming;
+    const serverTimingEntries = navEntries[0]?.serverTiming ?? [];
 
-    if (!serverTiming?.length) {
-      return;
-    }
-
-    for (const entry of serverTiming) {
+    for (const entry of serverTimingEntries) {
       if (this.limitManager?.limitServerTimingEntry()) {
         return;
       }

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
@@ -33,14 +33,12 @@ export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
     }
   }
 
-  private _stopObserving(): void {
+  private _disconnectObserver(): void {
     this._navigationObserver?.disconnect();
     this._navigationObserver = null;
   }
 
   public override onEnable(): void {
-    this._stopObserving();
-
     if (this._performanceCollected) {
       return;
     }
@@ -62,7 +60,7 @@ export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
       createPerformanceObserver<PerformanceNavigationTiming>(
         'navigation',
         () => {
-          this._stopObserving();
+          this._disconnectObserver();
           this._readServerTiming();
         },
         { diag: this._diag },
@@ -76,7 +74,7 @@ export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
   }
 
   public override onDisable(): void {
-    this._stopObserving();
+    this._disconnectObserver();
   }
 
   private _readServerTiming(): void {

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
@@ -41,13 +41,22 @@ export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
   public override onEnable(): void {
     this._stopObserving();
 
+    if (this._performanceCollected) {
+      return;
+    }
+
     /*
-     * Server timings arrive in the response headers, so they are on the
-     * navigation entry before any script runs and there is nothing to wait for
-     * beyond the entry itself. The observer is what keeps the read out of the
-     * constructor: onEnable runs from there, before the SDK wires the logger
-     * provider on, and logs emitted synchronously at that point are lost for
-     * good because the collection guard latches.
+     * The observer keeps the read out of the constructor. Under
+     * registerGlobally: false the logger provider arrives later in this same
+     * task, and a log emitted before it is lost for good because the
+     * collection guard latches.
+     *
+     * buffered stays at its default of true, the opposite of the navigation
+     * observer in DocumentLoadInstrumentation: server timings arrive in the
+     * response headers and are complete on the entry from the start, so a
+     * replay carries everything. It is also required, because the SDK usually
+     * starts after the entry was buffered and an unbuffered subscription would
+     * never be notified.
      */
     this._navigationObserver =
       createPerformanceObserver<PerformanceNavigationTiming>(
@@ -58,6 +67,12 @@ export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
         },
         { diag: this._diag },
       );
+
+    if (!this._navigationObserver) {
+      this._diag.warn(
+        'navigation entries are not observable, server timings will not be collected',
+      );
+    }
   }
 
   public override onDisable(): void {


### PR DESCRIPTION
## What problem is this solving?

`ServerTimingInstrumentation` read the navigation entry synchronously in `onEnable` whenever `readyState` was already `complete`. `onEnable` runs from the instrumentation's constructor, but `initSDK` only wires the logger provider onto instrumentations afterwards, via `registerInstrumentations`. Those logs therefore went to a logger that records nothing, and the once-per-page collection guard then latched so they were never retried.

That is live for an SDK initialized with `registerGlobally: false` after the page has finished loading, which is exactly what a late-initializing embedded component does.

## Short description of changes

- Read the server timings from a `navigation` PerformanceObserver notification instead of synchronously in `onEnable`, so the read lands in a later task, after the providers are wired. The subscription is buffered, which is `createPerformanceObserver`'s default, so an entry already on the timeline is replayed rather than waited for.
- Drop the `readyState` check and the `load` listener. Server timings arrive in the response headers, so they are on the navigation entry before any script runs and there is nothing to wait for beyond the entry itself.
- `onDisable()` is now just `disconnect()`, so disabling is exact.
- Default the entries to an empty array rather than guarding on length, since a `for…of` over an empty array is already a no-op.
- Warn when the entry type is unobservable. Nothing else re-triggers the read, so that case would otherwise drop server timings for the page with no diagnostic at all.
- Skip resubscribing on a re-enable once the timings have been collected.

`buffered` is deliberately left at its default here, the opposite of the `navigation` observer in `DocumentLoadInstrumentation`, which must subscribe unbuffered. The two requirements are inverted: server timings are complete on the entry from the start, so a replay carries everything and is in fact required, since the SDK usually starts after the entry was buffered. The comment says so at the subscription, so the difference between the two callers is not mistaken for an inconsistency.

## How has this been tested?

13 unit tests, covering:

- No logs are emitted while constructing, which is the regression this fixes.
- Logs are emitted whatever `readyState` is when the SDK starts, and none at all if it is disabled before the entry arrives.
- Nothing is emitted when the `serverTiming` array is empty or no navigation entry exists, which is what allows the length guard to go. Both cases now deliver an entry first, so neither passes vacuously.
- The subscription carries the buffered flag, and an unobservable entry type warns and collects nothing.

Both guards were confirmed by deleting them: forcing `buffered: false` fails 8 tests, and removing the collect-once latch fails the duplicate-collection test. Running the file against `main`'s implementation fails 6 of the 13, `does not emit while constructing` among them, so the regression is pinned rather than assumed.

Also checked in the demo (`npm run dev`), which serves a `Server-Timing` header from the dev server: the waterfall page emits exactly three `emb-server-timing` logs on load, one per header entry with the expected name, duration and description, and the soft-nav page adds none across five soft navigations that each roll the session part.

`npm run check` and `npm run lint` from the repo root.

## Checklist

- [ ] Documentation added
- [x] Tests added

