### PR TITLE
EMBR-13723 feat(logs): set eventName on the exception and message records

### DIFF
--- a/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.test.ts
@@ -228,6 +228,20 @@ describe('EmbraceLogManager', () => {
     expect(warningLogs[0]).to.equal('attributes must be a plain object');
   });
 
+  it('should name the message log record', () => {
+    manager.message('a message', 'info');
+
+    const [log] = memoryExporter.getFinishedLogRecords();
+    expect(log.eventName).to.equal('emb-log');
+  });
+
+  it('should name the exception log record', () => {
+    manager.logException(new Error('boom'));
+
+    const [log] = memoryExporter.getFinishedLogRecords();
+    expect(log.eventName).to.equal('emb-exception');
+  });
+
   it('should log an info log without stacktrace', () => {
     expect(() => {
       manager.message(

--- a/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/EmbraceLogManager.ts
@@ -39,6 +39,7 @@ import {
 } from '../../utils/index.ts';
 import type { LimitManagerInternal } from '../EmbraceLimitManager/index.ts';
 import type { UserSessionManagerInternal } from '../EmbraceUserSessionManager/index.ts';
+import { EXCEPTION_EVENT_NAME, LOG_EVENT_NAME } from './constants.ts';
 import type { EmbraceLogManagerArgs } from './types.ts';
 
 const EMBRACE_EXCEPTION_NUMBER_STORAGE_KEY = 'embrace_exception_number';
@@ -147,6 +148,7 @@ export class EmbraceLogManager implements LogManager {
     }
 
     this._logger.emit({
+      eventName: EXCEPTION_EVENT_NAME,
       timestamp,
       severityNumber: SeverityNumber.ERROR,
       severityText: 'ERROR',
@@ -243,6 +245,7 @@ export class EmbraceLogManager implements LogManager {
     }
 
     this._logger.emit({
+      eventName: LOG_EVENT_NAME,
       timestamp,
       severityNumber: EmbraceLogManager._logSeverityToSeverityNumber(severity),
       severityText: severity.toUpperCase(),

--- a/packages/web-sdk/src/managers/EmbraceLogManager/constants.ts
+++ b/packages/web-sdk/src/managers/EmbraceLogManager/constants.ts
@@ -1,0 +1,4 @@
+// Names for the two records the public log API emits, matching the `emb-`
+// prefixed family the instrumentations already use.
+export const EXCEPTION_EVENT_NAME = 'emb-exception';
+export const LOG_EVENT_NAME = 'emb-log';

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-log-record.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-log-record.json
@@ -1,11 +1,12 @@
 {
-  "timeUnixNano": "1787314498758300049",
-  "observedTimeUnixNano": "1787314498758000000",
+  "timeUnixNano": "1787329485226600098",
+  "observedTimeUnixNano": "1787329485226000000",
   "severityNumber": 13,
   "severityText": "WARNING",
   "body": {
     "stringValue": "This is a test log message"
   },
+  "eventName": "emb-log",
   "attributes": [
     {
       "key": "emb.type",
@@ -16,13 +17,13 @@
     {
       "key": "emb.stacktrace.js",
       "value": {
-        "stringValue": "Error\n    at uf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:99911)\n    at Fb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:267411\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:999\n    at new Promise (<anonymous>)\n    at Pt (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:819)\n    at n (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:267383)\n    at gg (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127507)"
+        "stringValue": "Error\n    at uf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:99956)\n    at Fb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:267724\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:999\n    at new Promise (<anonymous>)\n    at Pt (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:819)\n    at n (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:267696)\n    at gg (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127507)"
       }
     },
     {
       "key": "emb.js_file_bundle_ids",
       "value": {
-        "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:126\":\"dafd8a9632ad01a9a66219f8e46096af\"}"
+        "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:126\":\"a0d9967210bb52402b7843f13b16440a\"}"
       }
     },
     {
@@ -34,13 +35,13 @@
     {
       "key": "log.record.uid",
       "value": {
-        "stringValue": "4B73898E22DAEB10E98F017E559B4D9E"
+        "stringValue": "F4F0C00A5F449881D027DBF1CB022B14"
       }
     },
     {
       "key": "emb.user_session_id",
       "value": {
-        "stringValue": "BD546EF69E82DF938F6C6D243D03D3B1"
+        "stringValue": "32DB6FF47DFD5B6DDEDA528157F868CB"
       }
     },
     {
@@ -52,7 +53,7 @@
     {
       "key": "emb.session_part_id",
       "value": {
-        "stringValue": "9D4AF7DF955E5193BAFACB312F149936"
+        "stringValue": "F9EA07F81E1202AE225FB329758C4417"
       }
     },
     {
@@ -76,7 +77,7 @@
     {
       "key": "app.surface.id",
       "value": {
-        "stringValue": "FE5305422A3C29243FB1A88A5074D88D"
+        "stringValue": "AB8C3C2C040DC1FBFAFE5E6ECF95D1E0"
       }
     },
     {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-send-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "8F3192947084EF3DFB84DD8FCA1F81A7"
+              "stringValue": "AF70B963CF2AEE4107585DE278123C52"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1787314495244199951",
-              "observedTimeUnixNano": "1787314495250000000",
+              "timeUnixNano": "1787329481611699951",
+              "observedTimeUnixNano": "1787329481617000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0.19999999552965164,\"cacheDuration\":2.7000000029802322,\"dnsDuration\":0.10000000149011612,\"connectionDuration\":0.19999999552965164,\"requestDuration\":1.5}"
+                "stringValue": "{\"waitingDuration\":0.09999999403953552,\"cacheDuration\":1.3000000044703484,\"dnsDuration\":0,\"connectionDuration\":0.29999999701976776,\"requestDuration\":0.6000000014901161}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 4.699999995529652
+                    "doubleValue": 2.2999999970197678
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 4.699999995529652
+                    "doubleValue": 2.2999999970197678
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1787314495240-3387283146507"
+                    "stringValue": "v6-1787329481608-8884020888239"
                   }
                 },
                 {
@@ -139,13 +139,13 @@
                 {
                   "key": "browser.web_vital.navigation_id",
                   "value": {
-                    "intValue": 8788
+                    "intValue": 5479
                   }
                 },
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "9E9F940B66E7BF216238C49BA8B7B82C"
+                    "stringValue": "73F6216B0F958178EB6154F4D00583A4"
                   }
                 },
                 {
@@ -163,7 +163,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4D3D104798BEA25EB7FBB919151DDCF0"
+                    "stringValue": "4F42A417CC8EF942BBBB8006A21BC32A"
                   }
                 },
                 {
@@ -205,19 +205,19 @@
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 4
+                    "intValue": 2
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "E126F9CBA4155F3F77BAA248DB0367F9"
+                    "stringValue": "3E1EC5BDB718E1ED059FF982A301D301"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "3F93CE4D4465720F791555852C9BE754"
+                    "stringValue": "652290CF0FEF3787C75FC65C11AC0701"
                   }
                 },
                 {
@@ -236,11 +236,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1787314495263000000",
-              "observedTimeUnixNano": "1787314495264000000",
+              "timeUnixNano": "1787329481634000000",
+              "observedTimeUnixNano": "1787329481635000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":4.699999995529652,\"firstByteToFCP\":95.30000000447035,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":2.2999999970197678,\"firstByteToFCP\":89.70000000298023,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -259,13 +259,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 100
+                    "intValue": 92
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 100
+                    "intValue": 92
                   }
                 },
                 {
@@ -277,7 +277,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1787314495240-8584890296244"
+                    "stringValue": "v6-1787329481608-8802217465208"
                   }
                 },
                 {
@@ -289,13 +289,13 @@
                 {
                   "key": "browser.web_vital.navigation_id",
                   "value": {
-                    "intValue": 8788
+                    "intValue": 5479
                   }
                 },
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "9E9F940B66E7BF216238C49BA8B7B82C"
+                    "stringValue": "73F6216B0F958178EB6154F4D00583A4"
                   }
                 },
                 {
@@ -313,7 +313,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4D3D104798BEA25EB7FBB919151DDCF0"
+                    "stringValue": "4F42A417CC8EF942BBBB8006A21BC32A"
                   }
                 },
                 {
@@ -325,13 +325,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "FF4F1FCAE4DBB15DA7B92DAABF830465"
+                    "stringValue": "4F69F83F182355F64B0DCD9BD10B241E"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "3F93CE4D4465720F791555852C9BE754"
+                    "stringValue": "652290CF0FEF3787C75FC65C11AC0701"
                   }
                 },
                 {
@@ -358,8 +358,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1787314495374199951",
-              "observedTimeUnixNano": "1787314495376000000",
+              "timeUnixNano": "1787329481743100098",
+              "observedTimeUnixNano": "1787329481745000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -391,7 +391,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "doubleValue": 130.00004882365465
+                    "doubleValue": 131.40004882216454
                   }
                 },
                 {
@@ -409,13 +409,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "1C6A7640A9671BD7516F7F84D2F162AA"
+                    "stringValue": "86C7A45CAD2AAE6D05CE1762238CBBA5"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "3F93CE4D4465720F791555852C9BE754"
+                    "stringValue": "652290CF0FEF3787C75FC65C11AC0701"
                   }
                 },
                 {
@@ -427,7 +427,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "9E9F940B66E7BF216238C49BA8B7B82C"
+                    "stringValue": "73F6216B0F958178EB6154F4D00583A4"
                   }
                 },
                 {
@@ -451,7 +451,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4D3D104798BEA25EB7FBB919151DDCF0"
+                    "stringValue": "4F42A417CC8EF942BBBB8006A21BC32A"
                   }
                 },
                 {
@@ -471,13 +471,14 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1787314495377399902",
-              "observedTimeUnixNano": "1787314495377000000",
+              "timeUnixNano": "1787329481746199951",
+              "observedTimeUnixNano": "1787329481746000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
                 "stringValue": "This is a test log message"
               },
+              "eventName": "emb-log",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -488,13 +489,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "Error\n    at uf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:99911)\n    at Fb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:267411\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:999\n    at new Promise (<anonymous>)\n    at Pt (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:819)\n    at n (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:267383)\n    at gg (http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127507)"
+                    "stringValue": "Error\n    at uf.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:99956)\n    at Fb.message (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:38001)\n    at Proxy.<anonymous> (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:37542)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:267724\n    at Generator.next (<anonymous>)\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:999\n    at new Promise (<anonymous>)\n    at Pt (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:819)\n    at n (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:267696)\n    at gg (http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127507)"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:126\":\"dafd8a9632ad01a9a66219f8e46096af\"}"
+                    "stringValue": "{\"Error\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:33\\n    at http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:126\":\"a0d9967210bb52402b7843f13b16440a\"}"
                   }
                 },
                 {
@@ -506,13 +507,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "6487C246840B63AF2D7D8623002949D9"
+                    "stringValue": "B214D376519FE7B1A706B1762A299A25"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "3F93CE4D4465720F791555852C9BE754"
+                    "stringValue": "652290CF0FEF3787C75FC65C11AC0701"
                   }
                 },
                 {
@@ -524,7 +525,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "9E9F940B66E7BF216238C49BA8B7B82C"
+                    "stringValue": "73F6216B0F958178EB6154F4D00583A4"
                   }
                 },
                 {
@@ -548,7 +549,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "4D3D104798BEA25EB7FBB919151DDCF0"
+                    "stringValue": "4F42A417CC8EF942BBBB8006A21BC32A"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-log-record.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-log-record.json
@@ -1,11 +1,12 @@
 {
-  "timeUnixNano": "1787314519332000000",
-  "observedTimeUnixNano": "1787314519334000000",
+  "timeUnixNano": "1787329507243000000",
+  "observedTimeUnixNano": "1787329507243000000",
   "severityNumber": 13,
   "severityText": "WARNING",
   "body": {
     "stringValue": "This is a test log message"
   },
+  "eventName": "emb-log",
   "attributes": [
     {
       "key": "emb.type",
@@ -16,13 +17,13 @@
     {
       "key": "emb.stacktrace.js",
       "value": {
-        "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:99911\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:38001\ncN</as/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:37542\ncN</oN/n/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:267411\nPt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:999\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:819\nn@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:267385\ngg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127508\ncN</Vb/sc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:132562\nbd@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:28401\nEventListener.handleEvent*mg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:128304\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127704\ncN</Vb/rc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127870\nrc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127815\ncN</Vb/zr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:36448\ncN<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:268034\nxb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:268088\n"
+        "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:99956\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:38001\n_N</as/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:37542\n_N</dN/n/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:267724\nPt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:999\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:819\nn@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:267698\ngg@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127508\n_N</Vb/sc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:132562\nbd@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:28401\nEventListener.handleEvent*mg@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:128304\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127704\n_N</Vb/rc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127870\nrc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127815\n_N</Vb/zr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:36448\n_N<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:268347\nxb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:268401\n"
       }
     },
     {
       "key": "emb.js_file_bundle_ids",
       "value": {
-        "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:126\\n\":\"dafd8a9632ad01a9a66219f8e46096af\"}"
+        "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:126\\n\":\"a0d9967210bb52402b7843f13b16440a\"}"
       }
     },
     {
@@ -34,13 +35,13 @@
     {
       "key": "log.record.uid",
       "value": {
-        "stringValue": "DA1AF632CE79E1D1388B1093C076D2A6"
+        "stringValue": "13B44608A47E1D85A8B51D928A7CF330"
       }
     },
     {
       "key": "emb.user_session_id",
       "value": {
-        "stringValue": "B8C04302EEDEE891619A9DAA7F648374"
+        "stringValue": "50C2FD9744188B2A88DCF8696616266A"
       }
     },
     {
@@ -52,7 +53,7 @@
     {
       "key": "emb.session_part_id",
       "value": {
-        "stringValue": "93DFEB9F7832469F1A840D2626E4E15E"
+        "stringValue": "8499DCFFAAFC36B77F4309C3B4F3308A"
       }
     },
     {
@@ -76,7 +77,7 @@
     {
       "key": "app.surface.id",
       "value": {
-        "stringValue": "004E2FA78993B025E042946E835A8F15"
+        "stringValue": "4A85062DF8923ABCF0E29054C575B348"
       }
     },
     {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-send-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "6DB96D74D97581AA9220F736A0347E11"
+              "stringValue": "9C929E6E8CED99EB5B53C73E763E49B1"
             }
           },
           {
@@ -86,11 +86,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1787314514275000000",
-              "observedTimeUnixNano": "1787314514280000000",
+              "timeUnixNano": "1787329501680000000",
+              "observedTimeUnixNano": "1787329501682000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":3,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":10,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -109,13 +109,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 4
+                    "intValue": 11
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 4
+                    "intValue": 11
                   }
                 },
                 {
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1787314514264-6259388425963"
+                    "stringValue": "v6-1787329501669-3551407471476"
                   }
                 },
                 {
@@ -145,7 +145,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "B0363B6118C2FAB778E3969E94CBC3D6"
+                    "stringValue": "3A7AD7DFB18AEFE712DCA864811B9839"
                   }
                 },
                 {
@@ -163,7 +163,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "6245B52971E5FE39304148A00A5E427D"
+                    "stringValue": "CD5BFC935507434625B9F4E37F0D0D7B"
                   }
                 },
                 {
@@ -199,25 +199,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 1
+                    "intValue": 0
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 3
+                    "intValue": 11
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "29D46DEB33910BE94793175C7C37A1EE"
+                    "stringValue": "11C7739905C9D24D6A52893EE888430F"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "6698819157563E4DEB2FA8958FD35277"
+                    "stringValue": "B159BFDFABCB29225E2EEB02AF68D1AF"
                   }
                 },
                 {
@@ -236,11 +236,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1787314514276000000",
-              "observedTimeUnixNano": "1787314514281000000",
+              "timeUnixNano": "1787329501680000000",
+              "observedTimeUnixNano": "1787329501683000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":4,\"firstByteToFCP\":76,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":11,\"firstByteToFCP\":120,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -259,13 +259,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 80
+                    "intValue": 131
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 80
+                    "intValue": 131
                   }
                 },
                 {
@@ -277,7 +277,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1787314514264-1428265441918"
+                    "stringValue": "v6-1787329501669-2074681541195"
                   }
                 },
                 {
@@ -295,7 +295,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "B0363B6118C2FAB778E3969E94CBC3D6"
+                    "stringValue": "3A7AD7DFB18AEFE712DCA864811B9839"
                   }
                 },
                 {
@@ -313,7 +313,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "6245B52971E5FE39304148A00A5E427D"
+                    "stringValue": "CD5BFC935507434625B9F4E37F0D0D7B"
                   }
                 },
                 {
@@ -325,13 +325,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "10C86CB1A2111A1F3032429DF9EB7653"
+                    "stringValue": "D3B9D498651583954DAC548F15EE89F7"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "6698819157563E4DEB2FA8958FD35277"
+                    "stringValue": "B159BFDFABCB29225E2EEB02AF68D1AF"
                   }
                 },
                 {
@@ -358,8 +358,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1787314514449000000",
-              "observedTimeUnixNano": "1787314514451000000",
+              "timeUnixNano": "1787329501874000000",
+              "observedTimeUnixNano": "1787329501876000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -391,7 +391,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 174
+                    "intValue": 194
                   }
                 },
                 {
@@ -409,13 +409,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "D4604D4CFF25BA69B09BF56A514F5FAB"
+                    "stringValue": "6EA91990AAB6DA8771D5407F3FC4AF36"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "6698819157563E4DEB2FA8958FD35277"
+                    "stringValue": "B159BFDFABCB29225E2EEB02AF68D1AF"
                   }
                 },
                 {
@@ -427,7 +427,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "B0363B6118C2FAB778E3969E94CBC3D6"
+                    "stringValue": "3A7AD7DFB18AEFE712DCA864811B9839"
                   }
                 },
                 {
@@ -451,7 +451,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "6245B52971E5FE39304148A00A5E427D"
+                    "stringValue": "CD5BFC935507434625B9F4E37F0D0D7B"
                   }
                 },
                 {
@@ -471,13 +471,14 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1787314514450000000",
-              "observedTimeUnixNano": "1787314514452000000",
+              "timeUnixNano": "1787329501876000000",
+              "observedTimeUnixNano": "1787329501877000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
                 "stringValue": "This is a test log message"
               },
+              "eventName": "emb-log",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -488,13 +489,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:99911\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:38001\ncN</as/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:37542\ncN</oN/n/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:267411\nPt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:999\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:819\nn@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:267385\ngg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127508\ncN</Vb/sc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:132562\nbd@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:28401\nEventListener.handleEvent*mg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:128304\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127704\ncN</Vb/rc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127870\nrc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127815\ncN</Vb/zr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:36448\ncN<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:268034\nxb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:268088\n"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:99956\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:38001\n_N</as/get/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:37542\n_N</dN/n/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:267724\nPt/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:999\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:819\nn@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:267698\ngg@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127508\n_N</Vb/sc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:132562\nbd@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:28401\nEventListener.handleEvent*mg@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:128304\nac@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127704\n_N</Vb/rc/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127870\nrc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127815\n_N</Vb/zr.createRoot@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:36448\n_N<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:268347\nxb/<@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:691\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:268401\n"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:126\\n\":\"dafd8a9632ad01a9a66219f8e46096af\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:33\\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:126\\n\":\"a0d9967210bb52402b7843f13b16440a\"}"
                   }
                 },
                 {
@@ -506,13 +507,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "278311BC11FAA270509E4D0C2A4BAA13"
+                    "stringValue": "7674BE8CB67A8DC97120D72DF4FF2E82"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "6698819157563E4DEB2FA8958FD35277"
+                    "stringValue": "B159BFDFABCB29225E2EEB02AF68D1AF"
                   }
                 },
                 {
@@ -524,7 +525,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "B0363B6118C2FAB778E3969E94CBC3D6"
+                    "stringValue": "3A7AD7DFB18AEFE712DCA864811B9839"
                   }
                 },
                 {
@@ -548,7 +549,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "6245B52971E5FE39304148A00A5E427D"
+                    "stringValue": "CD5BFC935507434625B9F4E37F0D0D7B"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-log-record.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-log-record.json
@@ -1,11 +1,12 @@
 {
-  "timeUnixNano": "1787314532957000000",
-  "observedTimeUnixNano": "1787314532959000000",
+  "timeUnixNano": "1787329521219000000",
+  "observedTimeUnixNano": "1787329521220000000",
   "severityNumber": 13,
   "severityText": "WARNING",
   "body": {
     "stringValue": "This is a test log message"
   },
+  "eventName": "emb-log",
   "attributes": [
     {
       "key": "emb.type",
@@ -16,13 +17,13 @@
     {
       "key": "emb.stacktrace.js",
       "value": {
-        "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:99920\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:267418\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:1003\nPromise@[native code]\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:830\ngg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127508\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:132562\nbd@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:28403"
+        "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:99965\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:267731\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:1003\nPromise@[native code]\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:830\ngg@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127508\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:132562\nbd@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:28403"
       }
     },
     {
       "key": "emb.js_file_bundle_ids",
       "value": {
-        "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:126\":\"dafd8a9632ad01a9a66219f8e46096af\"}"
+        "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:126\":\"a0d9967210bb52402b7843f13b16440a\"}"
       }
     },
     {
@@ -34,13 +35,13 @@
     {
       "key": "log.record.uid",
       "value": {
-        "stringValue": "DD7B9959A1D638E524CD3F838B9BED92"
+        "stringValue": "0A5424CF3CD35DBF742694507A4245CC"
       }
     },
     {
       "key": "emb.user_session_id",
       "value": {
-        "stringValue": "060A72B26BCA21677810B6A1AA348CA9"
+        "stringValue": "100197DB167C31606CA92DFC9FA8DE62"
       }
     },
     {
@@ -52,7 +53,7 @@
     {
       "key": "emb.session_part_id",
       "value": {
-        "stringValue": "27D0343FB1D3E2FF7609F1FCA952C941"
+        "stringValue": "6EBFD556D2C940E987A3CF116E2BA685"
       }
     },
     {
@@ -76,7 +77,7 @@
     {
       "key": "app.surface.id",
       "value": {
-        "stringValue": "28ADCF70A5D4F3BD289D4FC202D3D431"
+        "stringValue": "58AAC18ACC4733427B6A862F5A662B67"
       }
     },
     {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-send-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "255D86C134A2025CED2F21F801EBCB0F"
+              "stringValue": "D94CC147714EC00C75E8086937F1635F"
             }
           },
           {
@@ -86,8 +86,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1787314529345000000",
-              "observedTimeUnixNano": "1787314529349000000",
+              "timeUnixNano": "1787329517431000000",
+              "observedTimeUnixNano": "1787329517435000000",
               "severityNumber": 9,
               "body": {
                 "stringValue": "{\"waitingDuration\":1,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":1}"
@@ -127,7 +127,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1787314529341-2896551726223"
+                    "stringValue": "v6-1787329517428-8132288279313"
                   }
                 },
                 {
@@ -145,7 +145,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "9BEF99ADB63E7209B40BCC529BE39DD1"
+                    "stringValue": "EAA8FCB2C7A70E0CC73472D72F6B2E39"
                   }
                 },
                 {
@@ -163,7 +163,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "24C17F2E5F9118241889EE9D3EFC5740"
+                    "stringValue": "CDB3F802300B0C8CEDC3463E6AE4EC80"
                   }
                 },
                 {
@@ -199,25 +199,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 0
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 2
+                    "intValue": 1
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "DBE264AA30B1FC530AC0E49FE9B367A8"
+                    "stringValue": "81850895A20766DCF803A0B7723410DA"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "0623BF581CB30E4A6D048F53E5849980"
+                    "stringValue": "9A708299377D844A1F83CD0F630A7B12"
                   }
                 },
                 {
@@ -236,11 +236,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1787314529363000000",
-              "observedTimeUnixNano": "1787314529365000000",
+              "timeUnixNano": "1787329517454000000",
+              "observedTimeUnixNano": "1787329517457000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":61,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":66,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -259,13 +259,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 63
+                    "intValue": 68
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 63
+                    "intValue": 68
                   }
                 },
                 {
@@ -277,7 +277,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1787314529340-5777982311067"
+                    "stringValue": "v6-1787329517428-5045136874130"
                   }
                 },
                 {
@@ -295,7 +295,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "9BEF99ADB63E7209B40BCC529BE39DD1"
+                    "stringValue": "EAA8FCB2C7A70E0CC73472D72F6B2E39"
                   }
                 },
                 {
@@ -313,7 +313,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "24C17F2E5F9118241889EE9D3EFC5740"
+                    "stringValue": "CDB3F802300B0C8CEDC3463E6AE4EC80"
                   }
                 },
                 {
@@ -325,13 +325,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "465EAF0FC2C03B3E900C1F7C45C9B0EF"
+                    "stringValue": "B35E883169F1D9BBA30337246B063702"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "0623BF581CB30E4A6D048F53E5849980"
+                    "stringValue": "9A708299377D844A1F83CD0F630A7B12"
                   }
                 },
                 {
@@ -358,8 +358,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1787314529509000000",
-              "observedTimeUnixNano": "1787314529513000000",
+              "timeUnixNano": "1787329517596000000",
+              "observedTimeUnixNano": "1787329517601000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -391,7 +391,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 164
+                    "intValue": 165
                   }
                 },
                 {
@@ -409,13 +409,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "E7E87CAA6209EC1939A8A953719E0F95"
+                    "stringValue": "51EEA6C0D0CB8E1CC81D9E2A978556F4"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "0623BF581CB30E4A6D048F53E5849980"
+                    "stringValue": "9A708299377D844A1F83CD0F630A7B12"
                   }
                 },
                 {
@@ -427,7 +427,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "9BEF99ADB63E7209B40BCC529BE39DD1"
+                    "stringValue": "EAA8FCB2C7A70E0CC73472D72F6B2E39"
                   }
                 },
                 {
@@ -451,7 +451,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "24C17F2E5F9118241889EE9D3EFC5740"
+                    "stringValue": "CDB3F802300B0C8CEDC3463E6AE4EC80"
                   }
                 },
                 {
@@ -471,13 +471,14 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1787314529513000000",
-              "observedTimeUnixNano": "1787314529514000000",
+              "timeUnixNano": "1787329517600000000",
+              "observedTimeUnixNano": "1787329517601000000",
               "severityNumber": 13,
               "severityText": "WARNING",
               "body": {
                 "stringValue": "This is a test log message"
               },
+              "eventName": "emb-log",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -488,13 +489,13 @@
                 {
                   "key": "emb.stacktrace.js",
                   "value": {
-                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:99920\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:267418\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:1003\nPromise@[native code]\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:1:830\ngg@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:127508\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:132562\nbd@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:9:28403"
+                    "stringValue": "message@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:99965\nmessage@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:38008\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:37547\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:267731\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:1003\nPromise@[native code]\nPt@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:1:830\ngg@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:127508\n@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:132562\nbd@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:15162\nsc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:8:128743\nvc@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:28581\nyb@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:9:28403"
                   }
                 },
                 {
                   "key": "emb.js_file_bundle_ids",
                   "value": {
-                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js:11:126\":\"dafd8a9632ad01a9a66219f8e46096af\"}"
+                    "stringValue": "{\"@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:33\\nmodule code@http://localhost:3001/platforms/vite-7/es2015/assets/index-CwdClkCB.js:11:126\":\"a0d9967210bb52402b7843f13b16440a\"}"
                   }
                 },
                 {
@@ -506,13 +507,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "82FAE4219BF2C2F53EDFF60179BB5708"
+                    "stringValue": "DEDBE4976CBAD62E042B7E0DBADD9D6C"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "0623BF581CB30E4A6D048F53E5849980"
+                    "stringValue": "9A708299377D844A1F83CD0F630A7B12"
                   }
                 },
                 {
@@ -524,7 +525,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "9BEF99ADB63E7209B40BCC529BE39DD1"
+                    "stringValue": "EAA8FCB2C7A70E0CC73472D72F6B2E39"
                   }
                 },
                 {
@@ -548,7 +549,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "24C17F2E5F9118241889EE9D3EFC5740"
+                    "stringValue": "CDB3F802300B0C8CEDC3463E6AE4EC80"
                   }
                 },
                 {


### PR DESCRIPTION
## What problem is this solving?

`EmbraceLogManager.logException` and `EmbraceLogManager.message` emitted log records with no `eventName`, while all seven instrumentation emitters set one. Every log reaching the backend through the public API arrived unnamed.

EMBR-13723

## Short description of changes

- Set `eventName` on both paths: `emb-exception` for exceptions, `emb-log` for `log.message`, matching the existing `emb-` prefixed family.
- Event names still use three styles across the SDK (`emb-` prefixed, bare kebab, and dotted `browser.web_vital`). A convention review covering all of them is separate, since renaming is a wire-format change the dashboard keys on.

## How has this been tested?

Unit: two tests asserting `eventName` on the emitted record for each path, 46 passed.

Integration: read-only first, which failed on exactly the six goldens carrying a manual log with `- "eventName": undefined / + "eventName": "emb-log"`, confirming the parent PR's `eventName` comparison catches this. Then regenerated: 300 passed. Only `emb-log` appears in the goldens because no e2e test raises an exception; the exception path is pinned by the unit test.

## Checklist

- [ ] Documentation added
- [x] Tests added
