### PR TITLE
feat: emit the document fetch span as a ux.resource_fetch span

### DIFF
--- a/packages/web-sdk/scripts/validate.ts
+++ b/packages/web-sdk/scripts/validate.ts
@@ -18,7 +18,7 @@ import zlib from 'node:zlib';
 import { COLORS, log, logSection } from '../../../scripts/build-config.ts';
 
 // Maximum bundle size (gzipped) — triggers hard failure to catch bloat/duplication early
-const MAX_BUNDLE_SIZE_KB = 60;
+const MAX_BUNDLE_SIZE_KB = 61;
 
 const BUNDLE_FILE = 'embrace-web-sdk.js';
 const BUNDLE_MAP_FILE = 'embrace-web-sdk.js.map';

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -28,7 +28,10 @@ import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/index.ts';
 import { OTelPerformanceManager } from '../../../utils/index.ts';
 import { DocumentLoadInstrumentation } from '../index.ts';
 import { EventNames } from './enums/EventNames.ts';
-import type { EmbracePerformanceResourceTiming } from './utils.ts';
+import type {
+  EmbracePerformanceNavigationTiming,
+  EmbracePerformanceResourceTiming,
+} from './utils.ts';
 import { getPerformanceNavigationEntries } from './utils.ts';
 
 const exporter = new InMemorySpanExporter();
@@ -472,6 +475,83 @@ describe('DocumentLoad Instrumentation', () => {
         assert.strictEqual(
           fetchSpan?.attributes['http.response.decoded_body_size'],
           entries.decodedBodySize,
+        );
+        assert.strictEqual(
+          fetchSpan?.attributes['browser.navigation_timing.type'],
+          entries.type,
+        );
+        done();
+      });
+    });
+
+    it('should not add navigation-only attributes to resourceFetch spans', (done) => {
+      spyEntries.withArgs('resource').returns(resources);
+
+      plugin.enable();
+
+      setTimeout(() => {
+        const resourceSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'resourceFetch');
+        assert.isOk(resourceSpan);
+        assert.isUndefined(
+          resourceSpan?.attributes['browser.navigation_timing.type'],
+        );
+        assert.isUndefined(
+          resourceSpan?.attributes[
+            'browser.navigation_timing.not_restored_reasons'
+          ],
+        );
+        done();
+      });
+    });
+
+    it('should add browser.navigation_timing.not_restored_reasons when the navigation was blocked from the back/forward cache', (done) => {
+      spyEntries.withArgs('navigation').returns([
+        {
+          ...entries,
+          notRestoredReasons: {
+            reasons: [{ reason: 'unload-listener' }, { reason: 'websocket' }],
+          },
+        } as EmbracePerformanceNavigationTiming,
+      ]);
+
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'documentFetch');
+        assert.isOk(fetchSpan);
+        assert.deepStrictEqual(
+          fetchSpan?.attributes[
+            'browser.navigation_timing.not_restored_reasons'
+          ],
+          ['unload-listener', 'websocket'],
+        );
+        done();
+      });
+    });
+
+    it('should not add browser.navigation_timing.not_restored_reasons when the navigation was restored from the back/forward cache', (done) => {
+      spyEntries.withArgs('navigation').returns([
+        {
+          ...entries,
+          notRestoredReasons: null,
+        } as PerformanceNavigationTiming,
+      ]);
+
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'documentFetch');
+        assert.isOk(fetchSpan);
+        assert.isUndefined(
+          fetchSpan?.attributes[
+            'browser.navigation_timing.not_restored_reasons'
+          ],
         );
         done();
       });

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -24,7 +24,6 @@ import {
 import { assert } from 'chai';
 import type { SinonStubbedFunction } from 'sinon';
 import * as sinon from 'sinon';
-import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/index.ts';
 import { OTelPerformanceManager } from '../../../utils/index.ts';
 import { DocumentLoadInstrumentation } from '../index.ts';
 import { EventNames } from './enums/EventNames.ts';
@@ -453,32 +452,29 @@ describe('DocumentLoad Instrumentation', () => {
         assert.isOk(fetchSpan);
 
         assert.strictEqual(
-          fetchSpan?.attributes[KEY_EMB_TYPE],
-          EMB_TYPES.ResourceFetch,
+          fetchSpan?.attributes['emb.type'],
+          'ux.resource_fetch',
         );
         assert.strictEqual(
           fetchSpan?.attributes['http.request.initiator_type'],
-          entries.initiatorType,
+          'navigation',
         );
         assert.strictEqual(
           fetchSpan?.attributes['http.response.status_code'],
-          entries.responseStatus,
+          200,
         );
-        assert.strictEqual(
-          fetchSpan?.attributes['http.response.size'],
-          entries.transferSize,
-        );
+        assert.strictEqual(fetchSpan?.attributes['http.response.size'], 655);
         assert.strictEqual(
           fetchSpan?.attributes['http.response.body.size'],
-          entries.encodedBodySize,
+          362,
         );
         assert.strictEqual(
           fetchSpan?.attributes['http.response.decoded_body_size'],
-          entries.decodedBodySize,
+          362,
         );
         assert.strictEqual(
           fetchSpan?.attributes['browser.navigation_timing.type'],
-          entries.type,
+          'reload',
         );
         done();
       });
@@ -557,7 +553,118 @@ describe('DocumentLoad Instrumentation', () => {
       });
     });
 
-    it('should default the documentFetch span sizes to 0 when the navigation entry lacks size fields', (done) => {
+    /* An empty reasons array is why the guard is ?.length rather than a bare
+     * presence check - simplifying to `if (entries.notRestoredReasons)` would
+     * still be truthy for [] and ship an empty array attribute. */
+    it('should not add browser.navigation_timing.not_restored_reasons when reasons is an empty array', (done) => {
+      spyEntries.withArgs('navigation').returns([
+        {
+          ...entries,
+          notRestoredReasons: { reasons: [] },
+        } as EmbracePerformanceNavigationTiming,
+      ]);
+
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'documentFetch');
+        assert.isOk(fetchSpan);
+        assert.isUndefined(
+          fetchSpan?.attributes[
+            'browser.navigation_timing.not_restored_reasons'
+          ],
+        );
+        done();
+      });
+    });
+
+    it('should not add browser.navigation_timing.not_restored_reasons when reasons is null', (done) => {
+      spyEntries.withArgs('navigation').returns([
+        {
+          ...entries,
+          notRestoredReasons: { reasons: null },
+        } as unknown as EmbracePerformanceNavigationTiming,
+      ]);
+
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'documentFetch');
+        assert.isOk(fetchSpan);
+        assert.isUndefined(
+          fetchSpan?.attributes[
+            'browser.navigation_timing.not_restored_reasons'
+          ],
+        );
+        done();
+      });
+    });
+
+    it('should add http.response.delivery_type to the documentFetch span when the navigation was served from cache', (done) => {
+      spyEntries.withArgs('navigation').returns([
+        {
+          ...entries,
+          deliveryType: 'cache',
+        } as EmbracePerformanceNavigationTiming,
+      ]);
+
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'documentFetch');
+        assert.isOk(fetchSpan);
+        assert.strictEqual(
+          fetchSpan?.attributes['http.response.delivery_type'],
+          'cache',
+        );
+        done();
+      });
+    });
+
+    it('should not add http.response.delivery_type to the documentFetch span when the navigation was served over the network', (done) => {
+      spyEntries.withArgs('navigation').returns([
+        {
+          ...entries,
+          deliveryType: '',
+        } as EmbracePerformanceNavigationTiming,
+      ]);
+
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'documentFetch');
+        assert.isOk(fetchSpan);
+        assert.isUndefined(
+          fetchSpan?.attributes['http.response.delivery_type'],
+        );
+        done();
+      });
+    });
+
+    it('should not add http.response.delivery_type to the documentFetch span when the engine does not report it', (done) => {
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'documentFetch');
+        assert.isOk(fetchSpan);
+        assert.isUndefined(
+          fetchSpan?.attributes['http.response.delivery_type'],
+        );
+        done();
+      });
+    });
+
+    it('should omit the documentFetch span sizes when the navigation entry lacks size fields', (done) => {
       const {
         transferSize,
         encodedBodySize,
@@ -567,6 +674,34 @@ describe('DocumentLoad Instrumentation', () => {
       spyEntries
         .withArgs('navigation')
         .returns([entryWithoutSizes as PerformanceNavigationTiming]);
+
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'documentFetch');
+        assert.isOk(fetchSpan);
+
+        // undefined (not reported) must not be conflated with a reported 0
+        assert.isUndefined(fetchSpan?.attributes['http.response.size']);
+        assert.isUndefined(fetchSpan?.attributes['http.response.body.size']);
+        assert.isUndefined(
+          fetchSpan?.attributes['http.response.decoded_body_size'],
+        );
+        done();
+      });
+    });
+
+    it('should report the documentFetch span sizes as 0 when the navigation entry reports 0', (done) => {
+      spyEntries.withArgs('navigation').returns([
+        {
+          ...entries,
+          transferSize: 0,
+          encodedBodySize: 0,
+          decodedBodySize: 0,
+        } as PerformanceNavigationTiming,
+      ]);
 
       plugin.enable();
 

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -24,9 +24,11 @@ import {
 import { assert } from 'chai';
 import type { SinonStubbedFunction } from 'sinon';
 import * as sinon from 'sinon';
+import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/index.ts';
 import { OTelPerformanceManager } from '../../../utils/index.ts';
 import { DocumentLoadInstrumentation } from '../index.ts';
 import { EventNames } from './enums/EventNames.ts';
+import type { EmbracePerformanceResourceTiming } from './utils.ts';
 import { getPerformanceNavigationEntries } from './utils.ts';
 
 const exporter = new InMemorySpanExporter();
@@ -434,6 +436,43 @@ describe('DocumentLoad Instrumentation', () => {
         assert.strictEqual(rsEvents.length, 9);
         assert.strictEqual(fsEvents.length, 11);
         assert.strictEqual(exporter.getFinishedSpans().length, 2);
+        done();
+      });
+    });
+
+    it('should mark the documentFetch span as a resource fetch with the same attributes as other resource spans', (done) => {
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'documentFetch');
+        assert.isOk(fetchSpan);
+
+        assert.strictEqual(
+          fetchSpan?.attributes[KEY_EMB_TYPE],
+          EMB_TYPES.ResourceFetch,
+        );
+        assert.strictEqual(
+          fetchSpan?.attributes['http.request.initiator_type'],
+          entries.initiatorType,
+        );
+        assert.strictEqual(
+          fetchSpan?.attributes['http.response.status_code'],
+          entries.responseStatus,
+        );
+        assert.strictEqual(
+          fetchSpan?.attributes['http.response.size'],
+          entries.transferSize,
+        );
+        assert.strictEqual(
+          fetchSpan?.attributes['http.response.body.size'],
+          entries.encodedBodySize,
+        );
+        assert.strictEqual(
+          fetchSpan?.attributes['http.response.decoded_body_size'],
+          entries.decodedBodySize,
+        );
         done();
       });
     });
@@ -1187,6 +1226,25 @@ describe('DocumentLoad Instrumentation', () => {
 
       assert.strictEqual(result[PTN.FETCH_START], entries.fetchStart);
       assert.strictEqual(result[PTN.LOAD_EVENT_END], entries.loadEventEnd);
+    });
+
+    it('should read the resource-shaped fields that are not part of PerformanceTimingNames', () => {
+      const spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([
+        {
+          ...entries,
+          deliveryType: 'cache',
+          renderBlockingStatus: 'non-blocking',
+        } as EmbracePerformanceResourceTiming,
+      ]);
+
+      const result = getPerformanceNavigationEntries();
+
+      assert.strictEqual(result.transferSize, entries.transferSize);
+      assert.strictEqual(result.initiatorType, entries.initiatorType);
+      assert.strictEqual(result.responseStatus, entries.responseStatus);
+      assert.strictEqual(result.deliveryType, 'cache');
+      assert.strictEqual(result.renderBlockingStatus, 'non-blocking');
     });
   });
 

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -477,6 +477,35 @@ describe('DocumentLoad Instrumentation', () => {
       });
     });
 
+    it('should default the documentFetch span sizes to 0 when the navigation entry lacks size fields', (done) => {
+      const {
+        transferSize,
+        encodedBodySize,
+        decodedBodySize,
+        ...entryWithoutSizes
+      } = entries;
+      spyEntries
+        .withArgs('navigation')
+        .returns([entryWithoutSizes as PerformanceNavigationTiming]);
+
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter
+          .getFinishedSpans()
+          .find((s) => s.name === 'documentFetch');
+        assert.isOk(fetchSpan);
+
+        assert.strictEqual(fetchSpan?.attributes['http.response.size'], 0);
+        assert.strictEqual(fetchSpan?.attributes['http.response.body.size'], 0);
+        assert.strictEqual(
+          fetchSpan?.attributes['http.response.decoded_body_size'],
+          0,
+        );
+        done();
+      });
+    });
+
     describe('AND window has information about server root span', () => {
       let spyGetElementsByTagName: SinonStubbedFunction<[string]>;
       beforeEach(() => {
@@ -1245,6 +1274,15 @@ describe('DocumentLoad Instrumentation', () => {
       assert.strictEqual(result.responseStatus, entries.responseStatus);
       assert.strictEqual(result.deliveryType, 'cache');
       assert.strictEqual(result.renderBlockingStatus, 'non-blocking');
+    });
+
+    it('should return an empty object when there is no navigation entry', () => {
+      const spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([]);
+
+      const result = getPerformanceNavigationEntries();
+
+      assert.deepStrictEqual(result, {});
     });
   });
 

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -43,19 +43,23 @@ import type {
   DocumentLoadInstrumentationConfig,
   ResourceFetchCustomAttributeFunction,
 } from './types.ts';
+import type { EmbracePerformanceResourceTiming } from './utils.ts';
 import {
   addSpanPerformancePaintEvents,
   getPerformanceNavigationEntries,
 } from './utils.ts';
 
-/**
- * Adds new browser features not yet in TypeScript's DOM lib (as of Oct 2025):
- * - deliveryType: Chromium only (experimental) https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType
- * - renderBlockingStatus: Chromium only https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/renderBlockingStatus
- */
-type EmbracePerformanceResourceTiming = PerformanceResourceTiming & {
+/** Fields shared by resource fetch spans and the document fetch span, which is emitted as a resource fetch for the main document request */
+type ResourceSpanData = {
   deliveryType?: 'cache' | '';
+  initiatorType?: string;
   renderBlockingStatus?: 'blocking' | 'non-blocking';
+  responseStatus?: number;
+  encodedBodySize?: number;
+  transferSize?: number;
+  decodedBodySize?: number;
+  fetchStart?: number;
+  responseEnd?: number;
 };
 
 // PerformanceResourceTiming attribute names
@@ -184,6 +188,7 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
               entries,
               this.getConfig().ignoreNetworkEvents,
             );
+            this._addResourceAttributesToSpan(fetchSpan, entries);
             this._addCustomAttributesOnSpan(
               fetchSpan,
               this.getConfig().applyCustomAttributesOnSpan?.documentFetch,
@@ -306,47 +311,10 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
       return;
     }
 
-    span.setAttribute(KEY_EMB_TYPE, EMB_TYPES.ResourceFetch);
     span.setAttribute(ATTR_URL_FULL, resource.name);
     addSpanNetworkEvents(span, resource, this.getConfig().ignoreNetworkEvents);
 
-    if (resource.deliveryType) {
-      span.setAttribute(
-        ATTR_HTTP_RESPONSE_DELIVERY_TYPE,
-        resource.deliveryType,
-      );
-    }
-
-    if (resource.initiatorType) {
-      span.setAttribute(
-        ATTR_HTTP_REQUEST_INITIATOR_TYPE,
-        resource.initiatorType,
-      );
-    }
-
-    if (resource.renderBlockingStatus) {
-      span.setAttribute(
-        ATTR_HTTP_REQUEST_RENDER_BLOCKING_STATUS,
-        resource.renderBlockingStatus,
-      );
-    }
-
-    if (resource.responseStatus) {
-      span.setAttribute(
-        ATTR_HTTP_RESPONSE_STATUS_CODE,
-        resource.responseStatus,
-      );
-    }
-
-    span.setAttribute(ATTR_HTTP_RESPONSE_BODY_SIZE, resource.encodedBodySize);
-    span.setAttribute(ATTR_HTTP_RESPONSE_SIZE, resource.transferSize);
-    span.setAttribute(
-      ATTR_HTTP_RESPONSE_DECODED_BODY_SIZE,
-      resource.decodedBodySize,
-    );
-
-    this._addResourceDiagnosticAttributes(span, resource);
-
+    this._addResourceAttributesToSpan(span, resource);
     this._addCustomAttributesOnResourceSpan(
       span,
       resource,
@@ -438,38 +406,84 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
     }
   }
 
-  private _hasNoSizeData(resource: EmbracePerformanceResourceTiming): boolean {
+  /**
+   * Sets emb.type and the PerformanceResourceTiming-derived attributes shared
+   * by resource fetch spans and the document fetch span, which is emitted as
+   * a resource fetch for the main document request.
+   */
+  private _addResourceAttributesToSpan(
+    span: Span,
+    resource: ResourceSpanData,
+  ): void {
+    span.setAttribute(KEY_EMB_TYPE, EMB_TYPES.ResourceFetch);
+
+    if (resource.deliveryType) {
+      span.setAttribute(
+        ATTR_HTTP_RESPONSE_DELIVERY_TYPE,
+        resource.deliveryType,
+      );
+    }
+
+    if (resource.initiatorType) {
+      span.setAttribute(
+        ATTR_HTTP_REQUEST_INITIATOR_TYPE,
+        resource.initiatorType,
+      );
+    }
+
+    if (resource.renderBlockingStatus) {
+      span.setAttribute(
+        ATTR_HTTP_REQUEST_RENDER_BLOCKING_STATUS,
+        resource.renderBlockingStatus,
+      );
+    }
+
+    if (resource.responseStatus) {
+      span.setAttribute(
+        ATTR_HTTP_RESPONSE_STATUS_CODE,
+        resource.responseStatus,
+      );
+    }
+
+    span.setAttribute(
+      ATTR_HTTP_RESPONSE_BODY_SIZE,
+      resource.encodedBodySize ?? 0,
+    );
+    span.setAttribute(ATTR_HTTP_RESPONSE_SIZE, resource.transferSize ?? 0);
+    span.setAttribute(
+      ATTR_HTTP_RESPONSE_DECODED_BODY_SIZE,
+      resource.decodedBodySize ?? 0,
+    );
+
+    this._addResourceDiagnosticAttributes(span, resource);
+  }
+
+  private _hasNoSizeData(resource: ResourceSpanData): boolean {
     return (
-      resource.transferSize === 0 &&
-      resource.decodedBodySize === 0 &&
-      resource.encodedBodySize === 0
+      (resource.transferSize ?? 0) === 0 &&
+      (resource.decodedBodySize ?? 0) === 0 &&
+      (resource.encodedBodySize ?? 0) === 0
     );
   }
 
-  private _hasTimingData(resource: EmbracePerformanceResourceTiming): boolean {
-    return resource.fetchStart > 0 && resource.responseEnd > 0;
+  private _hasTimingData(resource: ResourceSpanData): boolean {
+    return (resource.fetchStart ?? 0) > 0 && (resource.responseEnd ?? 0) > 0;
   }
 
-  private _isCorsRestricted(
-    resource: EmbracePerformanceResourceTiming,
-  ): boolean {
+  private _isCorsRestricted(resource: ResourceSpanData): boolean {
     return this._hasNoSizeData(resource) && this._hasTimingData(resource);
   }
 
-  private _isFetchIncomplete(
-    resource: EmbracePerformanceResourceTiming,
-  ): boolean {
+  private _isFetchIncomplete(resource: ResourceSpanData): boolean {
     return (
       this._hasNoSizeData(resource) &&
-      resource.fetchStart > 0 &&
-      resource.responseEnd === 0
+      (resource.fetchStart ?? 0) > 0 &&
+      (resource.responseEnd ?? 0) === 0
     );
   }
 
-  private _isFetchPrevented(
-    resource: EmbracePerformanceResourceTiming,
-  ): boolean {
-    return this._hasNoSizeData(resource) && resource.fetchStart === 0;
+  private _isFetchPrevented(resource: ResourceSpanData): boolean {
+    return this._hasNoSizeData(resource) && (resource.fetchStart ?? 0) === 0;
   }
 
   /**
@@ -480,11 +494,11 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
    *
    * Spec: https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-transfersize
    */
-  private _isCacheValidated(
-    resource: EmbracePerformanceResourceTiming,
-  ): boolean {
+  private _isCacheValidated(resource: ResourceSpanData): boolean {
     // deliveryType is Chromium only, so an engine without it never reads 'cache'.
-    return resource.transferSize === 300 && resource.deliveryType !== 'cache';
+    return (
+      (resource.transferSize ?? 0) === 300 && resource.deliveryType !== 'cache'
+    );
   }
 
   /**
@@ -496,14 +510,15 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
    * - Request incomplete (started but didn't complete - network error, aborted)
    * - Request prevented (never started - blocked by CSP, browser, extension)
    *
-   * The size and timing fields read below are always numbers: a cross-origin
-   * resource with no Timing-Allow-Origin reports them as 0 rather than omitting
-   * them, and a resource only reaches here once it has produced a span, which
-   * required a numeric fetchStart.
+   * The size and timing fields read below are always numbers on a genuine
+   * PerformanceResourceTiming/PerformanceNavigationTiming entry: a
+   * cross-origin resource with no Timing-Allow-Origin reports them as 0
+   * rather than omitting them, and a resource only reaches here once it has
+   * produced a span, which required a numeric fetchStart.
    */
   private _addResourceDiagnosticAttributes(
     span: Span,
-    resource: EmbracePerformanceResourceTiming,
+    resource: ResourceSpanData,
   ): void {
     if (this._isCorsRestricted(resource)) {
       span.setAttribute(ATTR_HTTP_RESPONSE_CORS_OPAQUE, true);

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -65,8 +65,6 @@ type ResourceSpanData = {
   encodedBodySize?: number;
   transferSize?: number;
   decodedBodySize?: number;
-  fetchStart?: number;
-  responseEnd?: number;
 };
 
 // PerformanceResourceTiming attribute names
@@ -328,6 +326,7 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
     addSpanNetworkEvents(span, resource, this.getConfig().ignoreNetworkEvents);
 
     this._addResourceAttributesToSpan(span, resource);
+    this._addResourceDiagnosticAttributes(span, resource);
     this._addCustomAttributesOnResourceSpan(
       span,
       resource,
@@ -458,17 +457,20 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
       );
     }
 
-    span.setAttribute(
-      ATTR_HTTP_RESPONSE_BODY_SIZE,
-      resource.encodedBodySize ?? 0,
-    );
-    span.setAttribute(ATTR_HTTP_RESPONSE_SIZE, resource.transferSize ?? 0);
-    span.setAttribute(
-      ATTR_HTTP_RESPONSE_DECODED_BODY_SIZE,
-      resource.decodedBodySize ?? 0,
-    );
+    if (resource.encodedBodySize !== undefined) {
+      span.setAttribute(ATTR_HTTP_RESPONSE_BODY_SIZE, resource.encodedBodySize);
+    }
 
-    this._addResourceDiagnosticAttributes(span, resource);
+    if (resource.transferSize !== undefined) {
+      span.setAttribute(ATTR_HTTP_RESPONSE_SIZE, resource.transferSize);
+    }
+
+    if (resource.decodedBodySize !== undefined) {
+      span.setAttribute(
+        ATTR_HTTP_RESPONSE_DECODED_BODY_SIZE,
+        resource.decodedBodySize,
+      );
+    }
   }
 
   /**
@@ -490,32 +492,38 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
     }
   }
 
-  private _hasNoSizeData(resource: ResourceSpanData): boolean {
+  private _hasNoSizeData(resource: EmbracePerformanceResourceTiming): boolean {
     return (
-      (resource.transferSize ?? 0) === 0 &&
-      (resource.decodedBodySize ?? 0) === 0 &&
-      (resource.encodedBodySize ?? 0) === 0
+      resource.transferSize === 0 &&
+      resource.decodedBodySize === 0 &&
+      resource.encodedBodySize === 0
     );
   }
 
-  private _hasTimingData(resource: ResourceSpanData): boolean {
-    return (resource.fetchStart ?? 0) > 0 && (resource.responseEnd ?? 0) > 0;
+  private _hasTimingData(resource: EmbracePerformanceResourceTiming): boolean {
+    return resource.fetchStart > 0 && resource.responseEnd > 0;
   }
 
-  private _isCorsRestricted(resource: ResourceSpanData): boolean {
+  private _isCorsRestricted(
+    resource: EmbracePerformanceResourceTiming,
+  ): boolean {
     return this._hasNoSizeData(resource) && this._hasTimingData(resource);
   }
 
-  private _isFetchIncomplete(resource: ResourceSpanData): boolean {
+  private _isFetchIncomplete(
+    resource: EmbracePerformanceResourceTiming,
+  ): boolean {
     return (
       this._hasNoSizeData(resource) &&
-      (resource.fetchStart ?? 0) > 0 &&
-      (resource.responseEnd ?? 0) === 0
+      resource.fetchStart > 0 &&
+      resource.responseEnd === 0
     );
   }
 
-  private _isFetchPrevented(resource: ResourceSpanData): boolean {
-    return this._hasNoSizeData(resource) && (resource.fetchStart ?? 0) === 0;
+  private _isFetchPrevented(
+    resource: EmbracePerformanceResourceTiming,
+  ): boolean {
+    return this._hasNoSizeData(resource) && resource.fetchStart === 0;
   }
 
   /**
@@ -526,11 +534,11 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
    *
    * Spec: https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-transfersize
    */
-  private _isCacheValidated(resource: ResourceSpanData): boolean {
+  private _isCacheValidated(
+    resource: EmbracePerformanceResourceTiming,
+  ): boolean {
     // deliveryType is Chromium only, so an engine without it never reads 'cache'.
-    return (
-      (resource.transferSize ?? 0) === 300 && resource.deliveryType !== 'cache'
-    );
+    return resource.transferSize === 300 && resource.deliveryType !== 'cache';
   }
 
   /**
@@ -542,15 +550,14 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
    * - Request incomplete (started but didn't complete - network error, aborted)
    * - Request prevented (never started - blocked by CSP, browser, extension)
    *
-   * The size and timing fields read below are always numbers on a genuine
-   * PerformanceResourceTiming/PerformanceNavigationTiming entry: a
-   * cross-origin resource with no Timing-Allow-Origin reports them as 0
-   * rather than omitting them, and a resource only reaches here once it has
-   * produced a span, which required a numeric fetchStart.
+   * The size and timing fields read below are always numbers: a cross-origin
+   * resource with no Timing-Allow-Origin reports them as 0 rather than omitting
+   * them, and a resource only reaches here once it has produced a span, which
+   * required a numeric fetchStart.
    */
   private _addResourceDiagnosticAttributes(
     span: Span,
-    resource: ResourceSpanData,
+    resource: EmbracePerformanceResourceTiming,
   ): void {
     if (this._isCorsRestricted(resource)) {
       span.setAttribute(ATTR_HTTP_RESPONSE_CORS_OPAQUE, true);

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -14,6 +14,10 @@
  * - http.response.cache_revalidated - 304 Not Modified response
  * - http.request.incomplete - Request started but didn't complete (network error, aborted)
  * - http.request.prevented - Request never started (blocked by CSP, browser, extension)
+ *
+ * Navigation-only attributes added to the document fetch span (no PerformanceResourceTiming equivalent):
+ * - browser.navigation_timing.type - how the browser arrived at the page (navigate, reload, back_forward)
+ * - browser.navigation_timing.not_restored_reasons - why the page couldn't be restored from the back/forward cache (Limited availability)
  */
 
 import type { Span } from '@opentelemetry/api';
@@ -43,7 +47,10 @@ import type {
   DocumentLoadInstrumentationConfig,
   ResourceFetchCustomAttributeFunction,
 } from './types.ts';
-import type { EmbracePerformanceResourceTiming } from './utils.ts';
+import type {
+  EmbracePerformanceNavigationEntries,
+  EmbracePerformanceResourceTiming,
+} from './utils.ts';
 import {
   addSpanPerformancePaintEvents,
   getPerformanceNavigationEntries,
@@ -74,6 +81,11 @@ const ATTR_HTTP_RESPONSE_CORS_OPAQUE = 'http.response.cors_opaque'; // CORS-rest
 const ATTR_HTTP_RESPONSE_CACHE_REVALIDATED = 'http.response.cache_revalidated'; // 304 Not Modified response
 const ATTR_HTTP_REQUEST_INCOMPLETE = 'http.request.incomplete'; // Request started but didn't complete
 const ATTR_HTTP_REQUEST_PREVENTED = 'http.request.prevented'; // Request never started (blocked)
+
+// Navigation-only attribute names - no PerformanceResourceTiming equivalent, so these never apply to resource fetch spans
+const ATTR_BROWSER_NAVIGATION_TIMING_TYPE = 'browser.navigation_timing.type';
+const ATTR_BROWSER_NAVIGATION_TIMING_NOT_RESTORED_REASONS =
+  'browser.navigation_timing.not_restored_reasons';
 
 export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<DocumentLoadInstrumentationConfig> {
   private _navigationObserver: PerformanceObserver | null = null;
@@ -189,6 +201,7 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
               this.getConfig().ignoreNetworkEvents,
             );
             this._addResourceAttributesToSpan(fetchSpan, entries);
+            this._addNavigationTimingAttributesToSpan(fetchSpan, entries);
             this._addCustomAttributesOnSpan(
               fetchSpan,
               this.getConfig().applyCustomAttributesOnSpan?.documentFetch,
@@ -456,6 +469,25 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
     );
 
     this._addResourceDiagnosticAttributes(span, resource);
+  }
+
+  /**
+   * Adds attributes that only make sense for the document fetch span
+   */
+  private _addNavigationTimingAttributesToSpan(
+    span: Span,
+    entries: EmbracePerformanceNavigationEntries,
+  ): void {
+    if (entries.type) {
+      span.setAttribute(ATTR_BROWSER_NAVIGATION_TIMING_TYPE, entries.type);
+    }
+
+    if (entries.notRestoredReasons?.length) {
+      span.setAttribute(
+        ATTR_BROWSER_NAVIGATION_TIMING_NOT_RESTORED_REASONS,
+        entries.notRestoredReasons,
+      );
+    }
   }
 
   private _hasNoSizeData(resource: ResourceSpanData): boolean {

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
@@ -20,11 +20,24 @@ export type EmbracePerformanceResourceTiming = PerformanceResourceTiming & {
 };
 
 /**
+ * Adds new browser features not yet in TypeScript's DOM lib (as of Oct 2025):
+ * - notRestoredReasons: Limited availability https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/notRestoredReasons
+ * Only the top-level document's own reasons are read; nested iframe reasons
+ * (the `children` field) aren't relevant to the document fetch span.
+ */
+export type EmbracePerformanceNavigationTiming = PerformanceNavigationTiming & {
+  deliveryType?: 'cache' | '';
+  renderBlockingStatus?: 'blocking' | 'non-blocking';
+  notRestoredReasons?: { reasons?: { reason: string }[] } | null;
+};
+
+/**
  * PerformanceTimingNames only covers navigation timing marks, so transferSize,
- * initiatorType, responseStatus, deliveryType and renderBlockingStatus - all
- * present on the underlying PerformanceNavigationTiming entry - are read
- * separately below. This lets the document fetch span carry the same
- * attributes as resource fetch spans.
+ * initiatorType, responseStatus, deliveryType, renderBlockingStatus, type and
+ * notRestoredReasons - all present on the underlying PerformanceNavigationTiming
+ * entry - are read separately below. This lets the document fetch span carry
+ * the same attributes as resource fetch spans, plus the navigation-specific
+ * ones no resource entry ever has.
  */
 export type EmbracePerformanceNavigationEntries = PerformanceEntries & {
   transferSize?: number;
@@ -32,6 +45,8 @@ export type EmbracePerformanceNavigationEntries = PerformanceEntries & {
   responseStatus?: number;
   deliveryType?: 'cache' | '';
   renderBlockingStatus?: 'blocking' | 'non-blocking';
+  type?: NavigationTimingType;
+  notRestoredReasons?: string[];
 };
 
 export const getPerformanceNavigationEntries =
@@ -39,7 +54,7 @@ export const getPerformanceNavigationEntries =
     const entries: EmbracePerformanceNavigationEntries = {};
     const performanceNavigationTiming = window.performance.getEntriesByType(
       'navigation',
-    )[0] as EmbracePerformanceResourceTiming | undefined;
+    )[0] as EmbracePerformanceNavigationTiming | undefined;
     if (!performanceNavigationTiming) {
       return entries;
     }
@@ -60,6 +75,12 @@ export const getPerformanceNavigationEntries =
     entries.deliveryType = performanceNavigationTiming.deliveryType;
     entries.renderBlockingStatus =
       performanceNavigationTiming.renderBlockingStatus;
+    entries.type = performanceNavigationTiming.type;
+    entries.notRestoredReasons =
+      // eslint-disable-next-line baseline-js/use-baseline
+      performanceNavigationTiming.notRestoredReasons?.reasons?.map(
+        (r) => r.reason,
+      );
 
     return entries;
   };

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/utils.ts
@@ -9,26 +9,60 @@ import { hasKey, PerformanceTimingNames } from '@opentelemetry/sdk-trace-web';
 import type { PerformanceManager } from '../../../utils/index.ts';
 import { EventNames } from './enums/EventNames.ts';
 
-export const getPerformanceNavigationEntries = (): PerformanceEntries => {
-  const entries: PerformanceEntries = {};
-  const performanceNavigationTiming =
-    window.performance.getEntriesByType('navigation')[0];
-  if (!performanceNavigationTiming) {
-    return entries;
-  }
-
-  const keys = Object.values(PerformanceTimingNames);
-  keys.forEach((key: PerformanceTimingNames) => {
-    if (hasKey(performanceNavigationTiming, key)) {
-      const value = performanceNavigationTiming[key];
-      if (typeof value === 'number') {
-        entries[key] = value;
-      }
-    }
-  });
-
-  return entries;
+/**
+ * Adds new browser features not yet in TypeScript's DOM lib (as of Oct 2025):
+ * - deliveryType: Chromium only (experimental) https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType
+ * - renderBlockingStatus: Chromium only https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/renderBlockingStatus
+ */
+export type EmbracePerformanceResourceTiming = PerformanceResourceTiming & {
+  deliveryType?: 'cache' | '';
+  renderBlockingStatus?: 'blocking' | 'non-blocking';
 };
+
+/**
+ * PerformanceTimingNames only covers navigation timing marks, so transferSize,
+ * initiatorType, responseStatus, deliveryType and renderBlockingStatus - all
+ * present on the underlying PerformanceNavigationTiming entry - are read
+ * separately below. This lets the document fetch span carry the same
+ * attributes as resource fetch spans.
+ */
+export type EmbracePerformanceNavigationEntries = PerformanceEntries & {
+  transferSize?: number;
+  initiatorType?: string;
+  responseStatus?: number;
+  deliveryType?: 'cache' | '';
+  renderBlockingStatus?: 'blocking' | 'non-blocking';
+};
+
+export const getPerformanceNavigationEntries =
+  (): EmbracePerformanceNavigationEntries => {
+    const entries: EmbracePerformanceNavigationEntries = {};
+    const performanceNavigationTiming = window.performance.getEntriesByType(
+      'navigation',
+    )[0] as EmbracePerformanceResourceTiming | undefined;
+    if (!performanceNavigationTiming) {
+      return entries;
+    }
+
+    const keys = Object.values(PerformanceTimingNames);
+    keys.forEach((key: PerformanceTimingNames) => {
+      if (hasKey(performanceNavigationTiming, key)) {
+        const value = performanceNavigationTiming[key];
+        if (typeof value === 'number') {
+          entries[key] = value;
+        }
+      }
+    });
+
+    entries.transferSize = performanceNavigationTiming.transferSize;
+    entries.initiatorType = performanceNavigationTiming.initiatorType;
+    entries.responseStatus = performanceNavigationTiming.responseStatus;
+    entries.deliveryType = performanceNavigationTiming.deliveryType;
+    entries.renderBlockingStatus =
+      performanceNavigationTiming.renderBlockingStatus;
+
+    return entries;
+  };
 
 const performancePaintNames = {
   'first-paint': EventNames.FIRST_PAINT,

--- a/tests/integration/config/thresholds.ts
+++ b/tests/integration/config/thresholds.ts
@@ -10,7 +10,7 @@ const TOTAL_UNCOMPRESSED_SIZE_THRESHOLD_IN_KB = getFromEnv(
 );
 const TOTAL_GZIP_SIZE_THRESHOLD_IN_KB = getFromEnv(
   'TOTAL_GZIP_SIZE_THRESHOLD_IN_KB',
-  75,
+  76,
 );
 
 export {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "794D0F2F07A4BF6EC05DE25675E8AED1"
+              "stringValue": "7803BABBA01A4C652AA38B8546C13731"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "9e5cf53a314df09a7c8920fa07124ed8",
-              "spanId": "54cc79638eac3338",
+              "traceId": "a29a30ebd3b0d3c754a264cba245a2bc",
+              "spanId": "776cdf277ef36092",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787314498294000000",
-              "endTimeUnixNano": "1787314499090800049",
+              "startTimeUnixNano": "1787334338969000000",
+              "endTimeUnixNano": "1787334340203300049",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "BD546EF69E82DF938F6C6D243D03D3B1"
+                    "stringValue": "C2A599983FA12BF6F2E06ACE85376258"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "doubleValue": 1787314498294.0999
+                    "doubleValue": 1787334338968.8
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "9D4AF7DF955E5193BAFACB312F149936"
+                    "stringValue": "A19F55E0F802A32DE13B09A5608305D5"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 10
+                    "intValue": 11
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "FE5305422A3C29243FB1A88A5074D88D"
+                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787314498432800049",
+                  "timeUnixNano": "1787334339180399902",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787314498757399902",
+                  "timeUnixNano": "1787334339805399902",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "ec5fc3d51e04487e280e535a5352ebd7",
-              "spanId": "f1dbc4efb44784f0",
-              "parentSpanId": "cbc93fb017fdc531",
+              "traceId": "dfa572cefb4dd6c8754e0a3c8a395704",
+              "spanId": "3e393227351da388",
+              "parentSpanId": "17dc0339540d00fa",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314498231899902",
-              "endTimeUnixNano": "1787314498234899902",
+              "startTimeUnixNano": "1787334338905600098",
+              "endTimeUnixNano": "1787334338915600098",
               "attributes": [
                 {
                   "key": "url.full",
@@ -317,6 +317,48 @@
                 },
                 {
                   "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 252
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
+                  }
+                },
+                {
+                  "key": "http.request.initiator_type",
+                  "value": {
+                    "stringValue": "navigation"
+                  }
+                },
+                {
+                  "key": "http.request.render_blocking_status",
+                  "value": {
+                    "stringValue": "non-blocking"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": 200
+                  }
+                },
+                {
+                  "key": "http.response.body.size",
+                  "value": {
+                    "intValue": 252
+                  }
+                },
+                {
+                  "key": "http.response.size",
+                  "value": {
+                    "intValue": 552
+                  }
+                },
+                {
+                  "key": "http.response.decoded_body_size",
                   "value": {
                     "intValue": 252
                   }
@@ -336,7 +378,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "FE5305422A3C29243FB1A88A5074D88D"
+                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
                   }
                 },
                 {
@@ -351,55 +393,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314498231500049",
+                  "timeUnixNano": "1787334338904999902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314498233000049",
+                  "timeUnixNano": "1787334338910699902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314498233000049",
+                  "timeUnixNano": "1787334338910699902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314498233000049",
+                  "timeUnixNano": "1787334338910699902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787314498231300049",
+                  "timeUnixNano": "1787334338904899902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314498233300049",
+                  "timeUnixNano": "1787334338910799902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314498233400049",
+                  "timeUnixNano": "1787334338910999902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314498234200049",
+                  "timeUnixNano": "1787334338914699902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314498234500049",
+                  "timeUnixNano": "1787334338914999902",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -412,30 +454,30 @@
               "flags": 257
             },
             {
-              "traceId": "ec5fc3d51e04487e280e535a5352ebd7",
-              "spanId": "e148c12602c0e4fa",
-              "parentSpanId": "cbc93fb017fdc531",
+              "traceId": "dfa572cefb4dd6c8754e0a3c8a395704",
+              "spanId": "36f51052f1c58585",
+              "parentSpanId": "17dc0339540d00fa",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314498237399902",
-              "endTimeUnixNano": "1787314498242500000",
+              "startTimeUnixNano": "1787334338918600098",
+              "endTimeUnixNano": "1787334338923300049",
               "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.resource_fetch"
-                  }
-                },
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-WJHWQ8y1.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 437209
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
                   }
                 },
                 {
@@ -459,19 +501,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 437209
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 425923
+                    "intValue": 437509
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 437209
                   }
                 },
                 {
@@ -489,7 +531,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "FE5305422A3C29243FB1A88A5074D88D"
+                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
                   }
                 },
                 {
@@ -504,49 +546,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314498237000049",
+                  "timeUnixNano": "1787334338918400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314498237000049",
+                  "timeUnixNano": "1787334338918400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314498237000049",
+                  "timeUnixNano": "1787334338918400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314498237000049",
+                  "timeUnixNano": "1787334338918400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314498237000049",
+                  "timeUnixNano": "1787334338918400049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314498240000049",
+                  "timeUnixNano": "1787334338921300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314498240900049",
+                  "timeUnixNano": "1787334338922200049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314498242100049",
+                  "timeUnixNano": "1787334338923100049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -559,12 +601,12 @@
               "flags": 257
             },
             {
-              "traceId": "ec5fc3d51e04487e280e535a5352ebd7",
-              "spanId": "cbc93fb017fdc531",
+              "traceId": "dfa572cefb4dd6c8754e0a3c8a395704",
+              "spanId": "17dc0339540d00fa",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787314498231899902",
-              "endTimeUnixNano": "1787314498300800049",
+              "startTimeUnixNano": "1787334338905600098",
+              "endTimeUnixNano": "1787334338977000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -599,7 +641,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "FE5305422A3C29243FB1A88A5074D88D"
+                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
                   }
                 },
                 {
@@ -614,43 +656,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314498231599902",
+                  "timeUnixNano": "1787334338905100000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787314498239399902",
+                  "timeUnixNano": "1787334338920100000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787314498300199902",
+                  "timeUnixNano": "1787334338976200000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787314498300199902",
+                  "timeUnixNano": "1787334338976200000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787314498300199902",
+                  "timeUnixNano": "1787334338976200000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787314498300199902",
+                  "timeUnixNano": "1787334338976200000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787314498300499902",
+                  "timeUnixNano": "1787334338976500000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -671,12 +713,12 @@
           },
           "spans": [
             {
-              "traceId": "ee17b139d3c5cc01f54cc5eee0a0ba62",
-              "spanId": "3a1bf4ccd1ee20e7",
+              "traceId": "647a0743b77db9fee5ccfb49a37f9f7a",
+              "spanId": "f237f93b19701b5e",
               "name": "GET",
               "kind": 3,
-              "startTimeUnixNano": "1787314498435000000",
-              "endTimeUnixNano": "1787314498440000000",
+              "startTimeUnixNano": "1787334339181000000",
+              "endTimeUnixNano": "1787334339199000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -729,7 +771,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "FE5305422A3C29243FB1A88A5074D88D"
+                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
                   }
                 },
                 {
@@ -744,49 +786,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314498435900000",
+                  "timeUnixNano": "1787334339181600000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314498435900000",
+                  "timeUnixNano": "1787334339181600000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314498435900000",
+                  "timeUnixNano": "1787334339181600000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314498435900000",
+                  "timeUnixNano": "1787334339181600000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314498435900000",
+                  "timeUnixNano": "1787334339181600000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314498435900000",
+                  "timeUnixNano": "1787334339181600000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314498439800000",
+                  "timeUnixNano": "1787334339198000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314498439800000",
+                  "timeUnixNano": "1787334339198000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -799,12 +841,12 @@
               "flags": 257
             },
             {
-              "traceId": "0a65bac920c87b2064e4cb07ac05a86a",
-              "spanId": "bc64259a34cd7718",
+              "traceId": "9d46a37d6e5f59e48a93a20654f7a562",
+              "spanId": "9da5d853bd445066",
               "name": "POST",
               "kind": 3,
-              "startTimeUnixNano": "1787314498761000000",
-              "endTimeUnixNano": "1787314498766000000",
+              "startTimeUnixNano": "1787334339810000000",
+              "endTimeUnixNano": "1787334339848000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -857,7 +899,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "FE5305422A3C29243FB1A88A5074D88D"
+                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
                   }
                 },
                 {
@@ -872,49 +914,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314498761300049",
+                  "timeUnixNano": "1787334339810599902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314498764100049",
+                  "timeUnixNano": "1787334339832799902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314498764100049",
+                  "timeUnixNano": "1787334339832999902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314498764100049",
+                  "timeUnixNano": "1787334339832999902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314498764300049",
+                  "timeUnixNano": "1787334339833199902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314498764400049",
+                  "timeUnixNano": "1787334339833199902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314498765100049",
+                  "timeUnixNano": "1787334339846999902",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314498765300049",
+                  "timeUnixNano": "1787334339847399902",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -935,12 +977,12 @@
           },
           "spans": [
             {
-              "traceId": "e3e132de25b310167a084de185a28d63",
-              "spanId": "7a726e46c7a73f03",
+              "traceId": "88a110df530596547be3768e84cef055",
+              "spanId": "465023bcf6f420d1",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787314498298599854",
-              "endTimeUnixNano": "1787314499091699951",
+              "startTimeUnixNano": "1787334338974000000",
+              "endTimeUnixNano": "1787334340204100098",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -957,7 +999,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "FE5305422A3C29243FB1A88A5074D88D"
+                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "7803BABBA01A4C652AA38B8546C13731"
+              "stringValue": "BDEF85C326B0F52B2F4D001BBD8F4730"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "a29a30ebd3b0d3c754a264cba245a2bc",
-              "spanId": "776cdf277ef36092",
+              "traceId": "b37a059c51c3ae3a6b6ace09e1ddaedc",
+              "spanId": "0bc55d6687b21e89",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787334338969000000",
-              "endTimeUnixNano": "1787334340203300049",
+              "startTimeUnixNano": "1787935838029000000",
+              "endTimeUnixNano": "1787935838910500000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "C2A599983FA12BF6F2E06ACE85376258"
+                    "stringValue": "149A66ADDCFFCED3428D383BC7AA92C1"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "doubleValue": 1787334338968.8
+                    "intValue": 1787935838029
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "A19F55E0F802A32DE13B09A5608305D5"
+                    "stringValue": "CFF41F361301C5DA6D6A8BBF85DDC091"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 11
+                    "intValue": 6
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
+                    "stringValue": "BE61390510B79A4A54FBE898160EE3AB"
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787334339180399902",
+                  "timeUnixNano": "1787935838157000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787334339805399902",
+                  "timeUnixNano": "1787935838581100098",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "dfa572cefb4dd6c8754e0a3c8a395704",
-              "spanId": "3e393227351da388",
-              "parentSpanId": "17dc0339540d00fa",
+              "traceId": "b55d301abb1d48b471f7a20f5b31b093",
+              "spanId": "b509c5d2112481e9",
+              "parentSpanId": "73b4f9f9018c4c24",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787334338905600098",
-              "endTimeUnixNano": "1787334338915600098",
+              "startTimeUnixNano": "1787935837993800049",
+              "endTimeUnixNano": "1787935837995400146",
               "attributes": [
                 {
                   "key": "url.full",
@@ -364,6 +364,12 @@
                   }
                 },
                 {
+                  "key": "browser.navigation_timing.type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -378,7 +384,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
+                    "stringValue": "BE61390510B79A4A54FBE898160EE3AB"
                   }
                 },
                 {
@@ -393,55 +399,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334338904999902",
+                  "timeUnixNano": "1787935837993300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334338910699902",
+                  "timeUnixNano": "1787935837994200049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334338910699902",
+                  "timeUnixNano": "1787935837994200049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334338910699902",
+                  "timeUnixNano": "1787935837994200049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787334338904899902",
+                  "timeUnixNano": "1787935837993300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334338910799902",
+                  "timeUnixNano": "1787935837994300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334338910999902",
+                  "timeUnixNano": "1787935837994300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787334338914699902",
+                  "timeUnixNano": "1787935837994800049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334338914999902",
+                  "timeUnixNano": "1787935837994900049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -454,24 +460,24 @@
               "flags": 257
             },
             {
-              "traceId": "dfa572cefb4dd6c8754e0a3c8a395704",
-              "spanId": "36f51052f1c58585",
-              "parentSpanId": "17dc0339540d00fa",
+              "traceId": "b55d301abb1d48b471f7a20f5b31b093",
+              "spanId": "930993644862db14",
+              "parentSpanId": "73b4f9f9018c4c24",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787334338918600098",
-              "endTimeUnixNano": "1787334338923300049",
+              "startTimeUnixNano": "1787935837997100098",
+              "endTimeUnixNano": "1787935837999699951",
               "attributes": [
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-WJHWQ8y1.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-CGC8ESZ5.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 437209
+                    "intValue": 437485
                   }
                 },
                 {
@@ -501,19 +507,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 437209
+                    "intValue": 437485
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 437509
+                    "intValue": 437785
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 437209
+                    "intValue": 437485
                   }
                 },
                 {
@@ -531,7 +537,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
+                    "stringValue": "BE61390510B79A4A54FBE898160EE3AB"
                   }
                 },
                 {
@@ -546,49 +552,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334338918400049",
+                  "timeUnixNano": "1787935837996999951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334338918400049",
+                  "timeUnixNano": "1787935837996999951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334338918400049",
+                  "timeUnixNano": "1787935837996999951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334338918400049",
+                  "timeUnixNano": "1787935837996999951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334338918400049",
+                  "timeUnixNano": "1787935837996999951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334338921300049",
+                  "timeUnixNano": "1787935837998499951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787334338922200049",
+                  "timeUnixNano": "1787935837998999951",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334338923100049",
+                  "timeUnixNano": "1787935837999599951",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -601,12 +607,12 @@
               "flags": 257
             },
             {
-              "traceId": "dfa572cefb4dd6c8754e0a3c8a395704",
-              "spanId": "17dc0339540d00fa",
+              "traceId": "b55d301abb1d48b471f7a20f5b31b093",
+              "spanId": "73b4f9f9018c4c24",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787334338905600098",
-              "endTimeUnixNano": "1787334338977000000",
+              "startTimeUnixNano": "1787935837993800049",
+              "endTimeUnixNano": "1787935838033100098",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -641,7 +647,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
+                    "stringValue": "BE61390510B79A4A54FBE898160EE3AB"
                   }
                 },
                 {
@@ -655,44 +661,38 @@
               "events": [
                 {
                   "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1787334338905100000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787334338920100000",
+                  "timeUnixNano": "1787935837997899903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787334338976200000",
+                  "timeUnixNano": "1787935838032499903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787334338976200000",
+                  "timeUnixNano": "1787935838032499903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787334338976200000",
+                  "timeUnixNano": "1787935838032499903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787334338976200000",
+                  "timeUnixNano": "1787935838032499903",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787334338976500000",
+                  "timeUnixNano": "1787935838032699903",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -713,12 +713,12 @@
           },
           "spans": [
             {
-              "traceId": "647a0743b77db9fee5ccfb49a37f9f7a",
-              "spanId": "f237f93b19701b5e",
+              "traceId": "3d4f0a87a51347d8b817640aa456040b",
+              "spanId": "577df6f890c2afc1",
               "name": "GET",
               "kind": 3,
-              "startTimeUnixNano": "1787334339181000000",
-              "endTimeUnixNano": "1787334339199000000",
+              "startTimeUnixNano": "1787935838158000000",
+              "endTimeUnixNano": "1787935838164000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -771,7 +771,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
+                    "stringValue": "BE61390510B79A4A54FBE898160EE3AB"
                   }
                 },
                 {
@@ -786,49 +786,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334339181600000",
+                  "timeUnixNano": "1787935838158500049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334339181600000",
+                  "timeUnixNano": "1787935838158500049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334339181600000",
+                  "timeUnixNano": "1787935838158500049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334339181600000",
+                  "timeUnixNano": "1787935838158500049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334339181600000",
+                  "timeUnixNano": "1787935838158500049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334339181600000",
+                  "timeUnixNano": "1787935838158500049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787334339198000000",
+                  "timeUnixNano": "1787935838160300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334339198000000",
+                  "timeUnixNano": "1787935838160300049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -841,12 +841,12 @@
               "flags": 257
             },
             {
-              "traceId": "9d46a37d6e5f59e48a93a20654f7a562",
-              "spanId": "9da5d853bd445066",
+              "traceId": "3dffbe13ac95c39bfc2ec8cd7cc450e7",
+              "spanId": "e7c8bc3e091ca1bf",
               "name": "POST",
               "kind": 3,
-              "startTimeUnixNano": "1787334339810000000",
-              "endTimeUnixNano": "1787334339848000000",
+              "startTimeUnixNano": "1787935838584000000",
+              "endTimeUnixNano": "1787935838589000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -899,7 +899,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
+                    "stringValue": "BE61390510B79A4A54FBE898160EE3AB"
                   }
                 },
                 {
@@ -914,49 +914,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334339810599902",
+                  "timeUnixNano": "1787935838584300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334339832799902",
+                  "timeUnixNano": "1787935838584300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334339832999902",
+                  "timeUnixNano": "1787935838584300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334339832999902",
+                  "timeUnixNano": "1787935838584300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334339833199902",
+                  "timeUnixNano": "1787935838584300049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334339833199902",
+                  "timeUnixNano": "1787935838586200049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787334339846999902",
+                  "timeUnixNano": "1787935838586800049",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334339847399902",
+                  "timeUnixNano": "1787935838586900049",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -977,12 +977,12 @@
           },
           "spans": [
             {
-              "traceId": "88a110df530596547be3768e84cef055",
-              "spanId": "465023bcf6f420d1",
+              "traceId": "ef47d6ab2c6dc78d6115006c56df8afa",
+              "spanId": "1fbe3171d08a1154",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787334338974000000",
-              "endTimeUnixNano": "1787334340204100098",
+              "startTimeUnixNano": "1787935838031600098",
+              "endTimeUnixNano": "1787935838911100098",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -999,7 +999,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "70F32005A5F457D6BE705530764B9CF3"
+                    "stringValue": "BE61390510B79A4A54FBE898160EE3AB"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "89E64DB4640D8B367611B635561AD894"
+              "stringValue": "1664C995752D835F8F4BF6B816ED8E6F"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "62b94d0fc7a741c5da41ff3cd4d39382",
-              "spanId": "f6fd33d466e310fa",
+              "traceId": "5df219a550875f666d27921f984044ed",
+              "spanId": "0f9de4570c62e777",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787314494830000000",
-              "endTimeUnixNano": "1787314494967699951",
+              "startTimeUnixNano": "1787334338134000000",
+              "endTimeUnixNano": "1787334338289300049",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "42F7B61E7361ED3A504B891824D7CB36"
+                    "stringValue": "B2E537469725DF9A32F07FDD667F5B8A"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "doubleValue": 1787314494829.8
+                    "doubleValue": 1787334338133.4001
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0B5A15EFAAF0B125AFE691B94927D7D0"
+                    "stringValue": "E7DBB94F8A23F1B384189916E7BA4885"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 10
+                    "intValue": 20
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "E92EC8A02D5B01E15F031DF12F77230D"
+                    "stringValue": "1CACFC4D05BD21DA5FE579C0EC89645D"
                   }
                 },
                 {
@@ -250,13 +250,13 @@
           },
           "spans": [
             {
-              "traceId": "b1adba0a647efaec137712ef1dd2bff1",
-              "spanId": "337f832634845f9e",
-              "parentSpanId": "b9235d18a5ddb6ae",
+              "traceId": "30d99fd41fdb40519a348d5faac800d6",
+              "spanId": "c93cd0222ba7b0f8",
+              "parentSpanId": "c2c426eaaff07582",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314494767199951",
-              "endTimeUnixNano": "1787314494769399902",
+              "startTimeUnixNano": "1787334337974900146",
+              "endTimeUnixNano": "1787334337995800049",
               "attributes": [
                 {
                   "key": "url.full",
@@ -266,6 +266,48 @@
                 },
                 {
                   "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 252
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
+                  }
+                },
+                {
+                  "key": "http.request.initiator_type",
+                  "value": {
+                    "stringValue": "navigation"
+                  }
+                },
+                {
+                  "key": "http.request.render_blocking_status",
+                  "value": {
+                    "stringValue": "non-blocking"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": 200
+                  }
+                },
+                {
+                  "key": "http.response.body.size",
+                  "value": {
+                    "intValue": 252
+                  }
+                },
+                {
+                  "key": "http.response.size",
+                  "value": {
+                    "intValue": 552
+                  }
+                },
+                {
+                  "key": "http.response.decoded_body_size",
                   "value": {
                     "intValue": 252
                   }
@@ -285,7 +327,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "E92EC8A02D5B01E15F031DF12F77230D"
+                    "stringValue": "1CACFC4D05BD21DA5FE579C0EC89645D"
                   }
                 },
                 {
@@ -300,55 +342,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314494766899951",
+                  "timeUnixNano": "1787334337974400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314494768199951",
+                  "timeUnixNano": "1787334337984700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314494768199951",
+                  "timeUnixNano": "1787334337985400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314494768199951",
+                  "timeUnixNano": "1787334337985400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787314494766699951",
+                  "timeUnixNano": "1787334337974100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314494768299951",
+                  "timeUnixNano": "1787334337987000098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314494768399951",
+                  "timeUnixNano": "1787334337988600098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314494768799951",
+                  "timeUnixNano": "1787334337992900098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314494769099951",
+                  "timeUnixNano": "1787334337995300098",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -361,30 +403,30 @@
               "flags": 257
             },
             {
-              "traceId": "b1adba0a647efaec137712ef1dd2bff1",
-              "spanId": "d3c2783c7eff369a",
-              "parentSpanId": "b9235d18a5ddb6ae",
+              "traceId": "30d99fd41fdb40519a348d5faac800d6",
+              "spanId": "1df6ca81769672f1",
+              "parentSpanId": "c2c426eaaff07582",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314494772000000",
-              "endTimeUnixNano": "1787314494776500000",
+              "startTimeUnixNano": "1787334338006100098",
+              "endTimeUnixNano": "1787334338053900146",
               "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.resource_fetch"
-                  }
-                },
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-WJHWQ8y1.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 437209
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
                   }
                 },
                 {
@@ -408,19 +450,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 437209
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 425923
+                    "intValue": 437509
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 437209
                   }
                 },
                 {
@@ -438,7 +480,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "E92EC8A02D5B01E15F031DF12F77230D"
+                    "stringValue": "1CACFC4D05BD21DA5FE579C0EC89645D"
                   }
                 },
                 {
@@ -453,49 +495,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314494771699951",
+                  "timeUnixNano": "1787334338005699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314494771699951",
+                  "timeUnixNano": "1787334338005699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314494771699951",
+                  "timeUnixNano": "1787334338005699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314494771699951",
+                  "timeUnixNano": "1787334338005699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314494771699951",
+                  "timeUnixNano": "1787334338005699952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314494774199951",
+                  "timeUnixNano": "1787334338048999952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314494775099951",
+                  "timeUnixNano": "1787334338050399952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314494776199951",
+                  "timeUnixNano": "1787334338053499952",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -508,12 +550,12 @@
               "flags": 257
             },
             {
-              "traceId": "b1adba0a647efaec137712ef1dd2bff1",
-              "spanId": "b9235d18a5ddb6ae",
+              "traceId": "30d99fd41fdb40519a348d5faac800d6",
+              "spanId": "c2c426eaaff07582",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787314494767199951",
-              "endTimeUnixNano": "1787314494836699951",
+              "startTimeUnixNano": "1787334337974900146",
+              "endTimeUnixNano": "1787334338145100098",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -548,7 +590,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "E92EC8A02D5B01E15F031DF12F77230D"
+                    "stringValue": "1CACFC4D05BD21DA5FE579C0EC89645D"
                   }
                 },
                 {
@@ -563,43 +605,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314494767000049",
+                  "timeUnixNano": "1787334337974400098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787314494773900049",
+                  "timeUnixNano": "1787334338013300098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787314494836200049",
+                  "timeUnixNano": "1787334338143700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787314494836200049",
+                  "timeUnixNano": "1787334338143700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787314494836200049",
+                  "timeUnixNano": "1787334338143700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787314494836200049",
+                  "timeUnixNano": "1787334338143700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787314494836500049",
+                  "timeUnixNano": "1787334338144600098",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -620,12 +662,12 @@
           },
           "spans": [
             {
-              "traceId": "83ee1a3f7b0b0dfa11412818008d857d",
-              "spanId": "ef9ab0f46317df05",
+              "traceId": "1c0ac1e25ab04b51a48d26d5dd4f7d3c",
+              "spanId": "f4d6ce2e96d6115d",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787314494834500000",
-              "endTimeUnixNano": "1787314494968899902",
+              "startTimeUnixNano": "1787334338140300049",
+              "endTimeUnixNano": "1787334338290100098",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -642,7 +684,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "E92EC8A02D5B01E15F031DF12F77230D"
+                    "stringValue": "1CACFC4D05BD21DA5FE579C0EC89645D"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "1664C995752D835F8F4BF6B816ED8E6F"
+              "stringValue": "12E04FF78D02008AAB549C6205629E58"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "5df219a550875f666d27921f984044ed",
-              "spanId": "0f9de4570c62e777",
+              "traceId": "1705c9485c286dbc20fa248c68e76e55",
+              "spanId": "1994b4a4008d52e3",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787334338134000000",
-              "endTimeUnixNano": "1787334338289300049",
+              "startTimeUnixNano": "1787935837661000000",
+              "endTimeUnixNano": "1787935837802700195",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B2E537469725DF9A32F07FDD667F5B8A"
+                    "stringValue": "6FAF6A14458ED77BE165B24E3E8D4866"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "doubleValue": 1787334338133.4001
+                    "doubleValue": 1787935837660.5
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "E7DBB94F8A23F1B384189916E7BA4885"
+                    "stringValue": "E33A63464032A6954AB42A2DA2106BAD"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 20
+                    "intValue": 14
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "1CACFC4D05BD21DA5FE579C0EC89645D"
+                    "stringValue": "37D458931CE3A43AE4F9CA894D5C8490"
                   }
                 },
                 {
@@ -250,13 +250,13 @@
           },
           "spans": [
             {
-              "traceId": "30d99fd41fdb40519a348d5faac800d6",
-              "spanId": "c93cd0222ba7b0f8",
-              "parentSpanId": "c2c426eaaff07582",
+              "traceId": "43833eff5670318a78ba964acc6e5592",
+              "spanId": "14b69a700a059e85",
+              "parentSpanId": "b206f4fc8dd71b45",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787334337974900146",
-              "endTimeUnixNano": "1787334337995800049",
+              "startTimeUnixNano": "1787935837587200195",
+              "endTimeUnixNano": "1787935837599600098",
               "attributes": [
                 {
                   "key": "url.full",
@@ -313,6 +313,12 @@
                   }
                 },
                 {
+                  "key": "browser.navigation_timing.type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -327,7 +333,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "1CACFC4D05BD21DA5FE579C0EC89645D"
+                    "stringValue": "37D458931CE3A43AE4F9CA894D5C8490"
                   }
                 },
                 {
@@ -342,55 +348,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334337974400098",
+                  "timeUnixNano": "1787935837586700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334337984700098",
+                  "timeUnixNano": "1787935837593600098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334337985400098",
+                  "timeUnixNano": "1787935837594000098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334337985400098",
+                  "timeUnixNano": "1787935837594000098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787334337974100098",
+                  "timeUnixNano": "1787935837586600098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334337987000098",
+                  "timeUnixNano": "1787935837594700098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334337988600098",
+                  "timeUnixNano": "1787935837595100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787334337992900098",
+                  "timeUnixNano": "1787935837597500098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334337995300098",
+                  "timeUnixNano": "1787935837599100098",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -403,24 +409,24 @@
               "flags": 257
             },
             {
-              "traceId": "30d99fd41fdb40519a348d5faac800d6",
-              "spanId": "1df6ca81769672f1",
-              "parentSpanId": "c2c426eaaff07582",
+              "traceId": "43833eff5670318a78ba964acc6e5592",
+              "spanId": "ed9ce534db9ac1c8",
+              "parentSpanId": "b206f4fc8dd71b45",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787334338006100098",
-              "endTimeUnixNano": "1787334338053900146",
+              "startTimeUnixNano": "1787935837605700195",
+              "endTimeUnixNano": "1787935837610500000",
               "attributes": [
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-WJHWQ8y1.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-CGC8ESZ5.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 437209
+                    "intValue": 437485
                   }
                 },
                 {
@@ -450,19 +456,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 437209
+                    "intValue": 437485
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 437509
+                    "intValue": 437785
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 437209
+                    "intValue": 437485
                   }
                 },
                 {
@@ -480,7 +486,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "1CACFC4D05BD21DA5FE579C0EC89645D"
+                    "stringValue": "37D458931CE3A43AE4F9CA894D5C8490"
                   }
                 },
                 {
@@ -495,49 +501,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334338005699952",
+                  "timeUnixNano": "1787935837605200098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334338005699952",
+                  "timeUnixNano": "1787935837605200098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334338005699952",
+                  "timeUnixNano": "1787935837605200098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334338005699952",
+                  "timeUnixNano": "1787935837605200098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334338005699952",
+                  "timeUnixNano": "1787935837605200098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334338048999952",
+                  "timeUnixNano": "1787935837608300098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787334338050399952",
+                  "timeUnixNano": "1787935837609100098",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334338053499952",
+                  "timeUnixNano": "1787935837610000098",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -550,12 +556,12 @@
               "flags": 257
             },
             {
-              "traceId": "30d99fd41fdb40519a348d5faac800d6",
-              "spanId": "c2c426eaaff07582",
+              "traceId": "43833eff5670318a78ba964acc6e5592",
+              "spanId": "b206f4fc8dd71b45",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787334337974900146",
-              "endTimeUnixNano": "1787334338145100098",
+              "startTimeUnixNano": "1787935837587200195",
+              "endTimeUnixNano": "1787935837668200195",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -590,7 +596,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "1CACFC4D05BD21DA5FE579C0EC89645D"
+                    "stringValue": "37D458931CE3A43AE4F9CA894D5C8490"
                   }
                 },
                 {
@@ -605,43 +611,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334337974400098",
+                  "timeUnixNano": "1787935837586799952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787334338013300098",
+                  "timeUnixNano": "1787935837609499952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787334338143700098",
+                  "timeUnixNano": "1787935837667399952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787334338143700098",
+                  "timeUnixNano": "1787935837667399952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787334338143700098",
+                  "timeUnixNano": "1787935837667399952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787334338143700098",
+                  "timeUnixNano": "1787935837667399952",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787334338144600098",
+                  "timeUnixNano": "1787935837667799952",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -662,12 +668,12 @@
           },
           "spans": [
             {
-              "traceId": "1c0ac1e25ab04b51a48d26d5dd4f7d3c",
-              "spanId": "f4d6ce2e96d6115d",
+              "traceId": "e5b24c46c8639789a7e35a66007f0267",
+              "spanId": "5b98b658def1262e",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787334338140300049",
-              "endTimeUnixNano": "1787334338290100098",
+              "startTimeUnixNano": "1787935837665500000",
+              "endTimeUnixNano": "1787935837803500000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -684,7 +690,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "1CACFC4D05BD21DA5FE579C0EC89645D"
+                    "stringValue": "37D458931CE3A43AE4F9CA894D5C8490"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "3BC4FB0E60C4DA3ED0388332B3FC36A7"
+              "stringValue": "1D5E03F8947D28974BF12ED8F6D52FDB"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "2a021f01fdcf0bf6b4b663f073efedc7",
-              "spanId": "183e2083d64c437f",
+              "traceId": "a0be262b69bf76efa787015f80433ba5",
+              "spanId": "a3ce7701cbf94d78",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787770818072000000",
-              "endTimeUnixNano": "1787770819043000000",
+              "startTimeUnixNano": "1787935838733000000",
+              "endTimeUnixNano": "1787935839647000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "3825F48343B38B4E817EAFBA74A913E7"
+                    "stringValue": "489BEB314B0C9830944EBDD7B1B870B7"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1787770818071
+                    "intValue": 1787935838733
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "B296EC87BAA7E79DECA907AB84F0C48B"
+                    "stringValue": "94069989D07E8A15B73A27D588D43717"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 8
+                    "intValue": 4
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
+                    "stringValue": "11BA1810BEB654419377FFE0A05E77F1"
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787770818240000000",
+                  "timeUnixNano": "1787935838873000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787770818683000000",
+                  "timeUnixNano": "1787935839308000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "1deeccb02e2d11c22f8934f0eb12047c",
-              "spanId": "818f720911d1e36a",
-              "parentSpanId": "19f41c49ddee19c6",
+              "traceId": "9529fb714ad5d8e6cf66637187ac10bd",
+              "spanId": "a6b36c1bd1b34936",
+              "parentSpanId": "c1f2a6204c442047",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787770818003000000",
-              "endTimeUnixNano": "1787770818010000000",
+              "startTimeUnixNano": "1787935838701000000",
+              "endTimeUnixNano": "1787935838703000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -319,6 +319,48 @@
                   "key": "http.response_content_length",
                   "value": {
                     "intValue": 252
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
+                  }
+                },
+                {
+                  "key": "http.request.initiator_type",
+                  "value": {
+                    "stringValue": "navigation"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": 200
+                  }
+                },
+                {
+                  "key": "http.response.body.size",
+                  "value": {
+                    "intValue": 252
+                  }
+                },
+                {
+                  "key": "http.response.size",
+                  "value": {
+                    "intValue": 552
+                  }
+                },
+                {
+                  "key": "http.response.decoded_body_size",
+                  "value": {
+                    "intValue": 252
+                  }
+                },
+                {
+                  "key": "browser.navigation_timing.type",
+                  "value": {
+                    "stringValue": "navigate"
                   }
                 },
                 {
@@ -336,7 +378,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
+                    "stringValue": "11BA1810BEB654419377FFE0A05E77F1"
                   }
                 },
                 {
@@ -351,55 +393,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787770818003000000",
+                  "timeUnixNano": "1787935838701000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787770818009000000",
+                  "timeUnixNano": "1787935838702000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787770818009000000",
+                  "timeUnixNano": "1787935838702000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787770818009000000",
+                  "timeUnixNano": "1787935838702000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787770818003000000",
+                  "timeUnixNano": "1787935838701000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787770818009000000",
+                  "timeUnixNano": "1787935838703000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787770818009000000",
+                  "timeUnixNano": "1787935838703000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787770818010000000",
+                  "timeUnixNano": "1787935838703000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787770818010000000",
+                  "timeUnixNano": "1787935838703000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -412,30 +454,30 @@
               "flags": 257
             },
             {
-              "traceId": "1deeccb02e2d11c22f8934f0eb12047c",
-              "spanId": "2fc10c1d01007e34",
-              "parentSpanId": "19f41c49ddee19c6",
+              "traceId": "9529fb714ad5d8e6cf66637187ac10bd",
+              "spanId": "fc8479a11dd274bf",
+              "parentSpanId": "c1f2a6204c442047",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787770818013000000",
-              "endTimeUnixNano": "1787770818028000000",
+              "startTimeUnixNano": "1787935838705000000",
+              "endTimeUnixNano": "1787935838712000000",
               "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.resource_fetch"
-                  }
-                },
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DwCiF-Sl.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-CGC8ESZ5.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 425996
+                    "intValue": 437485
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
                   }
                 },
                 {
@@ -453,19 +495,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 425996
+                    "intValue": 437485
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 426296
+                    "intValue": 437785
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 425996
+                    "intValue": 437485
                   }
                 },
                 {
@@ -483,7 +525,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
+                    "stringValue": "11BA1810BEB654419377FFE0A05E77F1"
                   }
                 },
                 {
@@ -498,49 +540,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787770818014000000",
+                  "timeUnixNano": "1787935838705000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787770818014000000",
+                  "timeUnixNano": "1787935838705000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787770818014000000",
+                  "timeUnixNano": "1787935838705000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787770818014000000",
+                  "timeUnixNano": "1787935838705000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787770818014000000",
+                  "timeUnixNano": "1787935838705000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787770818029000000",
+                  "timeUnixNano": "1787935838712000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787770818029000000",
+                  "timeUnixNano": "1787935838712000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787770818029000000",
+                  "timeUnixNano": "1787935838712000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -553,20 +595,14 @@
               "flags": 257
             },
             {
-              "traceId": "1deeccb02e2d11c22f8934f0eb12047c",
-              "spanId": "1235769cf966cc56",
-              "parentSpanId": "19f41c49ddee19c6",
+              "traceId": "9529fb714ad5d8e6cf66637187ac10bd",
+              "spanId": "c1ef9f6bd188e7a7",
+              "parentSpanId": "c1f2a6204c442047",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787770818018000000",
-              "endTimeUnixNano": "1787770818018000000",
+              "startTimeUnixNano": "1787935838707000000",
+              "endTimeUnixNano": "1787935838707000000",
               "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.resource_fetch"
-                  }
-                },
                 {
                   "key": "url.full",
                   "value": {
@@ -577,6 +613,12 @@
                   "key": "http.response_content_length",
                   "value": {
                     "intValue": 0
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
                   }
                 },
                 {
@@ -624,7 +666,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
+                    "stringValue": "11BA1810BEB654419377FFE0A05E77F1"
                   }
                 },
                 {
@@ -639,49 +681,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787770818019000000",
+                  "timeUnixNano": "1787935838707000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787770818019000000",
+                  "timeUnixNano": "1787935838707000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787770818019000000",
+                  "timeUnixNano": "1787935838707000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787770818019000000",
+                  "timeUnixNano": "1787935838707000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787770818019000000",
+                  "timeUnixNano": "1787935838707000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787770818019000000",
+                  "timeUnixNano": "1787935838707000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787770818019000000",
+                  "timeUnixNano": "1787935838707000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787770818019000000",
+                  "timeUnixNano": "1787935838707000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -694,30 +736,30 @@
               "flags": 257
             },
             {
-              "traceId": "1deeccb02e2d11c22f8934f0eb12047c",
-              "spanId": "6f12c1011f62102a",
-              "parentSpanId": "19f41c49ddee19c6",
+              "traceId": "9529fb714ad5d8e6cf66637187ac10bd",
+              "spanId": "27b11d45e2452053",
+              "parentSpanId": "c1f2a6204c442047",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787770818069000000",
-              "endTimeUnixNano": "1787770818074000000",
+              "startTimeUnixNano": "1787935838732000000",
+              "endTimeUnixNano": "1787935838733000000",
               "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.resource_fetch"
-                  }
-                },
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/v2/config?appId=11111&osVersion=1&appVersion=1.0.0&deviceId=A65FF047234B941D7ED835074529CDFF"
+                    "stringValue": "http://localhost:3001/v2/config?appId=11111&osVersion=1&appVersion=1.0.0&deviceId=E60EB82D73E40AF65576B4B74D8CFC3F"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
                     "intValue": 146
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
                   }
                 },
                 {
@@ -765,7 +807,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
+                    "stringValue": "11BA1810BEB654419377FFE0A05E77F1"
                   }
                 },
                 {
@@ -780,49 +822,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787770818068000000",
+                  "timeUnixNano": "1787935838733000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787770818068000000",
+                  "timeUnixNano": "1787935838733000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787770818068000000",
+                  "timeUnixNano": "1787935838733000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787770818068000000",
+                  "timeUnixNano": "1787935838733000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787770818068000000",
+                  "timeUnixNano": "1787935838733000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787770818073000000",
+                  "timeUnixNano": "1787935838734000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787770818073000000",
+                  "timeUnixNano": "1787935838734000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787770818073000000",
+                  "timeUnixNano": "1787935838734000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -835,12 +877,12 @@
               "flags": 257
             },
             {
-              "traceId": "1deeccb02e2d11c22f8934f0eb12047c",
-              "spanId": "19f41c49ddee19c6",
+              "traceId": "9529fb714ad5d8e6cf66637187ac10bd",
+              "spanId": "c1f2a6204c442047",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787770818003000000",
-              "endTimeUnixNano": "1787770818084000000",
+              "startTimeUnixNano": "1787935838701000000",
+              "endTimeUnixNano": "1787935838739000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -875,7 +917,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
+                    "stringValue": "11BA1810BEB654419377FFE0A05E77F1"
                   }
                 },
                 {
@@ -890,43 +932,37 @@
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787770818015000000",
+                  "timeUnixNano": "1787935838706000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787770818078000000",
+                  "timeUnixNano": "1787935838736000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787770818078000000",
+                  "timeUnixNano": "1787935838736000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787770818083000000",
+                  "timeUnixNano": "1787935838739000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787770818084000000",
+                  "timeUnixNano": "1787935838739000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787770818084000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "firstContentfulPaint",
-                  "timeUnixNano": "1787770818084000000",
+                  "timeUnixNano": "1787935838739000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -947,12 +983,12 @@
           },
           "spans": [
             {
-              "traceId": "11c593d79335c3dc57c555a21da997b1",
-              "spanId": "607e585fa8d42b1d",
+              "traceId": "3981751c791867e5dcacb19d5899dfd8",
+              "spanId": "deadd6ff0bc34bea",
               "name": "GET",
               "kind": 3,
-              "startTimeUnixNano": "1787770818242000000",
-              "endTimeUnixNano": "1787770818248000000",
+              "startTimeUnixNano": "1787935838874000000",
+              "endTimeUnixNano": "1787935838881000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -1005,7 +1041,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
+                    "stringValue": "11BA1810BEB654419377FFE0A05E77F1"
                   }
                 },
                 {
@@ -1020,49 +1056,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787770818243000000",
+                  "timeUnixNano": "1787935838874000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787770818243000000",
+                  "timeUnixNano": "1787935838874000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787770818243000000",
+                  "timeUnixNano": "1787935838874000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787770818243000000",
+                  "timeUnixNano": "1787935838874000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787770818243000000",
+                  "timeUnixNano": "1787935838874000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787770818243000000",
+                  "timeUnixNano": "1787935838874000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787770818243000000",
+                  "timeUnixNano": "1787935838874000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787770818243000000",
+                  "timeUnixNano": "1787935838874000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -1075,12 +1111,12 @@
               "flags": 257
             },
             {
-              "traceId": "a3439785dfbf024f9798d2979aaa7c14",
-              "spanId": "d266fe5795d6530d",
+              "traceId": "7d9ad54cf6e89afe3fdf653f9669c5f5",
+              "spanId": "84ba48b88b3e149e",
               "name": "POST",
               "kind": 3,
-              "startTimeUnixNano": "1787770818686000000",
-              "endTimeUnixNano": "1787770818693000000",
+              "startTimeUnixNano": "1787935839313000000",
+              "endTimeUnixNano": "1787935839320000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -1133,7 +1169,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
+                    "stringValue": "11BA1810BEB654419377FFE0A05E77F1"
                   }
                 },
                 {
@@ -1148,49 +1184,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787770818686000000",
+                  "timeUnixNano": "1787935839313000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787770818686000000",
+                  "timeUnixNano": "1787935839313000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787770818686000000",
+                  "timeUnixNano": "1787935839313000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787770818686000000",
+                  "timeUnixNano": "1787935839313000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787770818686000000",
+                  "timeUnixNano": "1787935839313000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787770818686000000",
+                  "timeUnixNano": "1787935839313000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787770818686000000",
+                  "timeUnixNano": "1787935839313000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787770818686000000",
+                  "timeUnixNano": "1787935839313000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -1211,12 +1247,12 @@
           },
           "spans": [
             {
-              "traceId": "1180c8422bf3f7be87035d98eef8e6dd",
-              "spanId": "feb37609a3ab2453",
+              "traceId": "16add93f1b056a2ecbce6077aa9dd839",
+              "spanId": "d1f3f0357c54e5f4",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787770818076000000",
-              "endTimeUnixNano": "1787770819044000000",
+              "startTimeUnixNano": "1787935838734000000",
+              "endTimeUnixNano": "1787935839648000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -1233,7 +1269,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
+                    "stringValue": "11BA1810BEB654419377FFE0A05E77F1"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "DB1B0E983AA30044256FF38D5E3A1638"
+              "stringValue": "BA285DCC89A877217E2D71A220B3F4B8"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "22db72487534b413122639c65c0f8822",
-              "spanId": "7aa22b4b663766e0",
+              "traceId": "fa5fca94d7904bf88ca43c58e5978b0f",
+              "spanId": "8baeefa03a3cf95c",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787770812250000000",
-              "endTimeUnixNano": "1787770812446000000",
+              "startTimeUnixNano": "1787935838310000000",
+              "endTimeUnixNano": "1787935838463000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "45837B85B568650748FA2554B71D531E"
+                    "stringValue": "E256A7677408841EFD3C1025BE970FA3"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1787770812249
+                    "intValue": 1787935838310
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "9EC21846399C8E49D93F7FE1D5802648"
+                    "stringValue": "99D0BB6FCD3780C5A8EAA50A95F6B173"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 7
+                    "intValue": 4
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
+                    "stringValue": "10DD1E66F970E019BEBD51E3CFE6085A"
                   }
                 },
                 {
@@ -250,13 +250,13 @@
           },
           "spans": [
             {
-              "traceId": "8e18442546fb55e526454305a3b0689e",
-              "spanId": "c9702dfb77320606",
-              "parentSpanId": "2225185d65920bd2",
+              "traceId": "5f7c7c4cebf24e1f5fb1dea5af2165ef",
+              "spanId": "38d7473b47c1a81a",
+              "parentSpanId": "d415cd3326800a1e",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787770812188000000",
-              "endTimeUnixNano": "1787770812193000000",
+              "startTimeUnixNano": "1787935838191000000",
+              "endTimeUnixNano": "1787935838227000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -268,6 +268,48 @@
                   "key": "http.response_content_length",
                   "value": {
                     "intValue": 252
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
+                  }
+                },
+                {
+                  "key": "http.request.initiator_type",
+                  "value": {
+                    "stringValue": "navigation"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": 200
+                  }
+                },
+                {
+                  "key": "http.response.body.size",
+                  "value": {
+                    "intValue": 252
+                  }
+                },
+                {
+                  "key": "http.response.size",
+                  "value": {
+                    "intValue": 552
+                  }
+                },
+                {
+                  "key": "http.response.decoded_body_size",
+                  "value": {
+                    "intValue": 252
+                  }
+                },
+                {
+                  "key": "browser.navigation_timing.type",
+                  "value": {
+                    "stringValue": "navigate"
                   }
                 },
                 {
@@ -285,7 +327,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
+                    "stringValue": "10DD1E66F970E019BEBD51E3CFE6085A"
                   }
                 },
                 {
@@ -300,55 +342,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787770812188000000",
+                  "timeUnixNano": "1787935838191000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787770812192000000",
+                  "timeUnixNano": "1787935838226000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787770812192000000",
+                  "timeUnixNano": "1787935838226000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787770812192000000",
+                  "timeUnixNano": "1787935838226000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787770812189000000",
+                  "timeUnixNano": "1787935838192000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787770812192000000",
+                  "timeUnixNano": "1787935838226000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787770812192000000",
+                  "timeUnixNano": "1787935838226000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787770812193000000",
+                  "timeUnixNano": "1787935838227000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787770812193000000",
+                  "timeUnixNano": "1787935838227000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -361,30 +403,30 @@
               "flags": 257
             },
             {
-              "traceId": "8e18442546fb55e526454305a3b0689e",
-              "spanId": "b4924a35857e007e",
-              "parentSpanId": "2225185d65920bd2",
+              "traceId": "5f7c7c4cebf24e1f5fb1dea5af2165ef",
+              "spanId": "4a16314fe58b7411",
+              "parentSpanId": "d415cd3326800a1e",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787770812196000000",
-              "endTimeUnixNano": "1787770812211000000",
+              "startTimeUnixNano": "1787935838266000000",
+              "endTimeUnixNano": "1787935838289000000",
               "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.resource_fetch"
-                  }
-                },
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DwCiF-Sl.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-CGC8ESZ5.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 425996
+                    "intValue": 437485
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
                   }
                 },
                 {
@@ -402,19 +444,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 425996
+                    "intValue": 437485
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 426296
+                    "intValue": 437785
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 425996
+                    "intValue": 437485
                   }
                 },
                 {
@@ -432,7 +474,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
+                    "stringValue": "10DD1E66F970E019BEBD51E3CFE6085A"
                   }
                 },
                 {
@@ -447,49 +489,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787770812197000000",
+                  "timeUnixNano": "1787935838266000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787770812197000000",
+                  "timeUnixNano": "1787935838266000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787770812197000000",
+                  "timeUnixNano": "1787935838266000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787770812197000000",
+                  "timeUnixNano": "1787935838266000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787770812197000000",
+                  "timeUnixNano": "1787935838266000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787770812211000000",
+                  "timeUnixNano": "1787935838288000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787770812212000000",
+                  "timeUnixNano": "1787935838289000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787770812212000000",
+                  "timeUnixNano": "1787935838289000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -502,294 +544,12 @@
               "flags": 257
             },
             {
-              "traceId": "8e18442546fb55e526454305a3b0689e",
-              "spanId": "3cb04a42bf3bbd10",
-              "parentSpanId": "2225185d65920bd2",
-              "name": "resourceFetch",
-              "kind": 1,
-              "startTimeUnixNano": "1787770812202000000",
-              "endTimeUnixNano": "1787770812202000000",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.resource_fetch"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/favicon.ico"
-                  }
-                },
-                {
-                  "key": "http.response_content_length",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "http.request.initiator_type",
-                  "value": {
-                    "stringValue": "other"
-                  }
-                },
-                {
-                  "key": "http.response.body.size",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "http.response.size",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "http.response.decoded_body_size",
-                  "value": {
-                    "intValue": 0
-                  }
-                },
-                {
-                  "key": "http.response.cors_opaque",
-                  "value": {
-                    "boolValue": true
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1787770812202000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupStart",
-                  "timeUnixNano": "1787770812202000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupEnd",
-                  "timeUnixNano": "1787770812202000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectStart",
-                  "timeUnixNano": "1787770812202000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectEnd",
-                  "timeUnixNano": "1787770812202000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "requestStart",
-                  "timeUnixNano": "1787770812202000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseStart",
-                  "timeUnixNano": "1787770812202000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseEnd",
-                  "timeUnixNano": "1787770812202000000",
-                  "droppedAttributesCount": 0
-                }
-              ],
-              "droppedEventsCount": 0,
-              "status": {
-                "code": 0
-              },
-              "links": [],
-              "droppedLinksCount": 0,
-              "flags": 257
-            },
-            {
-              "traceId": "8e18442546fb55e526454305a3b0689e",
-              "spanId": "60b46962a29491a3",
-              "parentSpanId": "2225185d65920bd2",
-              "name": "resourceFetch",
-              "kind": 1,
-              "startTimeUnixNano": "1787770812247000000",
-              "endTimeUnixNano": "1787770812249000000",
-              "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.resource_fetch"
-                  }
-                },
-                {
-                  "key": "url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/v2/config?appId=11111&osVersion=1&appVersion=1.0.0&deviceId=80AD9EEE0F64EBD3D141C22EBA6FD933"
-                  }
-                },
-                {
-                  "key": "http.response_content_length",
-                  "value": {
-                    "intValue": 146
-                  }
-                },
-                {
-                  "key": "http.request.initiator_type",
-                  "value": {
-                    "stringValue": "fetch"
-                  }
-                },
-                {
-                  "key": "http.response.status_code",
-                  "value": {
-                    "intValue": 200
-                  }
-                },
-                {
-                  "key": "http.response.body.size",
-                  "value": {
-                    "intValue": 146
-                  }
-                },
-                {
-                  "key": "http.response.size",
-                  "value": {
-                    "intValue": 446
-                  }
-                },
-                {
-                  "key": "http.response.decoded_body_size",
-                  "value": {
-                    "intValue": 146
-                  }
-                },
-                {
-                  "key": "browser.url.full",
-                  "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.name",
-                  "value": {
-                    "stringValue": "/platforms/vite-7/es2015/index.html"
-                  }
-                },
-                {
-                  "key": "app.surface.id",
-                  "value": {
-                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
-                  }
-                },
-                {
-                  "key": "app.surface.label",
-                  "value": {
-                    "stringValue": "React + TS + Vite"
-                  }
-                }
-              ],
-              "droppedAttributesCount": 0,
-              "events": [
-                {
-                  "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1787770812248000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupStart",
-                  "timeUnixNano": "1787770812248000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "domainLookupEnd",
-                  "timeUnixNano": "1787770812248000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectStart",
-                  "timeUnixNano": "1787770812248000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "connectEnd",
-                  "timeUnixNano": "1787770812248000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "requestStart",
-                  "timeUnixNano": "1787770812250000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseStart",
-                  "timeUnixNano": "1787770812250000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "responseEnd",
-                  "timeUnixNano": "1787770812250000000",
-                  "droppedAttributesCount": 0
-                }
-              ],
-              "droppedEventsCount": 0,
-              "status": {
-                "code": 0
-              },
-              "links": [],
-              "droppedLinksCount": 0,
-              "flags": 257
-            },
-            {
-              "traceId": "8e18442546fb55e526454305a3b0689e",
-              "spanId": "2225185d65920bd2",
+              "traceId": "5f7c7c4cebf24e1f5fb1dea5af2165ef",
+              "spanId": "d415cd3326800a1e",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787770812188000000",
-              "endTimeUnixNano": "1787770812260000000",
+              "startTimeUnixNano": "1787935838191000000",
+              "endTimeUnixNano": "1787935838317000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -824,7 +584,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
+                    "stringValue": "10DD1E66F970E019BEBD51E3CFE6085A"
                   }
                 },
                 {
@@ -839,49 +599,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787770812189000000",
+                  "timeUnixNano": "1787935838191000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787770812199000000",
+                  "timeUnixNano": "1787935838267000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787770812256000000",
+                  "timeUnixNano": "1787935838314000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787770812256000000",
+                  "timeUnixNano": "1787935838314000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787770812261000000",
+                  "timeUnixNano": "1787935838317000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787770812261000000",
+                  "timeUnixNano": "1787935838317000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787770812261000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
-                  "name": "firstContentfulPaint",
-                  "timeUnixNano": "1787770812260000000",
+                  "timeUnixNano": "1787935838317000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -902,12 +656,12 @@
           },
           "spans": [
             {
-              "traceId": "736ea99c2baf120c73d29f0b5d498b10",
-              "spanId": "952d2b2c46e0991b",
+              "traceId": "76f9c2f8eb9fca2f255719ad267d8140",
+              "spanId": "3f7dcdc7f69fa395",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787770812252000000",
-              "endTimeUnixNano": "1787770812447000000",
+              "startTimeUnixNano": "1787935838311000000",
+              "endTimeUnixNano": "1787935838463000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -924,7 +678,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
+                    "stringValue": "10DD1E66F970E019BEBD51E3CFE6085A"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "EEB1983D06C38B13955FA57391D6AEBD"
+              "stringValue": "32C1E6674C9151FBCD11F15D81A51601"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "6dbf272d3134055dc2e244bcfd684841",
-              "spanId": "edfe55649f43b7f0",
+              "traceId": "149b3b89aa691dfbcec303da5803b13b",
+              "spanId": "17451f714132f570",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787334339965000000",
-              "endTimeUnixNano": "1787334341101000000",
+              "startTimeUnixNano": "1787935838402000000",
+              "endTimeUnixNano": "1787935839189000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "47C5134CECCBAE06A44BBFA077C9910E"
+                    "stringValue": "919E0AC845D987A6C5527853A45156C4"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1787334339963
+                    "intValue": 1787935838401
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "5E9028BE4AAFCDE87CA94911C44E2D89"
+                    "stringValue": "70F0FB7A2F5F16EF20E49EAA2DA90E45"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 45
+                    "intValue": 7
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
+                    "stringValue": "96F9EB40E4A256643F08B3C56750220F"
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787334340159000000",
+                  "timeUnixNano": "1787935838534000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787334340690000000",
+                  "timeUnixNano": "1787935838855000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "3e2b7585d03805a4ce9f0360ef066062",
-              "spanId": "d57f74e12a73e322",
-              "parentSpanId": "6729a9d4f7f87520",
+              "traceId": "429c49d86c40eabe9578e2885f73c68a",
+              "spanId": "21ffd8810e56c3c7",
+              "parentSpanId": "c0940c61506177f4",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787334339878000000",
-              "endTimeUnixNano": "1787334339881000000",
+              "startTimeUnixNano": "1787935838381000000",
+              "endTimeUnixNano": "1787935838381000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -358,6 +358,12 @@
                   }
                 },
                 {
+                  "key": "browser.navigation_timing.type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -372,7 +378,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
+                    "stringValue": "96F9EB40E4A256643F08B3C56750220F"
                   }
                 },
                 {
@@ -387,55 +393,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334339879000000",
+                  "timeUnixNano": "1787935838382000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334339879000000",
+                  "timeUnixNano": "1787935838382000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334339879000000",
+                  "timeUnixNano": "1787935838382000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334339879000000",
+                  "timeUnixNano": "1787935838382000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787334339860000000",
+                  "timeUnixNano": "1787935838381000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334339879000000",
+                  "timeUnixNano": "1787935838382000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334339880000000",
+                  "timeUnixNano": "1787935838382000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787334339882000000",
+                  "timeUnixNano": "1787935838382000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334339882000000",
+                  "timeUnixNano": "1787935838382000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -448,30 +454,30 @@
               "flags": 257
             },
             {
-              "traceId": "3e2b7585d03805a4ce9f0360ef066062",
-              "spanId": "5064d869e99fe75f",
-              "parentSpanId": "6729a9d4f7f87520",
+              "traceId": "429c49d86c40eabe9578e2885f73c68a",
+              "spanId": "ffb1a42423e2319e",
+              "parentSpanId": "c0940c61506177f4",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787334339897000000",
-              "endTimeUnixNano": "1787334339901000000",
+              "startTimeUnixNano": "1787935838384000000",
+              "endTimeUnixNano": "1787935838385000000",
               "attributes": [
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-WJHWQ8y1.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-CGC8ESZ5.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 437221
+                    "intValue": 437497
                   }
                 },
                 {
                   "key": "http.response_content_length_uncompressed",
                   "value": {
-                    "intValue": 437209
+                    "intValue": 437485
                   }
                 },
                 {
@@ -489,19 +495,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 437221
+                    "intValue": 437497
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 437521
+                    "intValue": 437797
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 437209
+                    "intValue": 437485
                   }
                 },
                 {
@@ -519,7 +525,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
+                    "stringValue": "96F9EB40E4A256643F08B3C56750220F"
                   }
                 },
                 {
@@ -534,49 +540,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334339897000000",
+                  "timeUnixNano": "1787935838384000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334339897000000",
+                  "timeUnixNano": "1787935838384000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334339897000000",
+                  "timeUnixNano": "1787935838384000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334339897000000",
+                  "timeUnixNano": "1787935838384000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334339897000000",
+                  "timeUnixNano": "1787935838384000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334339898000000",
+                  "timeUnixNano": "1787935838384000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787334339900000000",
+                  "timeUnixNano": "1787935838385000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334339901000000",
+                  "timeUnixNano": "1787935838385000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -589,12 +595,12 @@
               "flags": 257
             },
             {
-              "traceId": "3e2b7585d03805a4ce9f0360ef066062",
-              "spanId": "6729a9d4f7f87520",
+              "traceId": "429c49d86c40eabe9578e2885f73c68a",
+              "spanId": "c0940c61506177f4",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787334339878000000",
-              "endTimeUnixNano": "1787334339973000000",
+              "startTimeUnixNano": "1787935838381000000",
+              "endTimeUnixNano": "1787935838405000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -629,7 +635,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
+                    "stringValue": "96F9EB40E4A256643F08B3C56750220F"
                   }
                 },
                 {
@@ -644,43 +650,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334339879000000",
+                  "timeUnixNano": "1787935838382000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787334339895000000",
+                  "timeUnixNano": "1787935838384000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787334339973000000",
+                  "timeUnixNano": "1787935838406000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787334339973000000",
+                  "timeUnixNano": "1787935838406000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787334339973000000",
+                  "timeUnixNano": "1787935838406000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787334339973000000",
+                  "timeUnixNano": "1787935838406000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787334339974000000",
+                  "timeUnixNano": "1787935838406000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -701,12 +707,12 @@
           },
           "spans": [
             {
-              "traceId": "ba1a57132b9f601b648ba8d1e008705e",
-              "spanId": "a010d415e8abacd7",
+              "traceId": "fd1e00a0a97c012a1c0a5b46f6c8db69",
+              "spanId": "70e36aac9d791ee4",
               "name": "GET",
               "kind": 3,
-              "startTimeUnixNano": "1787334340162000000",
-              "endTimeUnixNano": "1787334340182000000",
+              "startTimeUnixNano": "1787935838536000000",
+              "endTimeUnixNano": "1787935838538000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -759,7 +765,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
+                    "stringValue": "96F9EB40E4A256643F08B3C56750220F"
                   }
                 },
                 {
@@ -774,43 +780,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334340163000000",
+                  "timeUnixNano": "1787935838536000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334340163000000",
+                  "timeUnixNano": "1787935838536000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334340163000000",
+                  "timeUnixNano": "1787935838536000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334340163000000",
+                  "timeUnixNano": "1787935838536000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334340163000000",
+                  "timeUnixNano": "1787935838536000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334340163000000",
+                  "timeUnixNano": "1787935838536000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334340174000000",
+                  "timeUnixNano": "1787935838537000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -823,12 +829,12 @@
               "flags": 257
             },
             {
-              "traceId": "0bac896ecb61d13ba25e5548f576107f",
-              "spanId": "91e99cb65a382a03",
+              "traceId": "59e984d7cf65647cb35adaf78435609a",
+              "spanId": "d0c141895d50f3e2",
               "name": "POST",
               "kind": 3,
-              "startTimeUnixNano": "1787334340697000000",
-              "endTimeUnixNano": "1787334340717000000",
+              "startTimeUnixNano": "1787935838864000000",
+              "endTimeUnixNano": "1787935838869000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -881,7 +887,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
+                    "stringValue": "96F9EB40E4A256643F08B3C56750220F"
                   }
                 },
                 {
@@ -896,49 +902,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334340702000000",
+                  "timeUnixNano": "1787935838866000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334340706000000",
+                  "timeUnixNano": "1787935838866000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334340709000000",
+                  "timeUnixNano": "1787935838866000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334340713000000",
+                  "timeUnixNano": "1787935838866000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334340714000000",
+                  "timeUnixNano": "1787935838866000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334340712000000",
+                  "timeUnixNano": "1787935838867000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787334340715000000",
+                  "timeUnixNano": "1787935838867000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334340715000000",
+                  "timeUnixNano": "1787935838867000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -959,12 +965,12 @@
           },
           "spans": [
             {
-              "traceId": "cf210957ceb27614ab64e8582584b074",
-              "spanId": "0e467365a2a55bcd",
+              "traceId": "fc6129cd76532bb9da8fd3a9dacad782",
+              "spanId": "89735d266db491c2",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787334339970000000",
-              "endTimeUnixNano": "1787334341102000000",
+              "startTimeUnixNano": "1787935838404000000",
+              "endTimeUnixNano": "1787935839189000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -981,7 +987,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
+                    "stringValue": "96F9EB40E4A256643F08B3C56750220F"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "915072AADA587996885CA7A0E05EC2DB"
+              "stringValue": "EEB1983D06C38B13955FA57391D6AEBD"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "285bfb77ab9de5f91883242ab2fba00a",
-              "spanId": "ddb46597a343c031",
+              "traceId": "6dbf272d3134055dc2e244bcfd684841",
+              "spanId": "edfe55649f43b7f0",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787314532491000000",
-              "endTimeUnixNano": "1787314533291000000",
+              "startTimeUnixNano": "1787334339965000000",
+              "endTimeUnixNano": "1787334341101000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "060A72B26BCA21677810B6A1AA348CA9"
+                    "stringValue": "47C5134CECCBAE06A44BBFA077C9910E"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1787314532489
+                    "intValue": 1787334339963
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "27D0343FB1D3E2FF7609F1FCA952C941"
+                    "stringValue": "5E9028BE4AAFCDE87CA94911C44E2D89"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 10
+                    "intValue": 45
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "28ADCF70A5D4F3BD289D4FC202D3D431"
+                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787314532632000000",
+                  "timeUnixNano": "1787334340159000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787314532956000000",
+                  "timeUnixNano": "1787334340690000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "7257a1b6b5ddfffedd6cfa2366cd740f",
-              "spanId": "41529a0ba35ac131",
-              "parentSpanId": "7ac0ce21b35297da",
+              "traceId": "3e2b7585d03805a4ce9f0360ef066062",
+              "spanId": "d57f74e12a73e322",
+              "parentSpanId": "6729a9d4f7f87520",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314532459000000",
-              "endTimeUnixNano": "1787314532460000000",
+              "startTimeUnixNano": "1787334339878000000",
+              "endTimeUnixNano": "1787334339881000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -328,6 +328,36 @@
                   }
                 },
                 {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
+                  }
+                },
+                {
+                  "key": "http.request.initiator_type",
+                  "value": {
+                    "stringValue": "navigation"
+                  }
+                },
+                {
+                  "key": "http.response.body.size",
+                  "value": {
+                    "intValue": 261
+                  }
+                },
+                {
+                  "key": "http.response.size",
+                  "value": {
+                    "intValue": 561
+                  }
+                },
+                {
+                  "key": "http.response.decoded_body_size",
+                  "value": {
+                    "intValue": 252
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -342,7 +372,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "28ADCF70A5D4F3BD289D4FC202D3D431"
+                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
                   }
                 },
                 {
@@ -357,55 +387,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314532460000000",
+                  "timeUnixNano": "1787334339879000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314532460000000",
+                  "timeUnixNano": "1787334339879000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314532460000000",
+                  "timeUnixNano": "1787334339879000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314532460000000",
+                  "timeUnixNano": "1787334339879000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787314532459000000",
+                  "timeUnixNano": "1787334339860000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314532460000000",
+                  "timeUnixNano": "1787334339879000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314532460000000",
+                  "timeUnixNano": "1787334339880000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314532460000000",
+                  "timeUnixNano": "1787334339882000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314532461000000",
+                  "timeUnixNano": "1787334339882000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -418,36 +448,36 @@
               "flags": 257
             },
             {
-              "traceId": "7257a1b6b5ddfffedd6cfa2366cd740f",
-              "spanId": "c777185462f57f3a",
-              "parentSpanId": "7ac0ce21b35297da",
+              "traceId": "3e2b7585d03805a4ce9f0360ef066062",
+              "spanId": "5064d869e99fe75f",
+              "parentSpanId": "6729a9d4f7f87520",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314532463000000",
-              "endTimeUnixNano": "1787314532465000000",
+              "startTimeUnixNano": "1787334339897000000",
+              "endTimeUnixNano": "1787334339901000000",
               "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.resource_fetch"
-                  }
-                },
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-WJHWQ8y1.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 425635
+                    "intValue": 437221
                   }
                 },
                 {
                   "key": "http.response_content_length_uncompressed",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 437209
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
                   }
                 },
                 {
@@ -459,19 +489,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 425635
+                    "intValue": 437221
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 425935
+                    "intValue": 437521
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 437209
                   }
                 },
                 {
@@ -489,7 +519,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "28ADCF70A5D4F3BD289D4FC202D3D431"
+                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
                   }
                 },
                 {
@@ -504,49 +534,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314532464000000",
+                  "timeUnixNano": "1787334339897000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314532464000000",
+                  "timeUnixNano": "1787334339897000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314532464000000",
+                  "timeUnixNano": "1787334339897000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314532464000000",
+                  "timeUnixNano": "1787334339897000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314532464000000",
+                  "timeUnixNano": "1787334339897000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314532465000000",
+                  "timeUnixNano": "1787334339898000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314532465000000",
+                  "timeUnixNano": "1787334339900000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314532466000000",
+                  "timeUnixNano": "1787334339901000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -559,12 +589,12 @@
               "flags": 257
             },
             {
-              "traceId": "7257a1b6b5ddfffedd6cfa2366cd740f",
-              "spanId": "7ac0ce21b35297da",
+              "traceId": "3e2b7585d03805a4ce9f0360ef066062",
+              "spanId": "6729a9d4f7f87520",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787314532459000000",
-              "endTimeUnixNano": "1787314532496000000",
+              "startTimeUnixNano": "1787334339878000000",
+              "endTimeUnixNano": "1787334339973000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -599,7 +629,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "28ADCF70A5D4F3BD289D4FC202D3D431"
+                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
                   }
                 },
                 {
@@ -614,43 +644,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314532460000000",
+                  "timeUnixNano": "1787334339879000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787314532464000000",
+                  "timeUnixNano": "1787334339895000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787314532497000000",
+                  "timeUnixNano": "1787334339973000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787314532497000000",
+                  "timeUnixNano": "1787334339973000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787314532497000000",
+                  "timeUnixNano": "1787334339973000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787314532497000000",
+                  "timeUnixNano": "1787334339973000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787314532497000000",
+                  "timeUnixNano": "1787334339974000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -671,12 +701,12 @@
           },
           "spans": [
             {
-              "traceId": "9f062235856a901a6a27d31f2fd15168",
-              "spanId": "28b664cc03ee325f",
+              "traceId": "ba1a57132b9f601b648ba8d1e008705e",
+              "spanId": "a010d415e8abacd7",
               "name": "GET",
               "kind": 3,
-              "startTimeUnixNano": "1787314532637000000",
-              "endTimeUnixNano": "1787314532640000000",
+              "startTimeUnixNano": "1787334340162000000",
+              "endTimeUnixNano": "1787334340182000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -729,7 +759,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "28ADCF70A5D4F3BD289D4FC202D3D431"
+                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
                   }
                 },
                 {
@@ -744,43 +774,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314532637000000",
+                  "timeUnixNano": "1787334340163000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314532637000000",
+                  "timeUnixNano": "1787334340163000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314532637000000",
+                  "timeUnixNano": "1787334340163000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314532637000000",
+                  "timeUnixNano": "1787334340163000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314532637000000",
+                  "timeUnixNano": "1787334340163000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314532637000000",
+                  "timeUnixNano": "1787334340163000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314532640000000",
+                  "timeUnixNano": "1787334340174000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -793,12 +823,12 @@
               "flags": 257
             },
             {
-              "traceId": "c5fe1c50f011dd50cb5908beac373f19",
-              "spanId": "3a03a22507836696",
+              "traceId": "0bac896ecb61d13ba25e5548f576107f",
+              "spanId": "91e99cb65a382a03",
               "name": "POST",
               "kind": 3,
-              "startTimeUnixNano": "1787314532966000000",
-              "endTimeUnixNano": "1787314532972000000",
+              "startTimeUnixNano": "1787334340697000000",
+              "endTimeUnixNano": "1787334340717000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -851,7 +881,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "28ADCF70A5D4F3BD289D4FC202D3D431"
+                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
                   }
                 },
                 {
@@ -866,49 +896,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314532968000000",
+                  "timeUnixNano": "1787334340702000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314532969000000",
+                  "timeUnixNano": "1787334340706000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314532969000000",
+                  "timeUnixNano": "1787334340709000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314532969000000",
+                  "timeUnixNano": "1787334340713000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314532969000000",
+                  "timeUnixNano": "1787334340714000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314532970000000",
+                  "timeUnixNano": "1787334340712000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314532970000000",
+                  "timeUnixNano": "1787334340715000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314532971000000",
+                  "timeUnixNano": "1787334340715000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -929,12 +959,12 @@
           },
           "spans": [
             {
-              "traceId": "0cfff71e702a3e75c8f1e5df1fa0834e",
-              "spanId": "95696f885d9a7b5f",
+              "traceId": "cf210957ceb27614ab64e8582584b074",
+              "spanId": "0e467365a2a55bcd",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787314532493000000",
-              "endTimeUnixNano": "1787314533292000000",
+              "startTimeUnixNano": "1787334339970000000",
+              "endTimeUnixNano": "1787334341102000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -951,7 +981,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "28ADCF70A5D4F3BD289D4FC202D3D431"
+                    "stringValue": "5B8BC23B01914A2135DBB0284DB742BB"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "583BA1E0A6EFFD3AE3EA0C2D5EDE864B"
+              "stringValue": "91984ABC9B9E3C2D3D00C291412D9FA1"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "38f0437f00a7373f0093a5109f7329f3",
-              "spanId": "3c7b85a82f45dbd5",
+              "traceId": "1a6b41a0dc6a9e74a89bcf0020423fcd",
+              "spanId": "ad093de219b4e815",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787314528759000000",
-              "endTimeUnixNano": "1787314528932000000",
+              "startTimeUnixNano": "1787334338947000000",
+              "endTimeUnixNano": "1787334339195000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "FA3B018D094C09205DB9F1082699BAB4"
+                    "stringValue": "9DB4FC9ECE096D24C84AD434C346E046"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1787314528757
+                    "intValue": 1787334338943
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "F4D5EF7A903BFD4B4D47CCA9D8D53A09"
+                    "stringValue": "07D4C2068987D7D3776157EFBADA439D"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 11
+                    "intValue": 25
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "18703E1806CC4EAA6A9289A486D51A7A"
+                    "stringValue": "C637CBB54F07CD89744C4FFE0C5D8840"
                   }
                 },
                 {
@@ -250,13 +250,13 @@
           },
           "spans": [
             {
-              "traceId": "8c24b2424c826cacd3a9001039dbccf7",
-              "spanId": "d181e00727034bc4",
-              "parentSpanId": "57e67b832e26b05c",
+              "traceId": "1ce467a765f4274ee59cac19395acf27",
+              "spanId": "28e9d237eeac2530",
+              "parentSpanId": "dd5fc547ae5418c9",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314528726000000",
-              "endTimeUnixNano": "1787314528727000000",
+              "startTimeUnixNano": "1787334338856000000",
+              "endTimeUnixNano": "1787334338859000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -277,6 +277,36 @@
                   }
                 },
                 {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
+                  }
+                },
+                {
+                  "key": "http.request.initiator_type",
+                  "value": {
+                    "stringValue": "navigation"
+                  }
+                },
+                {
+                  "key": "http.response.body.size",
+                  "value": {
+                    "intValue": 261
+                  }
+                },
+                {
+                  "key": "http.response.size",
+                  "value": {
+                    "intValue": 561
+                  }
+                },
+                {
+                  "key": "http.response.decoded_body_size",
+                  "value": {
+                    "intValue": 252
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -291,7 +321,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "18703E1806CC4EAA6A9289A486D51A7A"
+                    "stringValue": "C637CBB54F07CD89744C4FFE0C5D8840"
                   }
                 },
                 {
@@ -306,55 +336,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314528726000000",
+                  "timeUnixNano": "1787334338856000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314528726000000",
+                  "timeUnixNano": "1787334338856000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314528726000000",
+                  "timeUnixNano": "1787334338856000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314528726000000",
+                  "timeUnixNano": "1787334338856000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787314528725000000",
+                  "timeUnixNano": "1787334338840000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314528726000000",
+                  "timeUnixNano": "1787334338856000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314528726000000",
+                  "timeUnixNano": "1787334338857000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314528727000000",
+                  "timeUnixNano": "1787334338859000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314528727000000",
+                  "timeUnixNano": "1787334338859000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -367,36 +397,36 @@
               "flags": 257
             },
             {
-              "traceId": "8c24b2424c826cacd3a9001039dbccf7",
-              "spanId": "44886b1d23412d42",
-              "parentSpanId": "57e67b832e26b05c",
+              "traceId": "1ce467a765f4274ee59cac19395acf27",
+              "spanId": "692c60a15df9c084",
+              "parentSpanId": "dd5fc547ae5418c9",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314528732000000",
-              "endTimeUnixNano": "1787314528733000000",
+              "startTimeUnixNano": "1787334338884000000",
+              "endTimeUnixNano": "1787334338889000000",
               "attributes": [
-                {
-                  "key": "emb.type",
-                  "value": {
-                    "stringValue": "ux.resource_fetch"
-                  }
-                },
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-WJHWQ8y1.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 425635
+                    "intValue": 437221
                   }
                 },
                 {
                   "key": "http.response_content_length_uncompressed",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 437209
+                  }
+                },
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
                   }
                 },
                 {
@@ -408,19 +438,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 425635
+                    "intValue": 437221
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 425935
+                    "intValue": 437521
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 437209
                   }
                 },
                 {
@@ -438,7 +468,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "18703E1806CC4EAA6A9289A486D51A7A"
+                    "stringValue": "C637CBB54F07CD89744C4FFE0C5D8840"
                   }
                 },
                 {
@@ -453,49 +483,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314528733000000",
+                  "timeUnixNano": "1787334338885000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314528733000000",
+                  "timeUnixNano": "1787334338885000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314528733000000",
+                  "timeUnixNano": "1787334338885000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314528733000000",
+                  "timeUnixNano": "1787334338885000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314528733000000",
+                  "timeUnixNano": "1787334338885000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314528733000000",
+                  "timeUnixNano": "1787334338886000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314528734000000",
+                  "timeUnixNano": "1787334338890000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314528734000000",
+                  "timeUnixNano": "1787334338890000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -508,12 +538,12 @@
               "flags": 257
             },
             {
-              "traceId": "8c24b2424c826cacd3a9001039dbccf7",
-              "spanId": "57e67b832e26b05c",
+              "traceId": "1ce467a765f4274ee59cac19395acf27",
+              "spanId": "dd5fc547ae5418c9",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787314528726000000",
-              "endTimeUnixNano": "1787314528766000000",
+              "startTimeUnixNano": "1787334338856000000",
+              "endTimeUnixNano": "1787334338960000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -548,7 +578,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "18703E1806CC4EAA6A9289A486D51A7A"
+                    "stringValue": "C637CBB54F07CD89744C4FFE0C5D8840"
                   }
                 },
                 {
@@ -563,43 +593,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314528727000000",
+                  "timeUnixNano": "1787334338857000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787314528732000000",
+                  "timeUnixNano": "1787334338882000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787314528766000000",
+                  "timeUnixNano": "1787334338957000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787314528766000000",
+                  "timeUnixNano": "1787334338957000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787314528766000000",
+                  "timeUnixNano": "1787334338957000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787314528766000000",
+                  "timeUnixNano": "1787334338958000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787314528767000000",
+                  "timeUnixNano": "1787334338961000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -620,12 +650,12 @@
           },
           "spans": [
             {
-              "traceId": "2ac4daf5649862127adb621c327d4ddc",
-              "spanId": "e7c55b2efa5544f5",
+              "traceId": "87c5e2f4c6920e0fddd2bfcb7cb209e8",
+              "spanId": "054f157ef65d3695",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787314528762000000",
-              "endTimeUnixNano": "1787314528932000000",
+              "startTimeUnixNano": "1787334338953000000",
+              "endTimeUnixNano": "1787334339196000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -642,7 +672,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "18703E1806CC4EAA6A9289A486D51A7A"
+                    "stringValue": "C637CBB54F07CD89744C4FFE0C5D8840"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "91984ABC9B9E3C2D3D00C291412D9FA1"
+              "stringValue": "BFEDF8B426167A915EAE83213313AF17"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "1a6b41a0dc6a9e74a89bcf0020423fcd",
-              "spanId": "ad093de219b4e815",
+              "traceId": "cef83267028d976f82d84e9a5688106a",
+              "spanId": "a4773f2042a50a35",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787334338947000000",
-              "endTimeUnixNano": "1787334339195000000",
+              "startTimeUnixNano": "1787935837962000000",
+              "endTimeUnixNano": "1787935838104000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "9DB4FC9ECE096D24C84AD434C346E046"
+                    "stringValue": "548BFF8A4B3A43D15D90A2C46D87713E"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1787334338943
+                    "intValue": 1787935837960
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "07D4C2068987D7D3776157EFBADA439D"
+                    "stringValue": "1671FDDABFC688936ABC09B5861FBEAD"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 25
+                    "intValue": 18
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "C637CBB54F07CD89744C4FFE0C5D8840"
+                    "stringValue": "9551C64AE0C9B366269EE7262139AAD7"
                   }
                 },
                 {
@@ -250,13 +250,13 @@
           },
           "spans": [
             {
-              "traceId": "1ce467a765f4274ee59cac19395acf27",
-              "spanId": "28e9d237eeac2530",
-              "parentSpanId": "dd5fc547ae5418c9",
+              "traceId": "4256ed6683f3e9faacce2f2eb558e8b9",
+              "spanId": "20b69a2d99de5eff",
+              "parentSpanId": "d0d2e09f52c688f5",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787334338856000000",
-              "endTimeUnixNano": "1787334338859000000",
+              "startTimeUnixNano": "1787935837909000000",
+              "endTimeUnixNano": "1787935837910000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -307,6 +307,12 @@
                   }
                 },
                 {
+                  "key": "browser.navigation_timing.type",
+                  "value": {
+                    "stringValue": "navigate"
+                  }
+                },
+                {
                   "key": "browser.url.full",
                   "value": {
                     "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
@@ -321,7 +327,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "C637CBB54F07CD89744C4FFE0C5D8840"
+                    "stringValue": "9551C64AE0C9B366269EE7262139AAD7"
                   }
                 },
                 {
@@ -336,55 +342,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334338856000000",
+                  "timeUnixNano": "1787935837909000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334338856000000",
+                  "timeUnixNano": "1787935837909000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334338856000000",
+                  "timeUnixNano": "1787935837909000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334338856000000",
+                  "timeUnixNano": "1787935837909000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787334338840000000",
+                  "timeUnixNano": "1787935837903000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334338856000000",
+                  "timeUnixNano": "1787935837909000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334338857000000",
+                  "timeUnixNano": "1787935837910000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787334338859000000",
+                  "timeUnixNano": "1787935837910000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334338859000000",
+                  "timeUnixNano": "1787935837910000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -397,30 +403,30 @@
               "flags": 257
             },
             {
-              "traceId": "1ce467a765f4274ee59cac19395acf27",
-              "spanId": "692c60a15df9c084",
-              "parentSpanId": "dd5fc547ae5418c9",
+              "traceId": "4256ed6683f3e9faacce2f2eb558e8b9",
+              "spanId": "fe0baacbf023c7d1",
+              "parentSpanId": "d0d2e09f52c688f5",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787334338884000000",
-              "endTimeUnixNano": "1787334338889000000",
+              "startTimeUnixNano": "1787935837923000000",
+              "endTimeUnixNano": "1787935837924000000",
               "attributes": [
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-WJHWQ8y1.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-CGC8ESZ5.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 437221
+                    "intValue": 437497
                   }
                 },
                 {
                   "key": "http.response_content_length_uncompressed",
                   "value": {
-                    "intValue": 437209
+                    "intValue": 437485
                   }
                 },
                 {
@@ -438,19 +444,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 437221
+                    "intValue": 437497
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 437521
+                    "intValue": 437797
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 437209
+                    "intValue": 437485
                   }
                 },
                 {
@@ -468,7 +474,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "C637CBB54F07CD89744C4FFE0C5D8840"
+                    "stringValue": "9551C64AE0C9B366269EE7262139AAD7"
                   }
                 },
                 {
@@ -483,49 +489,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334338885000000",
+                  "timeUnixNano": "1787935837923000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787334338885000000",
+                  "timeUnixNano": "1787935837923000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787334338885000000",
+                  "timeUnixNano": "1787935837923000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787334338885000000",
+                  "timeUnixNano": "1787935837923000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787334338885000000",
+                  "timeUnixNano": "1787935837923000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787334338886000000",
+                  "timeUnixNano": "1787935837923000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787334338890000000",
+                  "timeUnixNano": "1787935837924000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787334338890000000",
+                  "timeUnixNano": "1787935837924000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -538,12 +544,12 @@
               "flags": 257
             },
             {
-              "traceId": "1ce467a765f4274ee59cac19395acf27",
-              "spanId": "dd5fc547ae5418c9",
+              "traceId": "4256ed6683f3e9faacce2f2eb558e8b9",
+              "spanId": "d0d2e09f52c688f5",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787334338856000000",
-              "endTimeUnixNano": "1787334338960000000",
+              "startTimeUnixNano": "1787935837909000000",
+              "endTimeUnixNano": "1787935837970000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -578,7 +584,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "C637CBB54F07CD89744C4FFE0C5D8840"
+                    "stringValue": "9551C64AE0C9B366269EE7262139AAD7"
                   }
                 },
                 {
@@ -593,43 +599,43 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787334338857000000",
+                  "timeUnixNano": "1787935837909000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787334338882000000",
+                  "timeUnixNano": "1787935837922000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787334338957000000",
+                  "timeUnixNano": "1787935837968000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787334338957000000",
+                  "timeUnixNano": "1787935837968000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787334338957000000",
+                  "timeUnixNano": "1787935837968000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787334338958000000",
+                  "timeUnixNano": "1787935837968000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787334338961000000",
+                  "timeUnixNano": "1787935837970000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -650,12 +656,12 @@
           },
           "spans": [
             {
-              "traceId": "87c5e2f4c6920e0fddd2bfcb7cb209e8",
-              "spanId": "054f157ef65d3695",
+              "traceId": "a9e65a4df096841127afc7386b2231b8",
+              "spanId": "43a8a49c3b7191e7",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787334338953000000",
-              "endTimeUnixNano": "1787334339196000000",
+              "startTimeUnixNano": "1787935837966000000",
+              "endTimeUnixNano": "1787935838104000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -672,7 +678,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "C637CBB54F07CD89744C4FFE0C5D8840"
+                    "stringValue": "9551C64AE0C9B366269EE7262139AAD7"
                   }
                 },
                 {


### PR DESCRIPTION
## What problem is this solving?

The document fetch span (the main HTML document's own network timing) has never carried `emb.type`, so the backend's web-resource mapper (`spans_web_resource_mapper.go`, keyed on `emb.type=ux.resource_fetch`) never picks it up. Every other resource on the page (scripts, stylesheets, images, XHR/fetch...) shows up as a web resource; the main document itself doesn't, even though the span already carries equivalent timing data.

## Short description of changes

- `DocumentLoadInstrumentation.ts`: extracted the attribute-setting logic shared by resource fetch spans and the document fetch span (`emb.type`, delivery type, initiator type, render-blocking status, response status, sizes, CORS/cache/incomplete diagnostic flags) into `_addResourceAttributesToSpan`, and call it for the document fetch span too. It now sets `emb.type=ux.resource_fetch` and the same attributes as any other resource span.
- `utils.ts`: `getPerformanceNavigationEntries` now also reads `transferSize`, `initiatorType`, `responseStatus`, `deliveryType`, `renderBlockingStatus` off the navigation timing entry, since none of those are part of `PerformanceTimingNames`.

## How has this been tested?

```
Row 1:
──────
date:                   2026-08-21
app_id:                 ppduz
app_version:            2.26.0
os:                     web
os_variant:             macOS
framework:              native
sdk_version:            2.26.0
surface_name:           /
surface_label:          Embrace Web SDK React Demo
browser_name:           Chrome
browser_version:        151.0.0.0
id:                     bd2ea71b4ec0d799
render_blocking_status: non-blocking
initiator_type:         navigation
delivery_type:          cache
encoded_body_size:      468
decoded_body_size:      468
transfer_size:          0
response_status:        200
resource_type:          other
start_time:             2026-08-21 16:48:19.362
end_time:               2026-08-21 16:48:19.364
duration_ms:            2
page_load_id:           472b59c712bc3a74
page_url:               http://localhost:4847/
protocol:               http
domain:                 localhost:4847
path:                   /
```