### PR TITLE
EMBR-13620 refactor(instrumentations): enable via registerInstrumentations instead of constructors

### DIFF
--- a/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.test.ts
+++ b/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.test.ts
@@ -25,9 +25,6 @@ describe('EmbraceInstrumentationBase', () => {
 
   beforeEach(() => {
     instrumentation = new FakeInstrumentation();
-    instrumentation.enable();
-    // start Instrumentation in a disabled state so assertions are consistent
-    instrumentation.disable();
     onEnableSpy = sinon.spy(instrumentation, 'onEnable');
     onDisableSpy = sinon.spy(instrumentation, 'onDisable');
   });
@@ -60,6 +57,30 @@ describe('EmbraceInstrumentationBase', () => {
     expect(onDisableSpy).to.have.been.calledOnce;
   });
 
+  // registerInstrumentations only enables instrumentations whose config still
+  // reports them disabled, so a setConfig that flips the flag would leave the
+  // instrumentation permanently skipped with onEnable never run.
+  it('keeps a constructed instrumentation disabled across setConfig', () => {
+    instrumentation.setConfig({});
+
+    expect(instrumentation.getConfig().enabled).to.equal(false);
+
+    instrumentation.enable();
+
+    expect(onEnableSpy).to.have.been.calledOnce;
+  });
+
+  it('keeps an enabled instrumentation enabled across setConfig', () => {
+    instrumentation.enable();
+    instrumentation.setConfig({ enabled: false });
+
+    expect(instrumentation.getConfig().enabled).to.equal(true);
+
+    instrumentation.disable();
+
+    expect(onDisableSpy).to.have.been.calledOnce;
+  });
+
   describe('session part listeners', () => {
     let userSessionManager: UserSessionManagerInternal;
 
@@ -72,6 +93,18 @@ describe('EmbraceInstrumentationBase', () => {
         visibilityDoc: window.document,
       });
       session.setGlobalUserSessionManager(userSessionManager);
+    });
+
+    it('attaches no listeners while constructed but never enabled', () => {
+      instrumentation = new FakeInstrumentation();
+
+      userSessionManager.startSessionPartInternal({ reason: 'init' });
+      userSessionManager.endSessionPartInternal({
+        reason: 'web_foreground_inactivity',
+      });
+
+      expect(instrumentation.startCount).to.equal(0);
+      expect(instrumentation.endCount).to.equal(0);
     });
 
     it('invokes the start listener when a session part starts', () => {

--- a/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.test.ts
+++ b/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.test.ts
@@ -25,6 +25,7 @@ describe('EmbraceInstrumentationBase', () => {
 
   beforeEach(() => {
     instrumentation = new FakeInstrumentation();
+    instrumentation.enable();
     // start Instrumentation in a disabled state so assertions are consistent
     instrumentation.disable();
     onEnableSpy = sinon.spy(instrumentation, 'onEnable');
@@ -75,6 +76,7 @@ describe('EmbraceInstrumentationBase', () => {
 
     it('invokes the start listener when a session part starts', () => {
       instrumentation = new FakeInstrumentation();
+      instrumentation.enable();
 
       userSessionManager.startSessionPartInternal({ reason: 'init' });
 
@@ -83,6 +85,7 @@ describe('EmbraceInstrumentationBase', () => {
 
     it('invokes the end listener when a session part ends', () => {
       instrumentation = new FakeInstrumentation();
+      instrumentation.enable();
 
       userSessionManager.startSessionPartInternal({ reason: 'init' });
       userSessionManager.endSessionPartInternal({
@@ -94,6 +97,7 @@ describe('EmbraceInstrumentationBase', () => {
 
     it('stops invoking listeners after disable()', () => {
       instrumentation = new FakeInstrumentation();
+      instrumentation.enable();
       instrumentation.disable();
 
       userSessionManager.startSessionPartInternal({ reason: 'init' });
@@ -107,6 +111,7 @@ describe('EmbraceInstrumentationBase', () => {
 
     it('re-binds listeners to a user session manager set after enable', () => {
       instrumentation = new FakeInstrumentation();
+      instrumentation.enable();
 
       const replacementManager = new EmbraceUserSessionManager({
         dynamicConfigManager: TEST_DYNAMIC_CONFIG_MANAGER,

--- a/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.ts
+++ b/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.ts
@@ -34,7 +34,6 @@ export abstract class EmbraceInstrumentationBase<
   private _logManager: LogManager;
   private readonly _perf: PerformanceManager;
   private _limitManager: LimitManagerInternal | undefined;
-  protected _isEnabled = false;
   private _removeSessionPartListeners: RemoveSessionPartListeners = {};
   private _sessionPartListeners: SessionPartListeners = {};
 
@@ -47,6 +46,13 @@ export abstract class EmbraceInstrumentationBase<
     limitManager,
   }: EmbraceInstrumentationBaseArgs<ConfigType>) {
     super(instrumentationName, instrumentationVersion, config);
+    /*
+     * Construction only wires an instrumentation up; registerInstrumentations
+     * starts it. It attaches the tracer and logger providers first and then
+     * enables whatever still reports itself disabled, so enabling here would
+     * emit start-up telemetry into a provider that records nothing.
+     */
+    this._isEnabled = false;
     // optionally override the diag logger from the base class
     if (diag) {
       this._diag = diag;
@@ -55,6 +61,19 @@ export abstract class EmbraceInstrumentationBase<
     this._limitManager = limitManager;
     this._userSessionManager = session.getUserSessionManager();
     this._logManager = log.getLogManager();
+  }
+
+  /*
+   * Backed by config.enabled rather than a field of its own: that is the flag
+   * registerInstrumentations reads to decide whether an instrumentation still
+   * needs starting, so the two must never disagree.
+   */
+  protected get _isEnabled(): boolean {
+    return this._config.enabled === true;
+  }
+
+  protected set _isEnabled(enabled: boolean) {
+    this._config.enabled = enabled;
   }
 
   /* Returns session provider */

--- a/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.ts
+++ b/packages/web-sdk/src/instrumentations/EmbraceInstrumentationBase/EmbraceInstrumentationBase.ts
@@ -76,6 +76,17 @@ export abstract class EmbraceInstrumentationBase<
     this._config.enabled = enabled;
   }
 
+  /*
+   * The base setConfig defaults enabled to true, which would flip _isEnabled
+   * without onEnable running. Lifecycle state moves only through
+   * enable()/disable(), so it survives config replacement.
+   */
+  public override setConfig(config: ConfigType): void {
+    const wasEnabled = this._isEnabled;
+    super.setConfig(config);
+    this._isEnabled = wasEnabled;
+  }
+
   /* Returns session provider */
   protected get userSessionManager(): UserSessionManagerInternal {
     return this._userSessionManager;

--- a/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.test.ts
@@ -55,6 +55,7 @@ describe('ClicksInstrumentation', () => {
     instrumentation = new ClicksInstrumentation({
       diag,
     });
+    instrumentation.enable();
     const target = document.createElement('div');
     target.innerText = 'HEY';
     testContainer.append(target);
@@ -84,6 +85,7 @@ describe('ClicksInstrumentation', () => {
     instrumentation = new ClicksInstrumentation({
       diag,
     });
+    instrumentation.enable();
     const target = document.createElement('button');
     target.disabled = true;
     testContainer.append(target);
@@ -102,6 +104,7 @@ describe('ClicksInstrumentation', () => {
     instrumentation = new ClicksInstrumentation({
       diag,
     });
+    instrumentation.enable();
     const target = document.createElement('div');
     target.innerText = 'HEY';
     target.className = 'my-css-class';
@@ -132,6 +135,7 @@ describe('ClicksInstrumentation', () => {
     instrumentation = new ClicksInstrumentation({
       diag,
     });
+    instrumentation.enable();
     const target = document.createElement('div');
     target.innerText = 'my long inner text, plus some extra text';
     testContainer.append(target);
@@ -161,6 +165,7 @@ describe('ClicksInstrumentation', () => {
     instrumentation = new ClicksInstrumentation({
       diag,
     });
+    instrumentation.enable();
 
     const t1 = document.createElement('button');
     t1.innerText = 'button1';
@@ -219,6 +224,7 @@ describe('ClicksInstrumentation', () => {
     instrumentation = new ClicksInstrumentation({
       diag,
     });
+    instrumentation.enable();
 
     const t1 = document.createElement('button');
     t1.innerText = 'button1';
@@ -254,6 +260,7 @@ describe('ClicksInstrumentation', () => {
     instrumentation = new ClicksInstrumentation({
       diag,
     });
+    instrumentation.enable();
 
     const t1 = document.createElement('button');
     t1.innerText = 'button1';
@@ -289,6 +296,7 @@ describe('ClicksInstrumentation', () => {
       diag,
       shouldTrack: (element) => !element.hasAttribute('data-is-sensitive'),
     });
+    instrumentation.enable();
     const target1 = document.createElement('div');
     target1.setAttribute('data-is-sensitive', 'true');
     target1.innerText = 'should not track';
@@ -328,6 +336,7 @@ describe('ClicksInstrumentation', () => {
           ? '[REDACTED]'
           : element.innerText,
     });
+    instrumentation.enable();
     const target1 = document.createElement('div');
     target1.setAttribute('data-is-sensitive', 'true');
     target1.innerText = 'should not track';

--- a/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/clicks/ClicksInstrumentation/ClicksInstrumentation.ts
@@ -71,10 +71,6 @@ export class ClicksInstrumentation extends EmbraceInstrumentationBase {
         this._diag.error('failed to create new user interaction span event', e);
       }
     };
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   public override onDisable(): void {

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -284,9 +284,7 @@ describe('DocumentLoad Instrumentation', () => {
     FakePerformanceObserver.supportedEntryTypes = ['navigation'];
     (globalThis as Record<string, unknown>)['PerformanceObserver'] =
       FakePerformanceObserver;
-    plugin = new DocumentLoadInstrumentation({
-      enabled: false,
-    });
+    plugin = new DocumentLoadInstrumentation();
     plugin.setTracerProvider(provider);
     exporter.reset();
   });
@@ -315,31 +313,31 @@ describe('DocumentLoad Instrumentation', () => {
 
   describe('constructor', () => {
     it('should construct an instance', () => {
-      plugin = new DocumentLoadInstrumentation({
-        enabled: false,
-      });
+      plugin = new DocumentLoadInstrumentation();
       assert.ok(plugin instanceof DocumentLoadInstrumentation);
     });
 
     /*
-     * The SDK enables through the constructor and wires the tracer provider
-     * afterwards, so collection has to outlast that gap to be recorded.
+     * Construction only wires the instrumentation up; registerInstrumentations
+     * attaches the providers and enables it afterwards, so nothing may be
+     * collected until then.
      */
-    it('should collect when enabled through the constructor', async () => {
+    it('should not collect until it is enabled', async () => {
       const spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
       spyEntries.withArgs('navigation').returns([entries]);
       spyEntries.withArgs('resource').returns([]);
       spyEntries.withArgs('paint').returns([]);
 
-      plugin = new DocumentLoadInstrumentation({ enabled: true });
+      plugin = new DocumentLoadInstrumentation();
       plugin.setTracerProvider(provider);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await afterPendingTasks();
 
-      assert.strictEqual(
-        exporter.getFinishedSpans().filter((s) => s.name === 'documentLoad')
-          .length,
-        1,
-      );
+      assert.strictEqual(documentLoadSpans().length, 0);
+
+      plugin.enable();
+      await afterPendingTasks();
+
+      assert.strictEqual(documentLoadSpans().length, 1);
     });
   });
 
@@ -734,7 +732,6 @@ describe('DocumentLoad Instrumentation', () => {
 
     it('should add attribute to document load span', (done) => {
       plugin = new DocumentLoadInstrumentation({
-        enabled: false,
         applyCustomAttributesOnSpan: {
           documentLoad: (span) => {
             span.setAttribute('custom-key', 'custom-val');
@@ -752,7 +749,6 @@ describe('DocumentLoad Instrumentation', () => {
 
     it('should add attribute to document fetch span', (done) => {
       plugin = new DocumentLoadInstrumentation({
-        enabled: false,
         applyCustomAttributesOnSpan: {
           documentFetch: (span) => {
             span.setAttribute('custom-key', 'custom-val');
@@ -770,7 +766,6 @@ describe('DocumentLoad Instrumentation', () => {
 
     it('should add attribute to resource fetch spans', (done) => {
       plugin = new DocumentLoadInstrumentation({
-        enabled: false,
         applyCustomAttributesOnSpan: {
           resourceFetch: (span, resource) => {
             span.setAttribute('custom-key', 'custom-val');
@@ -807,7 +802,6 @@ describe('DocumentLoad Instrumentation', () => {
     });
     it('should still create the spans if the function throws error', (done) => {
       plugin = new DocumentLoadInstrumentation({
-        enabled: false,
         applyCustomAttributesOnSpan: {
           documentLoad: (_span) => {
             throw new Error('test error');
@@ -823,7 +817,6 @@ describe('DocumentLoad Instrumentation', () => {
 
     it('should still create the spans if the resourceFetch function throws error', (done) => {
       plugin = new DocumentLoadInstrumentation({
-        enabled: false,
         applyCustomAttributesOnSpan: {
           resourceFetch: (_span) => {
             throw new Error('test error');
@@ -1069,7 +1062,7 @@ describe('DocumentLoad Instrumentation', () => {
     });
 
     it('should not collect performance twice when disabled and re-enabled', (done) => {
-      plugin = new DocumentLoadInstrumentation({ enabled: false });
+      plugin = new DocumentLoadInstrumentation();
 
       plugin.enable();
       plugin.disable();
@@ -1102,7 +1095,6 @@ describe('DocumentLoad Instrumentation', () => {
 
     it('should ignore network span events if ignoreNetworkEvents is set to true', (done) => {
       plugin = new DocumentLoadInstrumentation({
-        enabled: false,
         ignoreNetworkEvents: true,
       });
       plugin.enable();
@@ -1135,7 +1127,6 @@ describe('DocumentLoad Instrumentation', () => {
 
     it('should ignore performance events if ignorePerformanceEvents is set to true', (done) => {
       plugin = new DocumentLoadInstrumentation({
-        enabled: false,
         ignorePerformancePaintEvents: true,
       });
       plugin.enable();
@@ -1158,7 +1149,6 @@ describe('DocumentLoad Instrumentation', () => {
 
     it('should have http.response_content_length attribute even if ignoreNetworkEvents is true', (done) => {
       plugin = new DocumentLoadInstrumentation({
-        enabled: false,
         ignoreNetworkEvents: true,
       });
       plugin.enable();
@@ -1362,7 +1352,6 @@ describe('DocumentLoad Instrumentation', () => {
       FakePerformanceObserver.supportedEntryTypes = [];
       const warnings: string[] = [];
       plugin = new DocumentLoadInstrumentation({
-        enabled: false,
         diag: {
           verbose: () => {},
           debug: () => {},
@@ -1445,9 +1434,10 @@ describe('DocumentLoad Instrumentation', () => {
 
     /* The constructor runs inside initSDK's try block, so throwing here fails
      * the whole SDK init and takes every other instrumentation with it. */
-    it('should construct without throwing when enabled', () => {
+    it('should construct and enable without throwing', () => {
       assert.doesNotThrow(() => {
-        const instance = new DocumentLoadInstrumentation({ enabled: true });
+        const instance = new DocumentLoadInstrumentation();
+        instance.enable();
         instance.disable();
       });
     });

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.test.ts
@@ -1393,26 +1393,11 @@ describe('DocumentLoad Instrumentation', () => {
       assert.strictEqual(FakePerformanceObserver.instances.length, 0);
     });
 
-    /* Under registerGlobally: false the tracer provider is wired after the
-     * constructor runs, so a synchronous collect would record nothing. */
-    it('should not collect synchronously while enabling', (done) => {
+    /* Nothing is coming to trigger a later read, so enabling collects. */
+    it('should collect while enabling', () => {
       plugin.enable();
 
-      assert.strictEqual(documentLoadSpans().length, 0);
-
-      setTimeout(() => {
-        assert.strictEqual(documentLoadSpans().length, 1);
-        done();
-      });
-    });
-
-    it('should collect nothing when disabled before the deferred read runs', async () => {
-      plugin.enable();
-      plugin.disable();
-
-      await afterPendingTasks();
-
-      assert.strictEqual(documentLoadSpans().length, 0);
+      assert.strictEqual(documentLoadSpans().length, 1);
     });
   });
 

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -75,13 +75,15 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
   private _navigationObserver: PerformanceObserver | null = null;
   private _performanceCollected = false;
 
+  // 'enabled' is refused here: construction only wires the instrumentation up,
+  // and registerInstrumentations starts it regardless of any flag passed in.
   public constructor({
     diag,
     perf,
     applyCustomAttributesOnSpan,
     ignorePerformancePaintEvents = false,
     ignoreNetworkEvents = false,
-  }: DocumentLoadInstrumentationConfig = {}) {
+  }: Omit<DocumentLoadInstrumentationConfig, 'enabled'> = {}) {
     super({
       instrumentationName: 'DocumentLoadInstrumentation',
       instrumentationVersion: '1.0.0',
@@ -516,8 +518,8 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
     // An unbuffered subscription registered after the load event is never
     // notified, so the finished entry is read off the timeline instead. Spans
     // are recorded here: enabling happens once the providers are attached.
-    if (this._isLoadEventFinished()) {
-      this._collectIfLoadEventFinished();
+    this._collectIfLoadEventFinished();
+    if (this._performanceCollected) {
       return;
     }
 

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -514,15 +514,10 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
 
   public override onEnable(): void {
     // An unbuffered subscription registered after the load event is never
-    // notified, so collect straight away instead of observing. Deferred a
-    // microtask because under registerGlobally: false the tracer provider
-    // arrives later in this same task, and earlier spans reach a no-op tracer.
+    // notified, so the finished entry is read off the timeline instead. Spans
+    // are recorded here: enabling happens once the providers are attached.
     if (this._isLoadEventFinished()) {
-      queueMicrotask(() => {
-        if (this._isEnabled) {
-          this._collectIfLoadEventFinished();
-        }
-      });
+      this._collectIfLoadEventFinished();
       return;
     }
 

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/DocumentLoadInstrumentation.ts
@@ -78,7 +78,6 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
   public constructor({
     diag,
     perf,
-    enabled,
     applyCustomAttributesOnSpan,
     ignorePerformancePaintEvents = false,
     ignoreNetworkEvents = false,
@@ -89,16 +88,11 @@ export class DocumentLoadInstrumentation extends EmbraceInstrumentationBase<Docu
       diag,
       perf,
       config: {
-        enabled,
         applyCustomAttributesOnSpan,
         ignorePerformancePaintEvents,
         ignoreNetworkEvents,
       },
     });
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   /**

--- a/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/types.ts
+++ b/packages/web-sdk/src/instrumentations/document-load/DocumentLoadInstrumentation/types.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Span } from '@opentelemetry/api';
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import type { EmbraceInstrumentationBaseArgs } from '../../EmbraceInstrumentationBase/index.ts';
 
 export type DocumentLoadCustomAttributeFunction = (span: Span) => void;
@@ -57,7 +58,4 @@ export type DocumentLoadInstrumentationConfig = Pick<
    * firstPaint
    */
   ignorePerformancePaintEvents?: boolean;
-
-  /** Whether the instrumentation is enabled */
-  enabled?: boolean;
-};
+} & InstrumentationConfig;

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
@@ -137,9 +137,12 @@ describe('DOMStateInstrumentation', () => {
     appendedImages.push(image);
   };
 
+  // Mirrors the SDK: construction wires the instrumentation up and the managers
+  // onto it, then registerInstrumentations enables it.
   const createInstrumentation = (): void => {
     instrumentation = new DOMStateInstrumentation();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
   };
 
   // Nothing is emitted until a part ends: each part end sends one log, and the
@@ -178,7 +181,7 @@ describe('DOMStateInstrumentation', () => {
 
   afterEach(() => {
     // Tests that register a manager on the global proxy must not leak it into
-    // the construction-time capture of later tests.
+    // the fold capture of later tests.
     session.setGlobalUserSessionManager(new NoOpUserSessionManager());
     instrumentation?.disable();
     for (const restore of restorers) {
@@ -193,7 +196,7 @@ describe('DOMStateInstrumentation', () => {
 
   it('emits nothing until the part ends, then one log carrying both measurements', () => {
     // @web/test-runner drives tests after the load event, so the navigation
-    // entry already reports it and the fold capture happens at wiring time.
+    // entry already reports it and the fold capture happens at enable.
     expect(
       (
         performance.getEntriesByType(
@@ -1035,10 +1038,10 @@ describe('DOMStateInstrumentation', () => {
     expect(foldLogs).to.have.lengthOf(1);
   });
 
-  it('contains a throw from the injected diag logger instead of escaping the constructor', () => {
-    // At construction the per-instance manager has not arrived, so the capture
-    // attempt takes the no-engaged-part skip, which logs through the injected
-    // diag: caller code, whose throw would otherwise abort SDK init.
+  it('contains a throw from the injected diag logger instead of escaping enable', () => {
+    // With no per-instance manager wired the capture attempt takes the
+    // no-engaged-part skip, which logs through the injected diag: caller code,
+    // whose throw would otherwise abort SDK init.
     let capturedErrors = 0;
     const throwingDiag = {
       verbose: () => {},
@@ -1053,6 +1056,7 @@ describe('DOMStateInstrumentation', () => {
     };
     expect(() => {
       instrumentation = new DOMStateInstrumentation({ diag: throwingDiag });
+      instrumentation.enable();
     }).to.not.throw();
     expect(capturedErrors).to.equal(1);
   });

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
@@ -1,7 +1,6 @@
 import type { Attributes } from '@opentelemetry/api';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { EMB_TYPES, KEY_EMB_TYPE } from '../../../constants/attributes.ts';
-import type { UserSessionManagerInternal } from '../../../managers/index.ts';
 import type { DocumentMeasurement } from '../../../utils/index.ts';
 import { measureDocument } from '../../../utils/index.ts';
 import { EmbraceInstrumentationBase } from '../../EmbraceInstrumentationBase/index.ts';
@@ -50,19 +49,15 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
     this._onLoad = (): void => {
       this._captureFoldMeasurement();
     };
-
-    if (this._config.enabled) {
-      this.enable();
-      if (this._hasLoadEventFired()) {
-        // Here rather than in onEnable so a re-enable takes no measurement of
-        // its own.
-        this._captureFoldMeasurement();
-      }
-    }
   }
 
   public override onEnable(): void {
-    if (!this._hasLoadEventFired()) {
+    if (this._hasLoadEventFired()) {
+      // Attaching to a page that already loaded: no load event is coming, so
+      // this is the only trigger left. The measurement is spent once, so a
+      // re-enable takes none of its own.
+      this._captureFoldMeasurement();
+    } else {
       window.addEventListener('load', this._onLoad, { once: true });
     }
 
@@ -95,17 +90,6 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
   public override onDisable(): void {
     window.removeEventListener('load', this._onLoad);
     this._pendingFoldAttributes = null;
-  }
-
-  public override setUserSessionManager(
-    userSessionManager: UserSessionManagerInternal,
-  ): void {
-    super.setUserSessionManager(userSessionManager);
-    // Per-instance wiring delivers the manager after construction, when the
-    // capture attempt saw no engaged part. Try again.
-    if (this._isEnabled && this._hasLoadEventFired()) {
-      this._captureFoldMeasurement();
-    }
   }
 
   private _hasLoadEventFired(): boolean {

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
@@ -53,9 +53,10 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
 
   public override onEnable(): void {
     if (this._hasLoadEventFired()) {
-      // Attaching to a page that already loaded: no load event is coming, so
-      // this is the only trigger left. The measurement is spent once, so a
-      // re-enable takes none of its own.
+      // Attaching to a page that already loaded: no load event is coming, and
+      // a part already running fired part-start before the listener below
+      // existed, so capture now. The measurement is spent once, so a re-enable
+      // takes none of its own.
       this._captureFoldMeasurement();
     } else {
       window.addEventListener('load', this._onLoad, { once: true });

--- a/packages/web-sdk/src/instrumentations/element-timing/ElementTimingInstrumentation/ElementTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/element-timing/ElementTimingInstrumentation/ElementTimingInstrumentation.test.ts
@@ -108,6 +108,7 @@ describe('ElementTimingInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     expect(observeOptions).to.deep.equal({ type: 'element', buffered: true });
 
@@ -119,6 +120,7 @@ describe('ElementTimingInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({
@@ -162,6 +164,7 @@ describe('ElementTimingInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({ loadTime: 0, renderTime: 200, startTime: 200 }),
@@ -180,6 +183,7 @@ describe('ElementTimingInstrumentation', () => {
       perf: timeOriginPerf,
       limitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([makeEntry({ startTime: 250 })]);
 
@@ -204,6 +208,7 @@ describe('ElementTimingInstrumentation', () => {
       perf: timeOriginPerf,
       limitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({ startTime: 700, renderTime: 700, loadTime: 650 }),
@@ -224,6 +229,7 @@ describe('ElementTimingInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([makeEntry({ element: null })]);
 
@@ -246,6 +252,7 @@ describe('ElementTimingInstrumentation', () => {
       diag: diagLogger,
       limitManager,
     });
+    instrumentation.enable();
 
     expect(observerCallback).to.be.null;
     expect(diagLogger.getDebugLogs().some((m) => m.includes('element'))).to.be
@@ -259,6 +266,7 @@ describe('ElementTimingInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     instrumentation.disable();
 
@@ -278,6 +286,7 @@ describe('ElementTimingInstrumentation', () => {
       perf,
       limitManager: customLimitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({ identifier: 'el-0' }),
@@ -295,6 +304,7 @@ describe('ElementTimingInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
     const firstCallback = observerCallback;
 
     instrumentation.enable();
@@ -320,6 +330,7 @@ describe('ElementTimingInstrumentation', () => {
       diag: diagLogger,
       limitManager,
     });
+    instrumentation.enable();
 
     expect(diagLogger.getErrorLogs()[0]).to.equal('failed to enable');
 

--- a/packages/web-sdk/src/instrumentations/element-timing/ElementTimingInstrumentation/ElementTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/element-timing/ElementTimingInstrumentation/ElementTimingInstrumentation.ts
@@ -35,10 +35,6 @@ export class ElementTimingInstrumentation extends EmbraceInstrumentationBase {
       limitManager,
       config: {},
     });
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   public override enable(): void {

--- a/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.test.ts
@@ -58,6 +58,7 @@ describe('EmptyInstrumentation', () => {
       rootNode,
       emptyCheckDelayMs: 10,
     });
+    instrumentation.enable();
 
     // Clear out the root node
     child1.remove();
@@ -109,6 +110,7 @@ describe('EmptyInstrumentation', () => {
       rootNode,
       emptyCheckDelayMs: 10,
     });
+    instrumentation.enable();
 
     child1.remove();
 
@@ -140,6 +142,7 @@ describe('EmptyInstrumentation', () => {
       rootNode,
       emptyCheckDelayMs: 10,
     });
+    instrumentation.enable();
 
     child1.remove();
     child2.remove();
@@ -173,6 +176,7 @@ describe('EmptyInstrumentation', () => {
       rootNode,
       emptyCheckDelayMs: 10,
     });
+    instrumentation.enable();
 
     rootNode.remove();
 
@@ -198,6 +202,7 @@ describe('EmptyInstrumentation', () => {
       rootNode: null,
       emptyCheckDelayMs: 10,
     });
+    instrumentation.enable();
 
     expect(diag.getWarnLogs()).to.deep.equal([
       "supplied root node was null, this instrumentation won't be enabled",

--- a/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/empty-root/EmptyRootInstrumentation/EmptyRootInstrumentation.ts
@@ -32,10 +32,6 @@ export class EmptyRootInstrumentation extends EmbraceInstrumentationBase {
         this._observerCallback(mutationList);
       },
     );
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   public override enable(): void {

--- a/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.test.ts
@@ -66,6 +66,7 @@ describe('GlobalExceptionInstrumentation', () => {
     instrumentation = new GlobalExceptionInstrumentation({
       perf,
     });
+    instrumentation.enable();
     // The runner will fail our tests if it detects an unhandled error / rejection, temporarily ignore the ones we're
     // artificially triggering from this suite
     existingRejectionHandler = window.onunhandledrejection;

--- a/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/exceptions/GlobalExceptionInstrumentation/GlobalExceptionInstrumentation.ts
@@ -29,10 +29,6 @@ export class GlobalExceptionInstrumentation extends EmbraceInstrumentationBase {
         handler: 'promise_rejection',
       });
     };
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   public onDisable(): void {

--- a/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.test.ts
@@ -302,8 +302,8 @@ describe('FirstInteractionInstrumentation', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
     instrumentation.enable();
 
-    // Listeners are attached in the constructor; calling enable() again while
-    // they are still attached must be a no-op rather than double-registering.
+    // Listeners are attached on enable(); calling enable() again while they
+    // are still attached must be a no-op rather than double-registering.
     instrumentation.enable();
 
     const target = document.createElement('button');

--- a/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.test.ts
@@ -59,12 +59,14 @@ describe('FirstInteractionInstrumentation', () => {
 
   it('does not emit any log when no interaction happens', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
 
     expect(getLogs()).to.have.lengthOf(0);
   });
 
   it('emits a click event on click with pointerType=mouse', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
 
     const target = document.createElement('button');
     target.id = 'go';
@@ -96,6 +98,7 @@ describe('FirstInteractionInstrumentation', () => {
 
   it('emits a tap event on click with pointerType=touch', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
 
     const target = document.createElement('a');
     target.id = 'home';
@@ -124,6 +127,7 @@ describe('FirstInteractionInstrumentation', () => {
 
   it('emits a keypress event on keydown with no coordinates', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
 
     const input = document.createElement('input');
     input.id = 'search';
@@ -149,6 +153,7 @@ describe('FirstInteractionInstrumentation', () => {
 
   it('emits a scroll event with element_type=document and empty selector', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
 
     document.dispatchEvent(new Event('scroll', { bubbles: true }));
 
@@ -167,6 +172,7 @@ describe('FirstInteractionInstrumentation', () => {
 
   it('emits only once across multiple interactions', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
 
     const target = document.createElement('button');
     target.id = 'first';
@@ -206,6 +212,7 @@ describe('FirstInteractionInstrumentation', () => {
 
   it('re-registers listeners on session part start', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
 
     const target = document.createElement('button');
     target.id = 'a';
@@ -255,6 +262,7 @@ describe('FirstInteractionInstrumentation', () => {
     testContainer.append(target);
 
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
     instrumentation.disable();
 
     target.dispatchEvent(
@@ -271,6 +279,7 @@ describe('FirstInteractionInstrumentation', () => {
 
   it('does not re-register on session part start after disable()', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
     instrumentation.disable();
 
     userSessionManager.startSessionPartInternal({ reason: 'init' });
@@ -291,6 +300,7 @@ describe('FirstInteractionInstrumentation', () => {
 
   it('does not re-attach listeners when they are already attached', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
 
     // Listeners are attached in the constructor; calling enable() again while
     // they are still attached must be a no-op rather than double-registering.
@@ -314,6 +324,7 @@ describe('FirstInteractionInstrumentation', () => {
 
   it('ignores a second handler that fires after listeners are detached', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
 
     const target = document.createElement('button');
     testContainer.append(target);
@@ -345,6 +356,7 @@ describe('FirstInteractionInstrumentation', () => {
 
   it('logs a diagnostic error when emitting fails', () => {
     instrumentation = new FirstInteractionInstrumentation({ diag });
+    instrumentation.enable();
 
     const target = document.createElement('button');
     testContainer.append(target);

--- a/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/first-interaction/FirstInteractionInstrumentation/FirstInteractionInstrumentation.ts
@@ -66,10 +66,6 @@ export class FirstInteractionInstrumentation extends EmbraceInstrumentationBase 
         timestamp: event.timeStamp,
       });
     };
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   public override onEnable(): void {

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
@@ -139,8 +139,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     expect(observeOptions).to.deep.equal({
       type: 'long-animation-frame',
@@ -154,8 +154,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({
@@ -201,8 +201,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     // renderStart present: work = renderStart - startTime = 150 - 100 = 50
     // renderStart = 0 (falsy): work = duration = 80
@@ -227,8 +227,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     // styleAndLayoutStart present: startTime + duration - styleAndLayoutStart = 100 + 100 - 180 = 20
     // styleAndLayoutStart = 0: contributes 0
@@ -255,8 +255,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({ blockingDuration: 100, firstUIEventTimestamp: 0 }),
@@ -281,8 +281,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({ blockingDuration: 100, firstUIEventTimestamp: 0 }),
@@ -307,8 +307,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     userSessionManager.endSessionPartInternal({
       reason: 'web_foreground_inactivity',
@@ -333,8 +333,8 @@ describe('LoafInstrumentation', () => {
       perf,
       diag: diagLogger,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     expect(diagLogger.getDebugLogs().length).to.be.greaterThan(0);
     expect(observerCallback).to.be.null;
@@ -346,8 +346,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     instrumentation.disable();
 
@@ -369,8 +369,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     instrumentation.disable();
     expect(observerDisconnected).to.be.true;
@@ -380,8 +380,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([makeEntry({ duration: 100 })]);
     userSessionManager.endSessionPartInternal({
@@ -403,8 +403,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({ blockingDuration: 0 }),
@@ -428,8 +428,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({ blockingDuration: 0 }),
@@ -455,8 +455,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({ blockingDuration: 0 }),
@@ -482,8 +482,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({ blockingDuration: 0 }),
@@ -507,10 +507,10 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
-    // enable() was already called in constructor; call again
+    // The observer attaches on enable(); a second enable() must be a no-op.
     instrumentation.enable();
 
     triggerEntries([makeEntry({ duration: 60 })]);
@@ -530,8 +530,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([makeEntry({ duration: 60 })]);
 
@@ -574,8 +574,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([makeEntry({ duration: 100 }), makeEntry({ duration: 80 })]);
 
@@ -589,8 +589,8 @@ describe('LoafInstrumentation', () => {
 
   it('should generate a unique web vital id per session part', () => {
     const instrumentation = new LoafInstrumentation({ perf });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([makeEntry({ duration: 100 })]);
     userSessionManager.endSessionPartInternal({
@@ -625,8 +625,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([makeEntry({ duration: 100 }), makeEntry({ duration: 80 })]);
 
@@ -672,8 +672,8 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     // styleAndLayoutStart > startTime + duration would produce negative value
     triggerEntries([
@@ -704,8 +704,8 @@ describe('LoafInstrumentation', () => {
       perf,
       diag: diagLogger,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     // Trigger an entry that will cause an error by passing a broken object
     triggerEntries([
@@ -727,8 +727,8 @@ describe('LoafInstrumentation', () => {
       perf,
       diag: diagLogger,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     triggerEntries([makeEntry()]);
 
@@ -763,8 +763,8 @@ describe('LoafInstrumentation', () => {
       perf,
       diag: diagLogger,
     });
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
 
     expect(diagLogger.getErrorLogs().length).to.be.greaterThan(0);
 
@@ -775,8 +775,8 @@ describe('LoafInstrumentation', () => {
   describe('script summary', () => {
     it('should emit script summary log with correct aggregated data', () => {
       const instrumentation = new LoafInstrumentation({ perf });
-      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
+      instrumentation.enable();
 
       triggerEntries([
         makeEntry({
@@ -822,8 +822,8 @@ describe('LoafInstrumentation', () => {
 
     it('should group scripts by sourceURL across multiple LoAF entries', () => {
       const instrumentation = new LoafInstrumentation({ perf });
-      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
+      instrumentation.enable();
 
       triggerEntries([
         makeEntry({
@@ -865,8 +865,8 @@ describe('LoafInstrumentation', () => {
 
     it('should limit script entries to 250', () => {
       const instrumentation = new LoafInstrumentation({ perf });
-      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
+      instrumentation.enable();
 
       // 251 scripts with unique URLs and incrementing durations (script 0 has lowest duration)
       const scripts = Array.from({ length: 251 }, (_, i) =>
@@ -895,8 +895,8 @@ describe('LoafInstrumentation', () => {
 
     it('should not emit script summary log when no scripts present', () => {
       const instrumentation = new LoafInstrumentation({ perf });
-      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
+      instrumentation.enable();
 
       triggerEntries([makeEntry({ scripts: [] })]);
 
@@ -914,8 +914,8 @@ describe('LoafInstrumentation', () => {
 
     it('should reset script summaries between session parts', () => {
       const instrumentation = new LoafInstrumentation({ perf });
-      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
+      instrumentation.enable();
 
       triggerEntries([
         makeEntry({
@@ -967,8 +967,8 @@ describe('LoafInstrumentation', () => {
 
     it('should group scripts with empty sourceURL under (inline)', () => {
       const instrumentation = new LoafInstrumentation({ perf });
-      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
+      instrumentation.enable();
 
       triggerEntries([
         makeEntry({
@@ -1006,8 +1006,8 @@ describe('LoafInstrumentation', () => {
 
     it('should round float durations to integers in script summary', () => {
       const instrumentation = new LoafInstrumentation({ perf });
-      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
+      instrumentation.enable();
 
       triggerEntries([
         makeEntry({ duration: 80 }),
@@ -1046,8 +1046,8 @@ describe('LoafInstrumentation', () => {
 
     it('should truncate script URLs longer than 2048 characters with ellipsis', () => {
       const instrumentation = new LoafInstrumentation({ perf });
-      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
+      instrumentation.enable();
 
       const longURL = `https://example.com/${'a'.repeat(2100)}`;
       const truncatedURL = `https://example.com/${'a'.repeat(2028)}...`;

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.test.ts
@@ -139,6 +139,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     expect(observeOptions).to.deep.equal({
@@ -153,6 +154,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([
@@ -199,6 +201,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     // renderStart present: work = renderStart - startTime = 150 - 100 = 50
@@ -224,6 +227,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     // styleAndLayoutStart present: startTime + duration - styleAndLayoutStart = 100 + 100 - 180 = 20
@@ -251,6 +255,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([
@@ -276,6 +281,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([
@@ -301,6 +307,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     userSessionManager.endSessionPartInternal({
@@ -326,6 +333,7 @@ describe('LoafInstrumentation', () => {
       perf,
       diag: diagLogger,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     expect(diagLogger.getDebugLogs().length).to.be.greaterThan(0);
@@ -338,6 +346,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     instrumentation.disable();
@@ -360,6 +369,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     instrumentation.disable();
@@ -370,6 +380,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([makeEntry({ duration: 100 })]);
@@ -392,6 +403,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([
@@ -416,6 +428,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([
@@ -442,6 +455,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([
@@ -468,6 +482,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([
@@ -492,6 +507,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     // enable() was already called in constructor; call again
@@ -514,6 +530,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([makeEntry({ duration: 60 })]);
@@ -557,6 +574,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([makeEntry({ duration: 100 }), makeEntry({ duration: 80 })]);
@@ -571,6 +589,7 @@ describe('LoafInstrumentation', () => {
 
   it('should generate a unique web vital id per session part', () => {
     const instrumentation = new LoafInstrumentation({ perf });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([makeEntry({ duration: 100 })]);
@@ -606,6 +625,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([makeEntry({ duration: 100 }), makeEntry({ duration: 80 })]);
@@ -652,6 +672,7 @@ describe('LoafInstrumentation', () => {
     const instrumentation = new LoafInstrumentation({
       perf,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     // styleAndLayoutStart > startTime + duration would produce negative value
@@ -683,6 +704,7 @@ describe('LoafInstrumentation', () => {
       perf,
       diag: diagLogger,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     // Trigger an entry that will cause an error by passing a broken object
@@ -705,6 +727,7 @@ describe('LoafInstrumentation', () => {
       perf,
       diag: diagLogger,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     triggerEntries([makeEntry()]);
@@ -740,6 +763,7 @@ describe('LoafInstrumentation', () => {
       perf,
       diag: diagLogger,
     });
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
 
     expect(diagLogger.getErrorLogs().length).to.be.greaterThan(0);
@@ -751,6 +775,7 @@ describe('LoafInstrumentation', () => {
   describe('script summary', () => {
     it('should emit script summary log with correct aggregated data', () => {
       const instrumentation = new LoafInstrumentation({ perf });
+      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
 
       triggerEntries([
@@ -797,6 +822,7 @@ describe('LoafInstrumentation', () => {
 
     it('should group scripts by sourceURL across multiple LoAF entries', () => {
       const instrumentation = new LoafInstrumentation({ perf });
+      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
 
       triggerEntries([
@@ -839,6 +865,7 @@ describe('LoafInstrumentation', () => {
 
     it('should limit script entries to 250', () => {
       const instrumentation = new LoafInstrumentation({ perf });
+      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
 
       // 251 scripts with unique URLs and incrementing durations (script 0 has lowest duration)
@@ -868,6 +895,7 @@ describe('LoafInstrumentation', () => {
 
     it('should not emit script summary log when no scripts present', () => {
       const instrumentation = new LoafInstrumentation({ perf });
+      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
 
       triggerEntries([makeEntry({ scripts: [] })]);
@@ -886,6 +914,7 @@ describe('LoafInstrumentation', () => {
 
     it('should reset script summaries between session parts', () => {
       const instrumentation = new LoafInstrumentation({ perf });
+      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
 
       triggerEntries([
@@ -938,6 +967,7 @@ describe('LoafInstrumentation', () => {
 
     it('should group scripts with empty sourceURL under (inline)', () => {
       const instrumentation = new LoafInstrumentation({ perf });
+      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
 
       triggerEntries([
@@ -976,6 +1006,7 @@ describe('LoafInstrumentation', () => {
 
     it('should round float durations to integers in script summary', () => {
       const instrumentation = new LoafInstrumentation({ perf });
+      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
 
       triggerEntries([
@@ -1015,6 +1046,7 @@ describe('LoafInstrumentation', () => {
 
     it('should truncate script URLs longer than 2048 characters with ellipsis', () => {
       const instrumentation = new LoafInstrumentation({ perf });
+      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
 
       const longURL = `https://example.com/${'a'.repeat(2100)}`;

--- a/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/loaf/LoafInstrumentation/LoafInstrumentation.ts
@@ -53,10 +53,6 @@ export class LoafInstrumentation extends EmbraceInstrumentationBase {
       perf,
       config: {},
     });
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   public override enable(): void {

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -133,6 +133,7 @@ describe('MaxScrollDepthInstrumentation', () => {
     stubGeometry();
 
     instrumentation = new MaxScrollDepthInstrumentation();
+    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
   });
 

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.test.ts
@@ -133,8 +133,8 @@ describe('MaxScrollDepthInstrumentation', () => {
     stubGeometry();
 
     instrumentation = new MaxScrollDepthInstrumentation();
-    instrumentation.enable();
     instrumentation.setUserSessionManager(userSessionManager);
+    instrumentation.enable();
   });
 
   afterEach(() => {

--- a/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/max-scroll-depth/MaxScrollDepthInstrumentation/MaxScrollDepthInstrumentation.ts
@@ -41,10 +41,6 @@ export class MaxScrollDepthInstrumentation extends EmbraceInstrumentationBase {
         this._diag.error('failed to process scroll', e);
       }
     };
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   public override onEnable(): void {

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.test.ts
@@ -60,6 +60,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     pageManager.setCurrentRoute({ path: '/test/:id', url: '/test/123' });
     const pageId = pageManager.getCurrentPageId();
@@ -98,6 +99,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     expect(surfaceSpans()).to.have.lengthOf(0);
 
@@ -111,6 +113,7 @@ describe('NavigationInstrumentation', () => {
   it('should fall back to the global page manager when none is provided', () => {
     page.setGlobalPageManager(pageManager);
     navigationInstrumentation = new NavigationInstrumentation({ diag });
+    navigationInstrumentation.enable();
 
     page.setCurrentRoute({ path: '/test/:id', url: '/test/123' });
     page.setCurrentRoute({ path: '/other', url: '/other' });
@@ -125,6 +128,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     pageManager.setCurrentRoute({ path: '/test/:id', url: '/test/123' });
     pageManager.setCurrentRoute({ path: '/test/:id', url: '/test/123' });
@@ -145,6 +149,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     // The raw pathname reported first (e.g. by EmbracePageManager on soft
     // nav — a complete, valid route on its own), then a react-router
@@ -183,6 +188,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     pageManager.setCurrentRoute({ path: '/first', url: '/first' });
     expect(surfaceSpans()).to.have.lengthOf(0);
@@ -202,6 +208,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     pageManager.setCurrentRoute({
       path: '/test/:time(hourly|daily|weekly|monthly)/:type(typeA|typeB)',
@@ -220,6 +227,7 @@ describe('NavigationInstrumentation', () => {
       pageManager,
       shouldCleanupPathOptionsFromRouteName: false,
     });
+    navigationInstrumentation.enable();
 
     pageManager.setCurrentRoute({
       path: '/test/:time(hourly|daily|weekly|monthly)',
@@ -239,6 +247,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     pageManager.setCurrentRoute({ path: '/test/hourly', url: '/test/hourly' });
     pageManager.setCurrentRoute({
@@ -256,6 +265,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
     navigationInstrumentation.disable();
 
     pageManager.setCurrentRoute({ path: '/test/:id', url: '/test/123' });
@@ -269,6 +279,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     pageManager.setCurrentRoute({ path: '/test/:id', url: '/test/123' });
     expect(surfaceSpans()).to.have.lengthOf(0);
@@ -285,6 +296,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     userSessionManager.startSessionPartInternal({ reason: 'init' });
     pageManager.setCurrentRoute({ path: '/test/:id', url: '/test/123' });
@@ -304,6 +316,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     pageManager.setCurrentRoute({ path: '/test/:id', url: '/test/123' });
     userSessionManager.startSessionPartInternal({ reason: 'init' });
@@ -324,6 +337,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     userSessionManager.startSessionPartInternal({ reason: 'init' });
     pageManager.setCurrentRoute({ path: '/first', url: '/first' });
@@ -356,6 +370,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     expect(() => {
       userSessionManager.startSessionPartInternal({ reason: 'init' });
@@ -370,6 +385,7 @@ describe('NavigationInstrumentation', () => {
       diag,
       pageManager,
     });
+    navigationInstrumentation.enable();
 
     pageManager.setCurrentRoute({ path: '/first', url: '/first' });
 
@@ -379,6 +395,9 @@ describe('NavigationInstrumentation', () => {
     pageManager.setCurrentRoute({ path: '/second', url: '/second' });
     pageManager.setCurrentRoute({ path: '/third', url: '/third' });
 
-    expect(surfaceSpans()).to.have.lengthOf(2);
+    // Re-enabling picks the current route back up rather than waiting for the
+    // next navigation, so '/first' is covered by a span on either side of the
+    // disable.
+    expect(surfaceSpans()).to.have.lengthOf(3);
   });
 });

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
@@ -39,20 +39,10 @@ export class NavigationInstrumentation extends EmbraceInstrumentationBase {
       shouldCleanupPathOptionsFromRouteName;
     this._pageManager = pageManager ?? page.getPageManager();
     this._pageManager.addRouteChangedListener(this._onRouteChanged);
-
-    if (this._config.enabled) {
-      this.enable();
-    }
-
-    // Starts the inital route span if the page manager already has a current route
-    const currentRoute = this._pageManager.getCurrentRoute();
-    if (currentRoute) {
-      this._onRouteChanged(currentRoute);
-    }
   }
 
   private readonly _onRouteChanged = (route: Route): void => {
-    if (!this._config.enabled) {
+    if (!this._isEnabled) {
       return;
     }
 
@@ -143,13 +133,17 @@ export class NavigationInstrumentation extends EmbraceInstrumentationBase {
   };
 
   public override onEnable = () => {
-    this.setConfig({
-      enabled: true,
-    });
     this.setSessionPartListeners({
       start: this._onSessionPartStarted,
       end: this._onSessionPartEnded,
     });
+
+    // Starts the inital route span if the page manager already has a current route
+    const currentRoute = this._pageManager.getCurrentRoute();
+    if (currentRoute) {
+      this._onRouteChanged(currentRoute);
+    }
+
     this._diag.debug(
       'NavigationInstrumentation enabled, listening for navigation events.',
     );
@@ -157,9 +151,6 @@ export class NavigationInstrumentation extends EmbraceInstrumentationBase {
 
   public override onDisable = () => {
     this._endRouteSpan();
-    this.setConfig({
-      enabled: false,
-    });
     this._diag.debug(
       'NavigationInstrumentation disabled, stopped listening for navigation events.',
     );

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/NavigationInstrumentation.ts
@@ -138,7 +138,8 @@ export class NavigationInstrumentation extends EmbraceInstrumentationBase {
       end: this._onSessionPartEnded,
     });
 
-    // Starts the inital route span if the page manager already has a current route
+    // Route changes while disabled are dropped by the _isEnabled guard, so a
+    // route set before enabling is replayed here to open its span.
     const currentRoute = this._pageManager.getCurrentRoute();
     if (currentRoute) {
       this._onRouteChanged(currentRoute);

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV5/ReactRouterV5.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV5/ReactRouterV5.test.tsx
@@ -95,13 +95,12 @@ describe('ReactRouterV5Legacy', () => {
       }),
     ]);
 
-    // In production this is wired up automatically by initSDK, after the
-    // tracer provider is set up; this test builds the pipeline manually, so
-    // it needs to construct it itself in the same order — otherwise the
-    // route span started immediately for the already-current route (see
-    // NavigationInstrumentation's constructor) would be created against the
-    // wrong tracer provider.
-    new NavigationInstrumentation({ pageManager });
+    // In production initSDK constructs this and registerInstrumentations
+    // enables it once the tracer provider is wired. This test builds the
+    // pipeline manually and has to follow the same order, or the route span
+    // opened for the already-current route on enable would go to the wrong
+    // tracer provider.
+    new NavigationInstrumentation({ pageManager }).enable();
   });
 
   it('create route spans', async () => {

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Data/ReactRouterV6Data.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Data/ReactRouterV6Data.test.tsx
@@ -132,13 +132,12 @@ describe('ReactRouterV6Data', () => {
       }),
     ]);
 
-    // In production this is wired up automatically by initSDK, after the
-    // tracer provider is set up; this test builds the pipeline manually, so
-    // it needs to construct it itself in the same order — otherwise the
-    // route span started immediately for the already-current route (see
-    // NavigationInstrumentation's constructor) would be created against the
-    // wrong tracer provider.
-    new NavigationInstrumentation({ pageManager });
+    // In production initSDK constructs this and registerInstrumentations
+    // enables it once the tracer provider is wired. This test builds the
+    // pipeline manually and has to follow the same order, or the route span
+    // opened for the already-current route on enable would go to the wrong
+    // tracer provider.
+    new NavigationInstrumentation({ pageManager }).enable();
   });
 
   it('create route spans', async () => {

--- a/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Declarative/ReactRouterV6Declarative.test.tsx
+++ b/packages/web-sdk/src/instrumentations/navigation/NavigationInstrumentation/react/reactRouterV6Declarative/ReactRouterV6Declarative.test.tsx
@@ -107,13 +107,12 @@ describe('ReactRouterV6Declarative', () => {
       }),
     ]);
 
-    // In production this is wired up automatically by initSDK, after the
-    // tracer provider is set up; this test builds the pipeline manually, so
-    // it needs to construct it itself in the same order — otherwise the
-    // route span started immediately for the already-current route (see
-    // NavigationInstrumentation's constructor) would be created against the
-    // wrong tracer provider.
-    new NavigationInstrumentation({ pageManager });
+    // In production initSDK constructs this and registerInstrumentations
+    // enables it once the tracer provider is wired. This test builds the
+    // pipeline manually and has to follow the same order, or the route span
+    // opened for the already-current route on enable would go to the wrong
+    // tracer provider.
+    new NavigationInstrumentation({ pageManager }).enable();
   });
 
   it('create route spans', async () => {

--- a/packages/web-sdk/src/instrumentations/rage-click/RageClickInstrumentation/RageClickInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/rage-click/RageClickInstrumentation/RageClickInstrumentation.test.ts
@@ -48,12 +48,14 @@ describe('RageClickInstrumentation', () => {
 
   it('does not emit any rage-click log when no clicks happen', () => {
     instrumentation = new RageClickInstrumentation({ diag });
+    instrumentation.enable();
 
     expect(getRageClickLogs()).to.have.lengthOf(0);
   });
 
   it('emits a rage-click log after 3 clicks on the same target within the window', async () => {
     instrumentation = new RageClickInstrumentation({ diag });
+    instrumentation.enable();
     const target = document.createElement('button');
     target.id = 'checkout-btn';
     testContainer.append(target);
@@ -81,6 +83,7 @@ describe('RageClickInstrumentation', () => {
 
   it('does not emit when fewer than 3 clicks occur in the window', async () => {
     instrumentation = new RageClickInstrumentation({ diag });
+    instrumentation.enable();
     const target = document.createElement('button');
     testContainer.append(target);
 
@@ -94,6 +97,7 @@ describe('RageClickInstrumentation', () => {
 
   it('counts clicks within a radius of the first click, even on different targets', async () => {
     instrumentation = new RageClickInstrumentation({ diag });
+    instrumentation.enable();
     const a = document.createElement('button');
     a.id = 'a';
     a.style.position = 'fixed';
@@ -146,6 +150,7 @@ describe('RageClickInstrumentation', () => {
 
   it('does not count clicks outside the radius and on a different target', async () => {
     instrumentation = new RageClickInstrumentation({ diag });
+    instrumentation.enable();
 
     const a = document.createElement('button');
     a.id = 'a';
@@ -187,6 +192,7 @@ describe('RageClickInstrumentation', () => {
 
   it('marks interaction_type=tap when the first click is a touch PointerEvent', async () => {
     instrumentation = new RageClickInstrumentation({ diag });
+    instrumentation.enable();
 
     const target = document.createElement('a');
     target.id = 'nav-home';
@@ -219,6 +225,7 @@ describe('RageClickInstrumentation', () => {
 
   it('does not emit any log for clicks after disable()', async () => {
     instrumentation = new RageClickInstrumentation({ diag });
+    instrumentation.enable();
     const target = document.createElement('button');
     target.id = 'a';
     testContainer.append(target);
@@ -235,6 +242,7 @@ describe('RageClickInstrumentation', () => {
 
   it('emits the in-progress window if disable() is called in the middle of a rage click', async () => {
     instrumentation = new RageClickInstrumentation({ diag });
+    instrumentation.enable();
 
     const target = document.createElement('button');
     target.id = 'a';
@@ -260,6 +268,7 @@ describe('RageClickInstrumentation', () => {
 
   it('ignores click events whose target is not an Element', async () => {
     instrumentation = new RageClickInstrumentation({ diag });
+    instrumentation.enable();
 
     for (let i = 0; i < 3; i++) {
       const evt = new MouseEvent('click', { bubbles: true });
@@ -274,6 +283,7 @@ describe('RageClickInstrumentation', () => {
 
   it('logs an error if processing a click throws', () => {
     instrumentation = new RageClickInstrumentation({ diag });
+    instrumentation.enable();
     const target = document.createElement('button');
     testContainer.append(target);
 
@@ -302,6 +312,7 @@ describe('RageClickInstrumentation', () => {
       diag,
       perf: throwingPerf,
     });
+    instrumentation.enable();
     const target = document.createElement('button');
     testContainer.append(target);
 
@@ -316,6 +327,7 @@ describe('RageClickInstrumentation', () => {
 
   it('emits one log per window across consecutive windows', async () => {
     instrumentation = new RageClickInstrumentation({ diag });
+    instrumentation.enable();
     const target = document.createElement('button');
     target.id = 'a';
     testContainer.append(target);

--- a/packages/web-sdk/src/instrumentations/rage-click/RageClickInstrumentation/RageClickInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/rage-click/RageClickInstrumentation/RageClickInstrumentation.ts
@@ -55,10 +55,6 @@ export class RageClickInstrumentation extends EmbraceInstrumentationBase {
         this._diag.error('failed to process rage-click candidate', e);
       }
     };
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   public override onDisable(): void {

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.test.ts
@@ -183,6 +183,7 @@ describe('ServerTimingInstrumentation', () => {
         perf,
         limitManager,
       });
+      instrumentation.enable();
       deliverNavigationEntry();
 
       const logs = memoryExporter.getFinishedLogRecords();
@@ -222,6 +223,7 @@ describe('ServerTimingInstrumentation', () => {
 
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(0);
 
+      instrumentation.enable();
       deliverNavigationEntry();
 
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(1);
@@ -238,6 +240,7 @@ describe('ServerTimingInstrumentation', () => {
         perf,
         limitManager,
       });
+      instrumentation.enable();
 
       const loadListenerAdded = addEventListenerSpy.args.some(
         ([event]) => event === 'load',
@@ -262,6 +265,7 @@ describe('ServerTimingInstrumentation', () => {
         perf,
         limitManager,
       });
+      instrumentation.enable();
 
       expect(FakePerformanceObserver.latest().observedOptions).to.deep.equal({
         type: 'navigation',
@@ -298,6 +302,7 @@ describe('ServerTimingInstrumentation', () => {
           perf,
           limitManager,
         });
+        instrumentation.enable();
         deliverNavigationEntry();
 
         const logs = memoryExporter.getFinishedLogRecords();
@@ -317,6 +322,7 @@ describe('ServerTimingInstrumentation', () => {
         perf,
         limitManager,
       });
+      instrumentation.enable();
       instrumentation.disable();
 
       deliverNavigationEntry();
@@ -342,6 +348,7 @@ describe('ServerTimingInstrumentation', () => {
         perf,
         limitManager: customLimitManager,
       });
+      instrumentation.enable();
       deliverNavigationEntry();
 
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(2);
@@ -360,6 +367,7 @@ describe('ServerTimingInstrumentation', () => {
         perf,
         limitManager,
       });
+      instrumentation.enable();
       deliverNavigationEntry();
 
       expect(memoryExporter.getFinishedLogRecords()).to.have.length(1);
@@ -384,6 +392,7 @@ describe('ServerTimingInstrumentation', () => {
         perf,
         limitManager,
       });
+      instrumentation.enable();
 
       deliverNavigationEntry();
 
@@ -399,6 +408,7 @@ describe('ServerTimingInstrumentation', () => {
         perf,
         limitManager,
       });
+      instrumentation.enable();
 
       deliverNavigationEntry();
 
@@ -426,6 +436,7 @@ describe('ServerTimingInstrumentation', () => {
           error: () => {},
         },
       });
+      instrumentation.enable();
 
       deliverNavigationEntry();
 

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
@@ -27,10 +27,6 @@ export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
       limitManager,
       config: {},
     });
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   private _disconnectObserver(): void {

--- a/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/server-timing/ServerTimingInstrumentation/ServerTimingInstrumentation.ts
@@ -40,11 +40,6 @@ export class ServerTimingInstrumentation extends EmbraceInstrumentationBase {
     }
 
     /*
-     * The observer keeps the read out of the constructor. Under
-     * registerGlobally: false the logger provider arrives later in this same
-     * task, and a log emitted before it is lost for good because the
-     * collection guard latches.
-     *
      * buffered stays at its default of true, the opposite of the navigation
      * observer in DocumentLoadInstrumentation: server timings arrive in the
      * response headers and are complete on the entry from the start, so a

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.test.ts
@@ -175,6 +175,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     expect(observeOptions).to.deep.equal({
       type: 'soft-navigation',
@@ -189,6 +190,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({
@@ -229,6 +231,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([makeEntry({ startTime: 200, duration: 50 })]);
 
@@ -245,6 +248,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       limitManager,
       signalBuffer,
     });
+    instrumentation.enable();
 
     signalBuffer.record({
       kind: 'span',
@@ -290,6 +294,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       limitManager,
       signalBuffer,
     });
+    instrumentation.enable();
 
     signalBuffer.record({
       kind: 'span',
@@ -314,6 +319,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       limitManager,
       signalBuffer,
     });
+    instrumentation.enable();
 
     triggerEntries([makeEntry({ startTime: 200, duration: 50 })]);
 
@@ -335,6 +341,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([makeEntry({ startTime: 200, duration: 50 })]);
 
@@ -358,6 +365,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({ paintTime: undefined, presentationTime: undefined }),
@@ -379,6 +387,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([makeEntry({ paintTime: null, presentationTime: null })]);
 
@@ -406,6 +415,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       diag: diagLogger,
       limitManager,
     });
+    instrumentation.enable();
 
     expect(observerCallback).to.be.null;
 
@@ -417,6 +427,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     instrumentation.disable();
 
@@ -436,6 +447,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       perf,
       limitManager: customLimitManager,
     });
+    instrumentation.enable();
 
     triggerEntries([
       makeEntry({ navigationId: 0 }),
@@ -453,6 +465,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
     const firstCallback = observerCallback;
 
     instrumentation.enable();
@@ -478,6 +491,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       diag: diagLogger,
       limitManager,
     });
+    instrumentation.enable();
 
     expect(diagLogger.getErrorLogs()[0]).to.equal('failed to enable');
 
@@ -490,6 +504,7 @@ describe('SoftNavigationPerformanceInstrumentation', () => {
       perf,
       limitManager,
     });
+    instrumentation.enable();
 
     const firstCallback = observerCallback;
 
@@ -579,6 +594,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     expect(eventObserveOptions).to.deep.include({
       type: 'event',
@@ -599,6 +615,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     // Simulate: user clicks at t=100, navigation commits at t=150
     clock.tick(150);
@@ -634,6 +651,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     // Click window is [100, 150] (navigation commits at t=150 below).
     signalBuffer.record({
@@ -685,6 +703,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     clock.tick(150);
     triggerCurrentEntryChange();
@@ -706,6 +725,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     clock.tick(500);
     triggerCurrentEntryChange();
@@ -729,6 +749,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     mockNavigation.currentEntry = null;
     clock.tick(150);
@@ -753,6 +774,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     // Navigation at t=0 (will be older than 60 s by the time the click arrives).
     triggerCurrentEntryChange();
@@ -792,6 +814,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     clock.tick(150);
     triggerCurrentEntryChange();
@@ -817,6 +840,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     clock.tick(150);
     triggerCurrentEntryChange();
@@ -839,6 +863,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     instrumentation.disable();
 
@@ -864,6 +889,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     clock.tick(150);
     triggerCurrentEntryChange();
@@ -896,6 +922,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     expect(diagLogger.getErrorLogs()[0]).to.equal('failed to enable polyfill');
     expect(currentEntryChangeListeners).to.have.length(0);
@@ -912,6 +939,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     mockNavigation.currentEntry = { url: 'https://example.com/first' };
     clock.tick(150);
@@ -945,6 +973,7 @@ describe('SoftNavigationPerformanceInstrumentation — polyfill', () => {
         location: { href: 'https://example.com', pathname: '/' },
       },
     });
+    instrumentation.enable();
 
     // Two navigations at distinct timestamps so each click entry matches one.
     clock.tick(150); // t = 150

--- a/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/soft-navigation-performance/SoftNavigationPerformanceInstrumentation/SoftNavigationPerformanceInstrumentation.ts
@@ -85,10 +85,6 @@ export class SoftNavigationPerformanceInstrumentation extends EmbraceInstrumenta
 
     this._navigationHost = navigationHost;
     this._signalBuffer = signalBuffer;
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   public override enable(): void {

--- a/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.test.ts
@@ -156,6 +156,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should create two buffered observers for mark and measure', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
 
     expect(markObserveOptions).to.deep.equal({ type: 'mark', buffered: true });
     expect(measureObserveOptions).to.deep.equal({
@@ -174,6 +175,7 @@ describe('UserTimingInstrumentation', () => {
       perf,
       diag: diagLogger,
     });
+    instrumentation.enable();
 
     expect(markObserveOptions).to.be.null;
     expect(measureObserveOptions).to.not.be.null;
@@ -191,6 +193,7 @@ describe('UserTimingInstrumentation', () => {
       perf,
       diag: diagLogger,
     });
+    instrumentation.enable();
 
     expect(markObserveOptions).to.not.be.null;
     expect(measureObserveOptions).to.be.null;
@@ -208,6 +211,7 @@ describe('UserTimingInstrumentation', () => {
       perf,
       diag: diagLogger,
     });
+    instrumentation.enable();
 
     expect(markObserveOptions).to.be.null;
     expect(measureObserveOptions).to.be.null;
@@ -218,6 +222,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should emit a log for a mark entry', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
 
     triggerMarkEntries([
       makeMark({ name: 'my-mark', startTime: 150, duration: 0 }),
@@ -243,6 +248,7 @@ describe('UserTimingInstrumentation', () => {
     const instrumentation = new UserTimingInstrumentation({
       perf: timeOriginPerf,
     });
+    instrumentation.enable();
 
     triggerMarkEntries([
       makeMark({ name: 'timed-mark', startTime: 150, duration: 0 }),
@@ -256,6 +262,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should create a span for a measure entry', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
 
     triggerMeasureEntries([
       makeMeasure({ name: 'my-measure', startTime: 50, duration: 300 }),
@@ -285,6 +292,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should set detail as a span attribute for measure entries with detail', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
 
     triggerMeasureEntries([
       makeMeasure({
@@ -303,6 +311,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should deduplicate entries with the same name on the same URL', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
 
     triggerMarkEntries([
       makeMark({ name: 'auth-start' }),
@@ -317,6 +326,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should allow the same name after URL changes', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
     const originalHref = location.href;
 
     triggerMarkEntries([makeMark({ name: 'page-load' })]);
@@ -341,6 +351,7 @@ describe('UserTimingInstrumentation', () => {
       perf,
       limitManager: capLimitManager,
     });
+    instrumentation.enable();
 
     triggerMarkEntries(
       Array.from({ length: markCap + 2 }, (_, i) =>
@@ -366,6 +377,7 @@ describe('UserTimingInstrumentation', () => {
       perf,
       limitManager: capLimitManager,
     });
+    instrumentation.enable();
 
     triggerMeasureEntries(
       Array.from({ length: measureCap + 2 }, (_, i) =>
@@ -388,6 +400,7 @@ describe('UserTimingInstrumentation', () => {
       perf,
       limitManager: capLimitManager,
     });
+    instrumentation.enable();
 
     triggerMarkEntries(
       Array.from({ length: markCap }, (_, i) =>
@@ -407,6 +420,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should not enforce cap when no limitManager is provided', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
 
     // Without a limitManager, all entries should be emitted
     triggerMarkEntries(
@@ -420,6 +434,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should not emit after disable', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
     instrumentation.disable();
 
     triggerMarkEntries([makeMark({ name: 'late-mark' })]);
@@ -430,6 +445,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should serialize detail as JSON string in log body', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
 
     triggerMarkEntries([
       makeMark({ name: 'auth', detail: { phase: 'login', attempt: 2 } }),
@@ -446,6 +462,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should not set body when detail is null', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
 
     triggerMarkEntries([makeMark({ name: 'no-detail', detail: null })]);
 
@@ -458,6 +475,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should not set body when detail is undefined', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
 
     const entry = makeMark({ name: 'no-detail-undef' });
     (entry as unknown as Record<string, unknown>)['detail'] = undefined;
@@ -472,6 +490,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should disconnect both observers on disable', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
 
     expect(markObserverDisconnected).to.be.false;
     expect(measureObserverDisconnected).to.be.false;
@@ -484,6 +503,7 @@ describe('UserTimingInstrumentation', () => {
 
   it('should reset deduplication state after disable and re-enable', () => {
     const instrumentation = new UserTimingInstrumentation({ perf });
+    instrumentation.enable();
 
     triggerMarkEntries([makeMark({ name: 'once' })]);
     expect(memoryExporter.getFinishedLogRecords()).to.have.length(1);
@@ -511,6 +531,7 @@ describe('UserTimingInstrumentation', () => {
   describe('allowedEntries filter', () => {
     it('should capture all entries when no filter is provided', () => {
       const instrumentation = new UserTimingInstrumentation({ perf });
+      instrumentation.enable();
 
       triggerMarkEntries([
         makeMark({ name: 'app-start' }),
@@ -526,6 +547,7 @@ describe('UserTimingInstrumentation', () => {
         perf,
         allowedEntries: ['app-start', 'app-ready'],
       });
+      instrumentation.enable();
 
       triggerMarkEntries([
         makeMark({ name: 'app-start' }),
@@ -547,6 +569,7 @@ describe('UserTimingInstrumentation', () => {
         perf,
         allowedEntries: [],
       });
+      instrumentation.enable();
 
       triggerMarkEntries([makeMark({ name: 'app-start' })]);
       triggerMeasureEntries([makeMeasure({ name: 'render' })]);
@@ -560,6 +583,7 @@ describe('UserTimingInstrumentation', () => {
         perf,
         allowedEntries: (entry) => entry.name.startsWith('app-'),
       });
+      instrumentation.enable();
 
       triggerMarkEntries([
         makeMark({ name: 'app-start' }),
@@ -585,6 +609,7 @@ describe('UserTimingInstrumentation', () => {
           return true;
         },
       });
+      instrumentation.enable();
 
       const mark = makeMark({ name: 'app-start', startTime: 42 });
       triggerMarkEntries([mark]);
@@ -601,6 +626,7 @@ describe('UserTimingInstrumentation', () => {
         perf,
         allowedEntries: ['app-start'],
       });
+      instrumentation.enable();
 
       // 'vendor' is filtered out — should not consume a dedup slot
       triggerMarkEntries([
@@ -618,6 +644,7 @@ describe('UserTimingInstrumentation', () => {
         perf,
         allowedEntries: (entry) => entry.entryType === 'mark',
       });
+      instrumentation.enable();
 
       triggerMarkEntries([makeMark({ name: 'app-start' })]);
       triggerMeasureEntries([makeMeasure({ name: 'render' })]);

--- a/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/user-timing/UserTimingInstrumentation/UserTimingInstrumentation.ts
@@ -41,10 +41,6 @@ export class UserTimingInstrumentation extends EmbraceInstrumentationBase {
       config: {},
     });
     this._allowedEntries = allowedEntries;
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   public override onEnable(): void {

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -3905,8 +3905,8 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
-      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
+      instrumentation.enable();
 
       const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -3944,8 +3944,8 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
-      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
+      instrumentation.enable();
 
       const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -3980,8 +3980,8 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
-      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
+      instrumentation.enable();
 
       const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.test.ts
@@ -87,6 +87,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     void expect(clsStub.calledOnce).to.be.true;
     const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
@@ -131,6 +132,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -182,6 +184,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -212,6 +215,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -245,6 +249,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = fcpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -296,6 +301,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -348,6 +354,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
     clock.tick(5000);
@@ -396,6 +403,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
     clock.tick(5000);
@@ -432,6 +440,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
     clock.tick(5000);
@@ -479,6 +488,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -587,6 +597,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
 
       const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -634,6 +645,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
 
       const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -679,6 +691,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
 
       const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -727,6 +740,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
 
       const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -747,6 +761,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
 
       const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -768,6 +783,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
 
       const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -787,6 +803,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
 
       const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -811,6 +828,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -890,6 +908,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlDocument,
     });
+    instrumentation.enable();
 
     const pageTrackFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
     const emitFunc = ttfbStub.getCall(1).args[0] as WebVitalOnReport;
@@ -950,6 +969,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -1013,6 +1033,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -1073,6 +1094,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -1133,6 +1155,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -1193,6 +1216,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -1257,6 +1281,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -1316,6 +1341,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -1375,6 +1401,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -1453,6 +1480,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -1513,6 +1541,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const clsReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
     const lcpReportFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
@@ -1571,6 +1600,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     // Call enable() multiple times
     instrumentation.enable();
@@ -1586,6 +1616,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     instrumentation.disable();
     instrumentation.enable();
@@ -1602,6 +1633,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -1643,6 +1675,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -1671,6 +1704,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     instrumentation.disable();
 
@@ -1686,6 +1720,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlDocument,
     });
+    instrumentation.enable();
 
     void expect(clsStub.calledTwice).to.be.true;
     const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
@@ -1733,6 +1768,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlDocument,
     });
+    instrumentation.enable();
 
     const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
     const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
@@ -1785,6 +1821,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
     clock.tick(5000);
@@ -1857,6 +1894,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
     clock.tick(5000);
@@ -1901,6 +1939,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
     clock.tick(5000);
@@ -1940,6 +1979,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
     clock.tick(5000);
@@ -1998,6 +2038,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const emitFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
     clock.tick(5000);
@@ -2034,6 +2075,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlDocument,
     });
+    instrumentation.enable();
 
     void expect(fcpStub.calledTwice).to.be.true;
     const pageTrackFunc = fcpStub.getCall(0).args[0] as WebVitalOnReport;
@@ -2088,6 +2130,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlDocument,
     });
+    instrumentation.enable();
 
     void expect(lcpStub.calledTwice).to.be.true;
     const pageTrackFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
@@ -2144,6 +2187,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlDocument,
     });
+    instrumentation.enable();
 
     void expect(inpStub.calledTwice).to.be.true;
     const pageTrackFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
@@ -2211,6 +2255,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlDocument,
     });
+    instrumentation.enable();
 
     void expect(ttfbStub.calledTwice).to.be.true;
     const pageTrackFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
@@ -2291,6 +2336,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlDocument,
     });
+    instrumentation.enable();
 
     const clsPageTrack = clsStub.getCall(0).args[0] as WebVitalOnReport;
     const clsEmit = clsStub.getCall(1).args[0] as WebVitalOnReport;
@@ -2368,6 +2414,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -2418,6 +2465,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -2454,6 +2502,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = fcpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -2494,6 +2543,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -2531,6 +2581,7 @@ describe('WebVitalsInstrumentation', () => {
       urlAttribution: false,
       includeRawAttribution: false,
     });
+    instrumentation.enable();
 
     const metricReportFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -2557,6 +2608,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlAttribution: false,
     });
+    instrumentation.enable();
 
     expect(inpStub.callCount).to.equal(1);
     expect(lcpStub.callCount).to.equal(1);
@@ -2576,6 +2628,7 @@ describe('WebVitalsInstrumentation', () => {
         urlDocument: testDocument,
         pageManager,
       });
+      instrumentation.enable();
 
       void expect(inpStub.callCount).to.equal(2);
       const changeFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
@@ -2643,6 +2696,7 @@ describe('WebVitalsInstrumentation', () => {
         urlDocument: testDocument,
         pageManager,
       });
+      instrumentation.enable();
 
       void expect(lcpStub.callCount).to.equal(2);
       const changeFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
@@ -2702,6 +2756,7 @@ describe('WebVitalsInstrumentation', () => {
         urlDocument: testDocument,
         pageManager,
       });
+      instrumentation.enable();
 
       void expect(clsStub.callCount).to.equal(2);
       const changeFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
@@ -2755,6 +2810,7 @@ describe('WebVitalsInstrumentation', () => {
         urlDocument: testDocument,
         pageManager,
       });
+      instrumentation.enable();
 
       void expect(fcpStub.callCount).to.equal(2);
       const changeFunc = fcpStub.getCall(0).args[0] as WebVitalOnReport;
@@ -2812,6 +2868,7 @@ describe('WebVitalsInstrumentation', () => {
         urlDocument: testDocument,
         pageManager,
       });
+      instrumentation.enable();
 
       void expect(ttfbStub.callCount).to.equal(2);
       const changeFunc = ttfbStub.getCall(0).args[0] as WebVitalOnReport;
@@ -2887,6 +2944,7 @@ describe('WebVitalsInstrumentation', () => {
         urlDocument,
         pageManager,
       });
+      instrumentation.enable();
 
       void expect(clsStub.calledTwice).to.be.true;
       const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
@@ -2930,6 +2988,7 @@ describe('WebVitalsInstrumentation', () => {
         urlDocument,
         pageManager,
       });
+      instrumentation.enable();
 
       const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
       const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
@@ -2969,6 +3028,7 @@ describe('WebVitalsInstrumentation', () => {
         urlDocument,
         pageManager,
       });
+      instrumentation.enable();
 
       const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
       const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
@@ -3017,6 +3077,7 @@ describe('WebVitalsInstrumentation', () => {
         urlDocument,
         pageManager,
       });
+      instrumentation.enable();
 
       const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
       const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
@@ -3053,6 +3114,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlDocument: { URL: 'https://example.com/page-a' },
       });
+      instrumentation.enable();
 
       // reportAllChanges listener registered first, emission listener second
       void expect(clsStub.calledTwice).to.be.true;
@@ -3090,6 +3152,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlDocument,
       });
+      instrumentation.enable();
 
       const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
       const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
@@ -3142,6 +3205,7 @@ describe('WebVitalsInstrumentation', () => {
         urlDocument: { URL: 'https://example.com/products/123' },
         pageManager: mockPageManager,
       });
+      instrumentation.enable();
 
       const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
       const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
@@ -3180,6 +3244,7 @@ describe('WebVitalsInstrumentation', () => {
         urlAttribution: false,
         urlDocument: { URL: 'https://example.com/page-a' },
       });
+      instrumentation.enable();
 
       void expect(clsStub.calledOnce).to.be.true;
       const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
@@ -3208,6 +3273,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlDocument: { URL: 'https://example.com/page-a' },
       });
+      instrumentation.enable();
 
       // Only call the emission listener, skip the reportAllChanges listener
       const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
@@ -3252,6 +3318,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
 
       expect(clsStub.callCount).to.equal(0);
       expect(diag.getDebugLogs()).to.include(
@@ -3269,6 +3336,7 @@ describe('WebVitalsInstrumentation', () => {
       listeners: mockWebVitalListeners,
       urlDocument,
     });
+    instrumentation.enable();
 
     const pageTrackFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
     const emitFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
@@ -3313,6 +3381,7 @@ describe('WebVitalsInstrumentation', () => {
           };
         },
       });
+      instrumentation.enable();
 
       const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -3343,6 +3412,7 @@ describe('WebVitalsInstrumentation', () => {
           throw new Error('hook error');
         },
       });
+      instrumentation.enable();
 
       const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -3395,6 +3465,7 @@ describe('WebVitalsInstrumentation', () => {
           listeners: mockWebVitalListeners,
           urlDocument,
         });
+        instrumentation.enable();
 
         void expect(clsStub.calledTwice).to.be.true;
         expect(clsStub.getCall(0).args[1]).to.deep.equal({
@@ -3414,6 +3485,7 @@ describe('WebVitalsInstrumentation', () => {
           listeners: mockWebVitalListeners,
           urlDocument,
         });
+        instrumentation.enable();
 
         void expect(ttfbStub.calledTwice).to.be.true;
         expect(ttfbStub.getCall(0).args[1]).to.deep.equal({
@@ -3434,6 +3506,7 @@ describe('WebVitalsInstrumentation', () => {
           urlDocument,
           reportSoftNavs: false,
         });
+        instrumentation.enable();
 
         expect(clsStub.getCall(0).args[1]).to.deep.equal({
           reportAllChanges: true,
@@ -3452,6 +3525,7 @@ describe('WebVitalsInstrumentation', () => {
           listeners: mockWebVitalListeners,
           urlDocument,
         });
+        instrumentation.enable();
 
         expect(clsStub.getCall(0).args[1]).to.deep.equal({
           reportAllChanges: true,
@@ -3470,6 +3544,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
 
       const emitFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -3504,6 +3579,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
 
       const emitFunc = inpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -3545,6 +3621,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
 
       const emitFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
 
@@ -3579,6 +3656,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlDocument: { URL: 'https://example.com/page-a' },
       });
+      instrumentation.enable();
 
       const pageTrackFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
       const emitFunc = lcpStub.getCall(1).args[0] as WebVitalOnReport;
@@ -3622,6 +3700,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlDocument: { URL: 'https://example.com/page-a' },
       });
+      instrumentation.enable();
 
       const pageTrackFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
       const emitFunc = lcpStub.getCall(1).args[0] as WebVitalOnReport;
@@ -3661,6 +3740,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlDocument: { URL: 'https://example.com/page-a' },
       });
+      instrumentation.enable();
 
       const pageTrackFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
       const emitFunc = lcpStub.getCall(1).args[0] as WebVitalOnReport;
@@ -3700,6 +3780,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlDocument: { URL: 'https://example.com/page-a' },
       });
+      instrumentation.enable();
 
       const pageTrackFunc = lcpStub.getCall(0).args[0] as WebVitalOnReport;
       const emitFunc = lcpStub.getCall(1).args[0] as WebVitalOnReport;
@@ -3742,6 +3823,7 @@ describe('WebVitalsInstrumentation', () => {
         urlDocument: testDocument,
         pageManager,
       });
+      instrumentation.enable();
 
       const changeFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
       const finalFunc = clsStub.getCall(1).args[0] as WebVitalOnReport;
@@ -3823,6 +3905,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
 
       const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
@@ -3861,6 +3944,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
 
       const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;
@@ -3896,6 +3980,7 @@ describe('WebVitalsInstrumentation', () => {
         listeners: mockWebVitalListeners,
         urlAttribution: false,
       });
+      instrumentation.enable();
       instrumentation.setUserSessionManager(userSessionManager);
 
       const emitFunc = clsStub.getCall(0).args[0] as WebVitalOnReport;

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -344,10 +344,6 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
       reportSoftNavs && isEntryTypeSupported('soft-navigation');
     this._pageManager = pageManager ?? page.getPageManager();
     this._applyCustomLogRecordData = applyCustomLogRecordData;
-
-    if (this._config.enabled !== false) {
-      this.enable();
-    }
   }
 
   public override onDisable(): void {

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/WebVitalsInstrumentation.ts
@@ -327,14 +327,13 @@ export class WebVitalsInstrumentation extends EmbraceInstrumentationBase {
     reportSoftNavs = true,
     pageManager,
     applyCustomLogRecordData,
-    ...config
   }: WebVitalsInstrumentationConfig = {}) {
     super({
       instrumentationName: 'WebVitalsInstrumentation',
       instrumentationVersion: '1.0.0',
       diag,
       perf,
-      config,
+      config: {},
     });
     this._listeners = listeners;
     this._urlDocument = urlDocument ?? window.document;

--- a/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
+++ b/packages/web-sdk/src/instrumentations/web-vitals/WebVitalsInstrumentation/types.ts
@@ -20,7 +20,10 @@ export type WebVitalListeners = Record<
   ((onReport: WebVitalOnReport, opts?: ReportOpts) => void) | undefined
 >;
 
-export interface WebVitalsInstrumentationConfig extends InstrumentationConfig {
+// 'enabled' is excluded: construction only wires the instrumentation up, and
+// registerInstrumentations starts it regardless of any flag passed here.
+export interface WebVitalsInstrumentationConfig
+  extends Omit<InstrumentationConfig, 'enabled'> {
   // OTel upstream options
   /**
    * @experimental

--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -372,11 +372,15 @@ describe('initSDK', () => {
 
   it('should allow setting custom instrumentations', async () => {
     const instrumentation = new FakeInstrumentation();
+    // document-load is omitted here and below because it spans the harness
+    // page's real resource entries, which would swamp the exact span counts.
     const result = initSDK({
       logExporters: [logExporter],
       spanExporters: [spanExporter],
       instrumentations: [instrumentation],
-      defaultInstrumentationConfig: { omit: new Set(['web-vital']) },
+      defaultInstrumentationConfig: {
+        omit: new Set(['web-vital', 'document-load']),
+      },
     });
     void expect(result).not.to.be.false;
 
@@ -403,7 +407,9 @@ describe('initSDK', () => {
       logProcessors: [new FakeLogRecordProcessor()],
       spanProcessors: [new FakeSpanProcessor()],
       instrumentations: [instrumentation],
-      defaultInstrumentationConfig: { omit: new Set(['web-vital']) },
+      defaultInstrumentationConfig: {
+        omit: new Set(['web-vital', 'document-load']),
+      },
     });
     void expect(result).not.to.be.false;
 
@@ -529,7 +535,9 @@ describe('initSDK', () => {
       appID: 'abc12',
       logExporters: [logExporter],
       spanExporters: [spanExporter],
-      defaultInstrumentationConfig: { omit: new Set(['web-vital']) },
+      defaultInstrumentationConfig: {
+        omit: new Set(['web-vital', 'document-load']),
+      },
     });
     void expect(result).not.to.be.false;
 
@@ -616,6 +624,7 @@ describe('initSDK', () => {
   it('should setup a default context manager when none is provided', async () => {
     const result = initSDK({
       spanExporters: [spanExporter],
+      defaultInstrumentationConfig: { omit: new Set(['document-load']) },
     });
     void expect(result).not.to.be.false;
 

--- a/packages/web-sdk/src/sdk/initSDK.test.ts
+++ b/packages/web-sdk/src/sdk/initSDK.test.ts
@@ -2214,27 +2214,30 @@ describe('isolated instances', () => {
       // Two emb-session-part spans are expected per instance: the init part
       // is ended explicitly, then a fresh activity part is opened and ended.
       // Each instance owns its own userSessionManager, so the parts are
-      // isolated per instance and not shared. The activity part resumes on
-      // the same route, so EmbracePageManager re-notifies NavigationInstrumentation
-      // on session-part-start, giving it its own route span too.
-      expect(finishedSpans).to.have.lengthOf(5);
+      // isolated per instance and not shared. Each part gets its own route
+      // span: the first when registerInstrumentations enables
+      // NavigationInstrumentation on the already-current route, the second
+      // because the activity part resumes on that same route and
+      // EmbracePageManager re-notifies on session-part-start.
+      expect(finishedSpans).to.have.lengthOf(6);
       expect(finishedSpans[0].name).to.equal('some span');
-      expect(finishedSpans[1].name).to.equal('emb-session-part');
+      expect(finishedSpans[1].name).to.equal(window.location.pathname);
+      expect(finishedSpans[2].name).to.equal('emb-session-part');
       expect(
-        finishedSpans[1].attributes['emb.session_part_start_reason'],
+        finishedSpans[2].attributes['emb.session_part_start_reason'],
       ).to.equal('init');
       expect(
-        finishedSpans[1].attributes['emb.session_part_end_reason'],
+        finishedSpans[2].attributes['emb.session_part_end_reason'],
       ).to.equal('web_foreground_inactivity');
-      expect(finishedSpans[2].name).to.equal(window.location.pathname);
-      expect(finishedSpans[3].name).to.equal('emb-session-part');
+      expect(finishedSpans[3].name).to.equal(window.location.pathname);
+      expect(finishedSpans[4].name).to.equal('emb-session-part');
       expect(
-        finishedSpans[3].attributes['emb.session_part_start_reason'],
+        finishedSpans[4].attributes['emb.session_part_start_reason'],
       ).to.equal('web_activity');
       expect(
-        finishedSpans[3].attributes['emb.session_part_end_reason'],
+        finishedSpans[4].attributes['emb.session_part_end_reason'],
       ).to.equal('web_foreground_inactivity');
-      expect(finishedSpans[4].name).to.equal('my span');
+      expect(finishedSpans[5].name).to.equal('my span');
     };
 
     await checkInstanceTelemetry(

--- a/packages/web-sdk/src/sdk/setupDefaultInstrumentations.test.ts
+++ b/packages/web-sdk/src/sdk/setupDefaultInstrumentations.test.ts
@@ -202,4 +202,29 @@ describe('setupDefaultInstrumentations', () => {
       }
     });
   });
+
+  describe('enabling', () => {
+    /*
+     * registerInstrumentations wires the tracer and logger providers onto each
+     * instrumentation and only then enables the ones still reporting themselves
+     * disabled. Anything already enabled by the time it is returned from here
+     * would emit its start-up telemetry into a provider that records nothing,
+     * and the once-per-page guards these instrumentations use mean it would
+     * never be retried.
+     */
+    it('returns instrumentations that are not enabled yet', () => {
+      const instrumentations = setupDefaultInstrumentations(
+        { 'empty-root': { rootNode: document.body } },
+        makeSetupArgs(),
+      );
+
+      expect(instrumentations).to.have.length.greaterThan(0);
+      for (const instrumentation of instrumentations) {
+        expect(
+          instrumentation.getConfig().enabled,
+          `${instrumentation.instrumentationName} should not be enabled yet`,
+        ).to.not.equal(true);
+      }
+    });
+  });
 });

--- a/packages/web-sdk/src/sdk/setupDefaultInstrumentations.test.ts
+++ b/packages/web-sdk/src/sdk/setupDefaultInstrumentations.test.ts
@@ -223,7 +223,7 @@ describe('setupDefaultInstrumentations', () => {
         expect(
           instrumentation.getConfig().enabled,
           `${instrumentation.instrumentationName} should not be enabled yet`,
-        ).to.not.equal(true);
+        ).to.equal(false);
       }
     });
   });

--- a/packages/web-sdk/src/sdk/setupDefaultInstrumentations.ts
+++ b/packages/web-sdk/src/sdk/setupDefaultInstrumentations.ts
@@ -118,10 +118,18 @@ export const setupDefaultInstrumentations = (
     );
   }
 
+  /*
+   * The upstream instrumentations patch fetch and XHR from their constructors
+   * unless told to start disabled. registerInstrumentations attaches the
+   * providers and then enables them, which keeps any request made during
+   * start-up out of a tracer that records nothing. Embrace instrumentations get
+   * this from EmbraceInstrumentationBase and need no flag here.
+   */
   if (!config.omit?.has('@opentelemetry/instrumentation-fetch')) {
     instrumentations.push(
       new FetchInstrumentation({
         ...config['@opentelemetry/instrumentation-fetch'],
+        enabled: false,
         ignoreUrls: [
           ...(config['network']?.ignoreUrls ?? []),
           ...(config['@opentelemetry/instrumentation-fetch']?.ignoreUrls ?? []),
@@ -134,6 +142,7 @@ export const setupDefaultInstrumentations = (
     instrumentations.push(
       new XMLHttpRequestInstrumentation({
         ...config['@opentelemetry/instrumentation-xml-http-request'],
+        enabled: false,
         ignoreUrls: [
           ...(config['network']?.ignoreUrls ?? []),
           ...(config['@opentelemetry/instrumentation-xml-http-request']

--- a/packages/web-sdk/src/sdk/types.ts
+++ b/packages/web-sdk/src/sdk/types.ts
@@ -416,10 +416,10 @@ export interface SetupDefaultInstrumentationsArgs {
   signalBuffer?: SignalBuffer;
 }
 
-/*
-  'enabled' is not accepted anywhere in here. It is misleading, since we call
-  `registerInstrumentations` for every instrumentation we include and that
-  starts them regardless. Use `omit` to turn a default instrumentation off.
+/**
+ * 'enabled' is not accepted anywhere in here. It is misleading, since we call
+ * `registerInstrumentations` for every instrumentation we include and that
+ * starts them regardless. Use `omit` to turn a default instrumentation off.
  */
 export interface DefaultInstrumentationConfig {
   omit?: Set<OptionalInstrumentations>;

--- a/packages/web-sdk/src/sdk/types.ts
+++ b/packages/web-sdk/src/sdk/types.ts
@@ -416,6 +416,11 @@ export interface SetupDefaultInstrumentationsArgs {
   signalBuffer?: SignalBuffer;
 }
 
+/*
+  'enabled' is not accepted anywhere in here. It is misleading, since we call
+  `registerInstrumentations` for every instrumentation we include and that
+  starts them regardless. Use `omit` to turn a default instrumentation off.
+ */
 export interface DefaultInstrumentationConfig {
   omit?: Set<OptionalInstrumentations>;
   exception?: GlobalExceptionInstrumentationArgs;
@@ -429,7 +434,7 @@ export interface DefaultInstrumentationConfig {
   'element-timing'?: ElementTimingInstrumentationArgs;
   'server-timing'?: ServerTimingInstrumentationArgs;
   'soft-navigation-performance'?: SoftNavigationPerformanceInstrumentationArgs;
-  'document-load'?: DocumentLoadInstrumentationConfig;
+  'document-load'?: Omit<DocumentLoadInstrumentationConfig, 'enabled'>;
   'dom-state'?: DOMStateInstrumentationArgs;
   navigation?: NavigationInstrumentationArgs;
 
@@ -437,11 +442,6 @@ export interface DefaultInstrumentationConfig {
   // '@opentelemetry/instrumentation-xml-http-request' to just be specified once
   network?: NetworkInstrumentationArgs;
 
-  /*
-    Remove 'enabled' from the accepted config for the @opentelemetry instrumentations. This parameter is misleading
-    since we are going to call `registerInstrumentations` for every instrumentation we include here even if their
-    config has enabled=false. Instead, use `omit` to specify which default instrumentations should be turned off.
-   */
   '@opentelemetry/instrumentation-fetch'?: Omit<
     FetchInstrumentationConfig,
     'enabled'

--- a/packages/web-sdk/tests/utils/FakeInstrumentation.ts
+++ b/packages/web-sdk/tests/utils/FakeInstrumentation.ts
@@ -10,10 +10,6 @@ export class FakeInstrumentation extends EmbraceInstrumentationBase {
       instrumentationVersion: '1.0.0',
       config: {},
     });
-
-    if (this._config.enabled) {
-      this.enable();
-    }
   }
 
   public override onDisable(): void {


### PR DESCRIPTION
## What problem is this solving?

Instrumentations enabled themselves in their constructors, but initSDK only wires the tracer and logger providers onto them afterwards, via registerInstrumentations. Anything emitted during start-up (the initial route span, document-load spans, server timings) landed in a provider that records nothing and was silently dropped. EMBR-13620 hit a customer running a non-global second instance, which takes that path on every init.

## Short description of changes

- Instrumentations construct disabled; registerInstrumentations attaches providers and then enables whatever still reports itself disabled. The enabled state is backed by `config.enabled`, the exact flag upstream reads, so the two cannot disagree.
- The upstream fetch and XHR instrumentations get `enabled: false` for the same reason, and the silently-ignored `enabled` knob is refused across the Embrace configs.
- `setConfig` now preserves the lifecycle state, so replacing config cannot flip an instrumentation to enabled without `onEnable` running.
- DocumentLoadInstrumentation collects at enable by reading the finished navigation entry off the timeline, instead of a deferred microtask; DOMStateInstrumentation drops its re-register workaround.
- Test suites mirror the production wiring order, and the initSDK exact-count tests omit document-load, whose spans previously vanished into the provider race and now genuinely record.

## How has this been tested?

Unit suites for every touched instrumentation plus initSDK and setupDefaultInstrumentations pass, including a sweep asserting every default instrumentation still reports disabled until registerInstrumentations enables it. Integration suite passes against the built artifacts (300 passed across the bundler matrix), including the goldens that pin documentLoad/documentFetch/resourceFetch spans.

## Checklist

- [ ] Documentation added
- [x] Tests added
