### PR TITLE
EMBR-13804 fix(server): answer /v2/config and 404 unmatched paths

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -32,6 +32,11 @@ const mimeTypes: Record<string, string> = {
 
 const receivedSpans: ReceivedSpans = {};
 
+// `threshold` is the only required field and maps to samplingPct; 100 keeps all
+// local telemetry flowing. The etag is fixed so a reload takes the 304 path.
+const REMOTE_CONFIG = { threshold: 100 };
+const REMOTE_CONFIG_ETAG = '"local-collector-1"';
+
 function serveFile(res: ServerResponse, filePath: string) {
   readFile(filePath, (err, data) => {
     if (err) {
@@ -78,6 +83,9 @@ const server = createServer((req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, DELETE');
   res.setHeader('Access-Control-Allow-Headers', '*');
+  // ETag is not CORS-safelisted, so without this the demo on another port reads
+  // it back as null and never sends If-None-Match.
+  res.setHeader('Access-Control-Expose-Headers', 'ETag');
 
   if (req.method === 'OPTIONS') {
     res.writeHead(204);
@@ -106,6 +114,21 @@ const server = createServer((req, res) => {
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(receivedSpans));
+    return;
+  }
+
+  if (pathname === '/v2/config') {
+    if (req.headers['if-none-match'] === REMOTE_CONFIG_ETAG) {
+      res.writeHead(304, { ETag: REMOTE_CONFIG_ETAG });
+      res.end();
+      return;
+    }
+
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      ETag: REMOTE_CONFIG_ETAG,
+    });
+    res.end(JSON.stringify(REMOTE_CONFIG));
     return;
   }
 
@@ -213,6 +236,11 @@ const server = createServer((req, res) => {
     serveFile(res, join(__dirname, pathname));
     return;
   }
+
+  // Every branch above returns, so reaching here means nothing matched. Without
+  // this the request stays open with no response until the client gives up.
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not Found');
 });
 
 server.listen(PORT, () => {

--- a/server/server.ts
+++ b/server/server.ts
@@ -32,9 +32,19 @@ const mimeTypes: Record<string, string> = {
 
 const receivedSpans: ReceivedSpans = {};
 
-// `threshold` is the only required field and maps to samplingPct; 100 keeps all
-// local telemetry flowing. The etag is fixed so a reload takes the 304 path.
-const REMOTE_CONFIG = { threshold: 100 };
+// Mirrors the production payload, narrowed to the fields this SDK reads. The
+// user_session values match the SDK's own defaults, so they change nothing at
+// runtime but do exercise parseRemoteConfig's optional branches and the manager's
+// clamping, which stay dead when the block is absent. The etag is fixed so a
+// reload takes the 304 path.
+const REMOTE_CONFIG = {
+  threshold: 100,
+  user_session: {
+    max_duration_seconds: 43200,
+    inactivity_timeout_seconds: 1800,
+    web_foreground_inactivity_timeout_seconds: 1800,
+  },
+};
 const REMOTE_CONFIG_ETAG = '"local-collector-1"';
 
 function serveFile(res: ServerResponse, filePath: string) {

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -198,11 +198,12 @@ const logBreadcrumbs = (sessionPartSpan: ISpan) => {
 const SEVERITY_NUMBER_WARN = 13;
 
 const LOG_RECORD_IGNORED_KEYS = [
-  'app.surface.label',
-  'log.record.uid',
+  'emb.js_file_bundle_ids',
+  'emb.session_part_id',
+  'emb.stacktrace.js',
   'emb.user_session_id',
   'emb.user_session_previous_id',
-  'emb.session_part_id',
+  'log.record.uid',
   'user.id',
 ];
 
@@ -228,7 +229,7 @@ const logReceivedLogRecords = (logRecords: ILogRecord[]) => {
       : '';
     const log =
       (record.severityNumber ?? 0) >= SEVERITY_NUMBER_WARN ? logWarn : logInfo;
-    log(`Log record: ${eventName}\n  ${parts.join('\n  ')}${body}`);
+    log(`LOG eventName: ${eventName}\n  ${parts.join('\n  ')}${body}`);
   }
 };
 

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "2CA0767E913DFDA82AA6C8F6A5E30E8A"
+              "stringValue": "3BC4FB0E60C4DA3ED0388332B3FC36A7"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "4f6b6efa3b74d88d7a122c10b827f649",
-              "spanId": "6d17a62e67b0bbc4",
+              "traceId": "2a021f01fdcf0bf6b4b663f073efedc7",
+              "spanId": "183e2083d64c437f",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787314518732000000",
-              "endTimeUnixNano": "1787314519723000000",
+              "startTimeUnixNano": "1787770818072000000",
+              "endTimeUnixNano": "1787770819043000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B8C04302EEDEE891619A9DAA7F648374"
+                    "stringValue": "3825F48343B38B4E817EAFBA74A913E7"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1787314518732
+                    "intValue": 1787770818071
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "93DFEB9F7832469F1A840D2626E4E15E"
+                    "stringValue": "B296EC87BAA7E79DECA907AB84F0C48B"
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "004E2FA78993B025E042946E835A8F15"
+                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
                   }
                 },
                 {
@@ -255,7 +255,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787314518891000000",
+                  "timeUnixNano": "1787770818240000000",
                   "droppedAttributesCount": 0
                 },
                 {
@@ -280,7 +280,7 @@
                     }
                   ],
                   "name": "click",
-                  "timeUnixNano": "1787314519331000000",
+                  "timeUnixNano": "1787770818683000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -301,13 +301,13 @@
           },
           "spans": [
             {
-              "traceId": "9bbdefbed3ce08d25992895c53cd8054",
-              "spanId": "b18592b8527e2f90",
-              "parentSpanId": "ade0c69d37ededbf",
+              "traceId": "1deeccb02e2d11c22f8934f0eb12047c",
+              "spanId": "818f720911d1e36a",
+              "parentSpanId": "19f41c49ddee19c6",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314518671000000",
-              "endTimeUnixNano": "1787314518677000000",
+              "startTimeUnixNano": "1787770818003000000",
+              "endTimeUnixNano": "1787770818010000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -336,7 +336,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "004E2FA78993B025E042946E835A8F15"
+                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
                   }
                 },
                 {
@@ -351,55 +351,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314518673000000",
+                  "timeUnixNano": "1787770818003000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314518678000000",
+                  "timeUnixNano": "1787770818009000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314518678000000",
+                  "timeUnixNano": "1787770818009000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314518678000000",
+                  "timeUnixNano": "1787770818009000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787314518674000000",
+                  "timeUnixNano": "1787770818003000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314518678000000",
+                  "timeUnixNano": "1787770818009000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314518678000000",
+                  "timeUnixNano": "1787770818009000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314518679000000",
+                  "timeUnixNano": "1787770818010000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314518679000000",
+                  "timeUnixNano": "1787770818010000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -412,13 +412,13 @@
               "flags": 257
             },
             {
-              "traceId": "9bbdefbed3ce08d25992895c53cd8054",
-              "spanId": "fd66e6221e72fb18",
-              "parentSpanId": "ade0c69d37ededbf",
+              "traceId": "1deeccb02e2d11c22f8934f0eb12047c",
+              "spanId": "2fc10c1d01007e34",
+              "parentSpanId": "19f41c49ddee19c6",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314518683000000",
-              "endTimeUnixNano": "1787314518696000000",
+              "startTimeUnixNano": "1787770818013000000",
+              "endTimeUnixNano": "1787770818028000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -429,13 +429,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DwCiF-Sl.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 425996
                   }
                 },
                 {
@@ -453,19 +453,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 425996
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 425923
+                    "intValue": 426296
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 425996
                   }
                 },
                 {
@@ -483,7 +483,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "004E2FA78993B025E042946E835A8F15"
+                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
                   }
                 },
                 {
@@ -498,49 +498,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314518683000000",
+                  "timeUnixNano": "1787770818014000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314518683000000",
+                  "timeUnixNano": "1787770818014000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314518683000000",
+                  "timeUnixNano": "1787770818014000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314518683000000",
+                  "timeUnixNano": "1787770818014000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314518683000000",
+                  "timeUnixNano": "1787770818014000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314518694000000",
+                  "timeUnixNano": "1787770818029000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314518696000000",
+                  "timeUnixNano": "1787770818029000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314518696000000",
+                  "timeUnixNano": "1787770818029000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -553,12 +553,294 @@
               "flags": 257
             },
             {
-              "traceId": "9bbdefbed3ce08d25992895c53cd8054",
-              "spanId": "ade0c69d37ededbf",
+              "traceId": "1deeccb02e2d11c22f8934f0eb12047c",
+              "spanId": "1235769cf966cc56",
+              "parentSpanId": "19f41c49ddee19c6",
+              "name": "resourceFetch",
+              "kind": 1,
+              "startTimeUnixNano": "1787770818018000000",
+              "endTimeUnixNano": "1787770818018000000",
+              "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/favicon.ico"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.request.initiator_type",
+                  "value": {
+                    "stringValue": "other"
+                  }
+                },
+                {
+                  "key": "http.response.body.size",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.response.size",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.response.decoded_body_size",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.response.cors_opaque",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {
+                    "stringValue": "/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {
+                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1787770818019000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1787770818019000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1787770818019000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1787770818019000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1787770818019000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1787770818019000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1787770818019000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1787770818019000000",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            },
+            {
+              "traceId": "1deeccb02e2d11c22f8934f0eb12047c",
+              "spanId": "6f12c1011f62102a",
+              "parentSpanId": "19f41c49ddee19c6",
+              "name": "resourceFetch",
+              "kind": 1,
+              "startTimeUnixNano": "1787770818069000000",
+              "endTimeUnixNano": "1787770818074000000",
+              "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/v2/config?appId=11111&osVersion=1&appVersion=1.0.0&deviceId=A65FF047234B941D7ED835074529CDFF"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 146
+                  }
+                },
+                {
+                  "key": "http.request.initiator_type",
+                  "value": {
+                    "stringValue": "fetch"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": 200
+                  }
+                },
+                {
+                  "key": "http.response.body.size",
+                  "value": {
+                    "intValue": 146
+                  }
+                },
+                {
+                  "key": "http.response.size",
+                  "value": {
+                    "intValue": 446
+                  }
+                },
+                {
+                  "key": "http.response.decoded_body_size",
+                  "value": {
+                    "intValue": 146
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {
+                    "stringValue": "/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {
+                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1787770818068000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1787770818068000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1787770818068000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1787770818068000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1787770818068000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1787770818073000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1787770818073000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1787770818073000000",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            },
+            {
+              "traceId": "1deeccb02e2d11c22f8934f0eb12047c",
+              "spanId": "19f41c49ddee19c6",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787314518671000000",
-              "endTimeUnixNano": "1787314518742000000",
+              "startTimeUnixNano": "1787770818003000000",
+              "endTimeUnixNano": "1787770818084000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -593,7 +875,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "004E2FA78993B025E042946E835A8F15"
+                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
                   }
                 },
                 {
@@ -607,50 +889,44 @@
               "events": [
                 {
                   "attributes": [],
-                  "name": "fetchStart",
-                  "timeUnixNano": "1787314518673000000",
-                  "droppedAttributesCount": 0
-                },
-                {
-                  "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787314518687000000",
+                  "timeUnixNano": "1787770818015000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787314518738000000",
+                  "timeUnixNano": "1787770818078000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787314518739000000",
+                  "timeUnixNano": "1787770818078000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787314518744000000",
+                  "timeUnixNano": "1787770818083000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787314518744000000",
+                  "timeUnixNano": "1787770818084000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787314518744000000",
+                  "timeUnixNano": "1787770818084000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "firstContentfulPaint",
-                  "timeUnixNano": "1787314518742000000",
+                  "timeUnixNano": "1787770818084000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -671,12 +947,12 @@
           },
           "spans": [
             {
-              "traceId": "13a503f1ef2b01d3d7dea4daef6a1b46",
-              "spanId": "0bf525edf9da02dd",
+              "traceId": "11c593d79335c3dc57c555a21da997b1",
+              "spanId": "607e585fa8d42b1d",
               "name": "GET",
               "kind": 3,
-              "startTimeUnixNano": "1787314518894000000",
-              "endTimeUnixNano": "1787314518900000000",
+              "startTimeUnixNano": "1787770818242000000",
+              "endTimeUnixNano": "1787770818248000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -729,7 +1005,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "004E2FA78993B025E042946E835A8F15"
+                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
                   }
                 },
                 {
@@ -744,49 +1020,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314518894000000",
+                  "timeUnixNano": "1787770818243000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314518894000000",
+                  "timeUnixNano": "1787770818243000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314518894000000",
+                  "timeUnixNano": "1787770818243000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314518894000000",
+                  "timeUnixNano": "1787770818243000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314518894000000",
+                  "timeUnixNano": "1787770818243000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314518894000000",
+                  "timeUnixNano": "1787770818243000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314518894000000",
+                  "timeUnixNano": "1787770818243000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314518894000000",
+                  "timeUnixNano": "1787770818243000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -799,12 +1075,12 @@
               "flags": 257
             },
             {
-              "traceId": "a1600f5149f97fe28437448bef01862d",
-              "spanId": "77cd1c251d4d5cbb",
+              "traceId": "a3439785dfbf024f9798d2979aaa7c14",
+              "spanId": "d266fe5795d6530d",
               "name": "POST",
               "kind": 3,
-              "startTimeUnixNano": "1787314519336000000",
-              "endTimeUnixNano": "1787314519342000000",
+              "startTimeUnixNano": "1787770818686000000",
+              "endTimeUnixNano": "1787770818693000000",
               "attributes": [
                 {
                   "key": "http.request.method",
@@ -857,7 +1133,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "004E2FA78993B025E042946E835A8F15"
+                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
                   }
                 },
                 {
@@ -872,49 +1148,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314519336000000",
+                  "timeUnixNano": "1787770818686000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314519336000000",
+                  "timeUnixNano": "1787770818686000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314519336000000",
+                  "timeUnixNano": "1787770818686000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314519336000000",
+                  "timeUnixNano": "1787770818686000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314519336000000",
+                  "timeUnixNano": "1787770818686000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314519336000000",
+                  "timeUnixNano": "1787770818686000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314519336000000",
+                  "timeUnixNano": "1787770818686000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314519336000000",
+                  "timeUnixNano": "1787770818686000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -935,12 +1211,12 @@
           },
           "spans": [
             {
-              "traceId": "f2c8ab873e42125e755914c2b5d176f8",
-              "spanId": "c39360899fb0dfe4",
+              "traceId": "1180c8422bf3f7be87035d98eef8e6dd",
+              "spanId": "feb37609a3ab2453",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787314518734000000",
-              "endTimeUnixNano": "1787314519725000000",
+              "startTimeUnixNano": "1787770818076000000",
+              "endTimeUnixNano": "1787770819044000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -957,7 +1233,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "004E2FA78993B025E042946E835A8F15"
+                    "stringValue": "91CD470CEA3EFB1ACD91A2858C373DC5"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-session.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "2CF5ADD992B37FCA5E6E44C8830C18A4"
+              "stringValue": "DB1B0E983AA30044256FF38D5E3A1638"
             }
           },
           {
@@ -85,17 +85,17 @@
           },
           "spans": [
             {
-              "traceId": "6c5e19c179769bd5221063a9fa37ab94",
-              "spanId": "9158cac675a9dc18",
+              "traceId": "22db72487534b413122639c65c0f8822",
+              "spanId": "7aa22b4b663766e0",
               "name": "emb-session-part",
               "kind": 1,
-              "startTimeUnixNano": "1787314513620000000",
-              "endTimeUnixNano": "1787314513803000000",
+              "startTimeUnixNano": "1787770812250000000",
+              "endTimeUnixNano": "1787770812446000000",
               "attributes": [
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B1E9E95731497331AC42171AF95FE4FB"
+                    "stringValue": "45837B85B568650748FA2554B71D531E"
                   }
                 },
                 {
@@ -125,7 +125,7 @@
                 {
                   "key": "emb.user_session_start_ts",
                   "value": {
-                    "intValue": 1787314513619
+                    "intValue": 1787770812249
                   }
                 },
                 {
@@ -161,7 +161,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "B23B08D82BB18AAD2F96A09EA7C5AEC4"
+                    "stringValue": "9EC21846399C8E49D93F7FE1D5802648"
                   }
                 },
                 {
@@ -185,7 +185,7 @@
                 {
                   "key": "emb.sdk_startup_duration",
                   "value": {
-                    "intValue": 11
+                    "intValue": 7
                   }
                 },
                 {
@@ -221,7 +221,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "DF8C7EBF388001919B6FF0EE7E0211F5"
+                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
                   }
                 },
                 {
@@ -250,13 +250,13 @@
           },
           "spans": [
             {
-              "traceId": "1ab3223132c9958e87582b7d10e13b88",
-              "spanId": "736548d7b28253d6",
-              "parentSpanId": "5d68d8a3b999af4d",
+              "traceId": "8e18442546fb55e526454305a3b0689e",
+              "spanId": "c9702dfb77320606",
+              "parentSpanId": "2225185d65920bd2",
               "name": "documentFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314513540000000",
-              "endTimeUnixNano": "1787314513545000000",
+              "startTimeUnixNano": "1787770812188000000",
+              "endTimeUnixNano": "1787770812193000000",
               "attributes": [
                 {
                   "key": "url.full",
@@ -285,7 +285,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "DF8C7EBF388001919B6FF0EE7E0211F5"
+                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
                   }
                 },
                 {
@@ -300,55 +300,55 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314513541000000",
+                  "timeUnixNano": "1787770812188000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314513545000000",
+                  "timeUnixNano": "1787770812192000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314513545000000",
+                  "timeUnixNano": "1787770812192000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314513545000000",
+                  "timeUnixNano": "1787770812192000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "secureConnectionStart",
-                  "timeUnixNano": "1787314513542000000",
+                  "timeUnixNano": "1787770812189000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314513545000000",
+                  "timeUnixNano": "1787770812192000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314513545000000",
+                  "timeUnixNano": "1787770812192000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314513546000000",
+                  "timeUnixNano": "1787770812193000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314513546000000",
+                  "timeUnixNano": "1787770812193000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -361,13 +361,13 @@
               "flags": 257
             },
             {
-              "traceId": "1ab3223132c9958e87582b7d10e13b88",
-              "spanId": "c1f6adb7abebb4bc",
-              "parentSpanId": "5d68d8a3b999af4d",
+              "traceId": "8e18442546fb55e526454305a3b0689e",
+              "spanId": "b4924a35857e007e",
+              "parentSpanId": "2225185d65920bd2",
               "name": "resourceFetch",
               "kind": 1,
-              "startTimeUnixNano": "1787314513549000000",
-              "endTimeUnixNano": "1787314513576000000",
+              "startTimeUnixNano": "1787770812196000000",
+              "endTimeUnixNano": "1787770812211000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -378,13 +378,13 @@
                 {
                   "key": "url.full",
                   "value": {
-                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-BZMZaKNj.js"
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/assets/index-DwCiF-Sl.js"
                   }
                 },
                 {
                   "key": "http.response_content_length",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 425996
                   }
                 },
                 {
@@ -402,19 +402,19 @@
                 {
                   "key": "http.response.body.size",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 425996
                   }
                 },
                 {
                   "key": "http.response.size",
                   "value": {
-                    "intValue": 425923
+                    "intValue": 426296
                   }
                 },
                 {
                   "key": "http.response.decoded_body_size",
                   "value": {
-                    "intValue": 425623
+                    "intValue": 425996
                   }
                 },
                 {
@@ -432,7 +432,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "DF8C7EBF388001919B6FF0EE7E0211F5"
+                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
                   }
                 },
                 {
@@ -447,49 +447,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314513550000000",
+                  "timeUnixNano": "1787770812197000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupStart",
-                  "timeUnixNano": "1787314513550000000",
+                  "timeUnixNano": "1787770812197000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domainLookupEnd",
-                  "timeUnixNano": "1787314513550000000",
+                  "timeUnixNano": "1787770812197000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectStart",
-                  "timeUnixNano": "1787314513550000000",
+                  "timeUnixNano": "1787770812197000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "connectEnd",
-                  "timeUnixNano": "1787314513550000000",
+                  "timeUnixNano": "1787770812197000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "requestStart",
-                  "timeUnixNano": "1787314513577000000",
+                  "timeUnixNano": "1787770812211000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseStart",
-                  "timeUnixNano": "1787314513577000000",
+                  "timeUnixNano": "1787770812212000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "responseEnd",
-                  "timeUnixNano": "1787314513577000000",
+                  "timeUnixNano": "1787770812212000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -502,12 +502,294 @@
               "flags": 257
             },
             {
-              "traceId": "1ab3223132c9958e87582b7d10e13b88",
-              "spanId": "5d68d8a3b999af4d",
+              "traceId": "8e18442546fb55e526454305a3b0689e",
+              "spanId": "3cb04a42bf3bbd10",
+              "parentSpanId": "2225185d65920bd2",
+              "name": "resourceFetch",
+              "kind": 1,
+              "startTimeUnixNano": "1787770812202000000",
+              "endTimeUnixNano": "1787770812202000000",
+              "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/favicon.ico"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.request.initiator_type",
+                  "value": {
+                    "stringValue": "other"
+                  }
+                },
+                {
+                  "key": "http.response.body.size",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.response.size",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.response.decoded_body_size",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "http.response.cors_opaque",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {
+                    "stringValue": "/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {
+                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1787770812202000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1787770812202000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1787770812202000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1787770812202000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1787770812202000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1787770812202000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1787770812202000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1787770812202000000",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            },
+            {
+              "traceId": "8e18442546fb55e526454305a3b0689e",
+              "spanId": "60b46962a29491a3",
+              "parentSpanId": "2225185d65920bd2",
+              "name": "resourceFetch",
+              "kind": 1,
+              "startTimeUnixNano": "1787770812247000000",
+              "endTimeUnixNano": "1787770812249000000",
+              "attributes": [
+                {
+                  "key": "emb.type",
+                  "value": {
+                    "stringValue": "ux.resource_fetch"
+                  }
+                },
+                {
+                  "key": "url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/v2/config?appId=11111&osVersion=1&appVersion=1.0.0&deviceId=80AD9EEE0F64EBD3D141C22EBA6FD933"
+                  }
+                },
+                {
+                  "key": "http.response_content_length",
+                  "value": {
+                    "intValue": 146
+                  }
+                },
+                {
+                  "key": "http.request.initiator_type",
+                  "value": {
+                    "stringValue": "fetch"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": 200
+                  }
+                },
+                {
+                  "key": "http.response.body.size",
+                  "value": {
+                    "intValue": 146
+                  }
+                },
+                {
+                  "key": "http.response.size",
+                  "value": {
+                    "intValue": 446
+                  }
+                },
+                {
+                  "key": "http.response.decoded_body_size",
+                  "value": {
+                    "intValue": 146
+                  }
+                },
+                {
+                  "key": "browser.url.full",
+                  "value": {
+                    "stringValue": "http://localhost:3001/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.name",
+                  "value": {
+                    "stringValue": "/platforms/vite-7/es2015/index.html"
+                  }
+                },
+                {
+                  "key": "app.surface.id",
+                  "value": {
+                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
+                  }
+                },
+                {
+                  "key": "app.surface.label",
+                  "value": {
+                    "stringValue": "React + TS + Vite"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [
+                {
+                  "attributes": [],
+                  "name": "fetchStart",
+                  "timeUnixNano": "1787770812248000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupStart",
+                  "timeUnixNano": "1787770812248000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "domainLookupEnd",
+                  "timeUnixNano": "1787770812248000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectStart",
+                  "timeUnixNano": "1787770812248000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "connectEnd",
+                  "timeUnixNano": "1787770812248000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "requestStart",
+                  "timeUnixNano": "1787770812250000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseStart",
+                  "timeUnixNano": "1787770812250000000",
+                  "droppedAttributesCount": 0
+                },
+                {
+                  "attributes": [],
+                  "name": "responseEnd",
+                  "timeUnixNano": "1787770812250000000",
+                  "droppedAttributesCount": 0
+                }
+              ],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            },
+            {
+              "traceId": "8e18442546fb55e526454305a3b0689e",
+              "spanId": "2225185d65920bd2",
               "name": "documentLoad",
               "kind": 1,
-              "startTimeUnixNano": "1787314513540000000",
-              "endTimeUnixNano": "1787314513634000000",
+              "startTimeUnixNano": "1787770812188000000",
+              "endTimeUnixNano": "1787770812260000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -542,7 +824,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "DF8C7EBF388001919B6FF0EE7E0211F5"
+                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
                   }
                 },
                 {
@@ -557,49 +839,49 @@
                 {
                   "attributes": [],
                   "name": "fetchStart",
-                  "timeUnixNano": "1787314513541000000",
+                  "timeUnixNano": "1787770812189000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domInteractive",
-                  "timeUnixNano": "1787314513552000000",
+                  "timeUnixNano": "1787770812199000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventStart",
-                  "timeUnixNano": "1787314513627000000",
+                  "timeUnixNano": "1787770812256000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domContentLoadedEventEnd",
-                  "timeUnixNano": "1787314513628000000",
+                  "timeUnixNano": "1787770812256000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "domComplete",
-                  "timeUnixNano": "1787314513635000000",
+                  "timeUnixNano": "1787770812261000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventStart",
-                  "timeUnixNano": "1787314513635000000",
+                  "timeUnixNano": "1787770812261000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "loadEventEnd",
-                  "timeUnixNano": "1787314513635000000",
+                  "timeUnixNano": "1787770812261000000",
                   "droppedAttributesCount": 0
                 },
                 {
                   "attributes": [],
                   "name": "firstContentfulPaint",
-                  "timeUnixNano": "1787314513634000000",
+                  "timeUnixNano": "1787770812260000000",
                   "droppedAttributesCount": 0
                 }
               ],
@@ -620,12 +902,12 @@
           },
           "spans": [
             {
-              "traceId": "8085cba7cb4cd6467f0616c8a4bca574",
-              "spanId": "810845e8033b0c64",
+              "traceId": "736ea99c2baf120c73d29f0b5d498b10",
+              "spanId": "952d2b2c46e0991b",
               "name": "/platforms/vite-7/es2015/index.html",
               "kind": 1,
-              "startTimeUnixNano": "1787314513623000000",
-              "endTimeUnixNano": "1787314513804000000",
+              "startTimeUnixNano": "1787770812252000000",
+              "endTimeUnixNano": "1787770812447000000",
               "attributes": [
                 {
                   "key": "emb.type",
@@ -642,7 +924,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "DF8C7EBF388001919B6FF0EE7E0211F5"
+                    "stringValue": "2A85421990F4A2AB2D4325AD791EBC2D"
                   }
                 },
                 {

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -104,8 +104,12 @@ const LOGS_WITH_IGNORED_BODY = new Set(['browser.web_vital.name']);
 // may or may not complete before the SDK captures PerformanceResourceTiming
 // entries, making their presence in a session non-deterministic. The SDK's own
 // uploads are instrumented like any other fetch, so whether one has resolved by
-// the time the part flushes depends on how fast the test got there.
-const EXCLUDED_RESOURCE_URL_PATTERNS = [/favicon\.ico$/, /\/v2\/(logs|spans)$/];
+// the time the part flushes depends on how fast the test got there. The config
+// request is unanchored because its query string carries a per-run deviceId.
+const EXCLUDED_RESOURCE_URL_PATTERNS = [
+  /favicon\.ico$/,
+  /\/v2\/(logs|spans|config)/,
+];
 const IGNORED_ATTRIBUTES_LIST = [
   'log.record.uid',
   'emb.sdk_startup_duration',


### PR DESCRIPTION
## What problem is this solving?

The local collector has no terminal branch, so any unmatched path hangs with no response at all. `.env.template` points `VITE_CONFIG_URL` at it and there is no `/v2/config` route, so the documented local setup hangs on every config refresh.

## Short description of changes

- Add a `/v2/config` handler with a fixed etag, and a 304 on a matching `If-None-Match`. The payload mirrors production, narrowed to the fields this SDK reads; the `user_session` values equal the SDK's own defaults, so they exercise `parseRemoteConfig`'s optional branches without changing behavior.
- Expose `ETag` via `Access-Control-Expose-Headers`; it is not CORS-safelisted, so the demo on another port reads it back as null and never revalidates.
- Add a catch-all 404 so unmatched paths fail fast.
- Exclude `/v2/config` from golden comparison. Now that the request resolves it reaches the resource buffer before the load event, and its `url.full` carries a per-run `deviceId`, so it can never match a stored golden.
- Regenerate the two Firefox session goldens.

## How has this been tested?

Checked the payload, 304, stale-etag and 404 by hand, plus two demo loads in one browser context returning 200 then 304.

## Checklist

- [ ] Documentation added
- [ ] Tests added
