### PR TITLE
EMBR-13803 fix(transport): drain fetch response body to release keepalive quota

### DIFF
--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
@@ -41,6 +41,61 @@ function createDeferred(): Deferred {
   return { promise, resolve, reject };
 }
 
+// A body whose chunks are produced only when a reader pulls them, so a fully
+// drained stream is distinguishable from one that was left alone or cancelled.
+function createTrackedBody(chunkCount: number) {
+  let pulls = 0;
+  let cancelled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulls === chunkCount) {
+        controller.close();
+        return;
+      }
+      pulls++;
+      controller.enqueue(new TextEncoder().encode(`chunk-${pulls}`));
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+
+  return {
+    stream,
+    pullCount: () => pulls,
+    wasCancelled: () => cancelled,
+  };
+}
+
+// A body that stays open until the test closes or errors it.
+function createPendingBody() {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(streamController) {
+      controller = streamController;
+    },
+  });
+
+  return {
+    stream,
+    close: () => controller.close(),
+    fail: (error: Error) => controller.error(error),
+  };
+}
+
+// The drain settles after `send()` resolves; a macrotask turn flushes it.
+function flushBodyDrain(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createFailingBody(message: string) {
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      controller.error(new Error(message));
+    },
+  });
+}
+
 function reinstallFetch() {
   fakeFetchRestore();
   return fakeFetchInstall();
@@ -179,6 +234,7 @@ describe('FetchTransport', () => {
       // Resolve first request to free up budget
       deferred.resolve(new Response('ok', { status: 200 }));
       await first;
+      await flushBodyDrain();
 
       // Third request should fit now
       await transport.send(payload30k, 5000);
@@ -420,6 +476,7 @@ describe('FetchTransport', () => {
       try {
         const transport = makeTransport();
         await transport.send(smallPayload, 1000);
+        await flushBodyDrain();
 
         void expect(clearTimeoutSpy.calledOnce).to.be.true;
       } finally {
@@ -538,6 +595,121 @@ describe('FetchTransport', () => {
       const warns = diagLogger.getWarnLogs();
       const match = warns.find((msg) => msg.includes('HTTP 401'));
       expect(match).to.be.a('string');
+    });
+  });
+
+  describe('response body draining', () => {
+    it('should read the body to its end without cancelling on success', async () => {
+      const body = createTrackedBody(3);
+      fakeFetchRespondWith(body.stream, { status: 200 });
+      const transport = makeTransport();
+
+      const result = await transport.send(smallPayload, 1000);
+      await flushBodyDrain();
+
+      expect(result.status).to.equal('success');
+      expect(body.pullCount()).to.equal(3);
+      expect(body.wasCancelled()).to.equal(false);
+    });
+
+    it('should read the body to its end on a retryable response', async () => {
+      const body = createTrackedBody(3);
+      fakeFetchRespondWith(body.stream, { status: 503 });
+      const transport = makeTransport();
+
+      const result = await transport.send(smallPayload, 1000);
+      await flushBodyDrain();
+
+      expect(result.status).to.equal('retryable');
+      expect(body.pullCount()).to.equal(3);
+      expect(body.wasCancelled()).to.equal(false);
+    });
+
+    it('should settle the export before the body reaches its end', async () => {
+      const body = createPendingBody();
+      fakeFetchRespondWith(body.stream, { status: 200 });
+      const transport = makeTransport();
+
+      const result = await transport.send(smallPayload, 1000);
+
+      expect(result.status).to.equal('success');
+
+      body.close();
+      await flushBodyDrain();
+    });
+
+    it('should leave the export result untouched when the body fails to read', async () => {
+      fakeFetchRespondWith(createFailingBody('body read failed'), {
+        status: 200,
+      });
+      const transport = makeTransport();
+
+      const result = await transport.send(smallPayload, 1000);
+      await flushBodyDrain();
+
+      expect(result.status).to.equal('success');
+      const match = diagLogger
+        .getDebugLogs()
+        .find((msg) => msg.includes('failed to drain response body'));
+      expect(match).to.be.a('string');
+    });
+
+    it('should leave the export result untouched when the body is locked by another reader', async () => {
+      // A fetch wrapper may hold the body's reader. The export already reached
+      // the collector, so an undrainable body must not fail it.
+      const response = new Response('ok', { status: 200 });
+      response.body?.getReader();
+      reinstallFetch().resolves(response);
+      const transport = makeTransport();
+
+      const result = await transport.send(smallPayload, 1000);
+      await flushBodyDrain();
+
+      expect(result.status).to.equal('success');
+      const match = diagLogger
+        .getDebugLogs()
+        .find((msg) => msg.includes('failed to drain response body'));
+      expect(match).to.be.a('string');
+    });
+
+    it('should hold the keepalive budget until the body drains', async () => {
+      const body = createPendingBody();
+      const stub = reinstallFetch();
+      stub.onCall(0).resolves(new Response(body.stream, { status: 200 }));
+      stub.onCall(1).resolves(new Response('ok', { status: 200 }));
+      stub.onCall(2).resolves(new Response('ok', { status: 200 }));
+
+      const transport = makeTransport();
+      const payload30k = new Uint8Array(30 * 1024);
+
+      await transport.send(payload30k, 5000);
+      await flushBodyDrain();
+      await transport.send(payload30k, 5000);
+
+      expect(fakeFetchGetKeepalive(1)).to.equal(false);
+
+      body.close();
+      await flushBodyDrain();
+      await transport.send(payload30k, 5000);
+
+      expect(fakeFetchGetKeepalive(2)).to.equal(true);
+    });
+
+    it('should release the keepalive budget when the body drain fails', async () => {
+      const body = createPendingBody();
+      const stub = reinstallFetch();
+      stub.onCall(0).resolves(new Response(body.stream, { status: 200 }));
+      stub.onCall(1).resolves(new Response('ok', { status: 200 }));
+
+      const transport = makeTransport();
+      const payload30k = new Uint8Array(30 * 1024);
+
+      await transport.send(payload30k, 5000);
+      body.fail(new Error('body errored'));
+      await flushBodyDrain();
+      await transport.send(payload30k, 5000);
+
+      expect(fakeFetchGetKeepalive(1)).to.equal(true);
     });
   });
 });

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
@@ -23,6 +23,51 @@ export function _resetKeepaliveTracking(): void {
   inflightKeepaliveCount = 0;
 }
 
+/**
+ * Reads the response body to its end and discards it.
+ *
+ * Chromium returns the request's share of the keepalive quota only once the
+ * body has been read to the end, and it skips the buffering consumer that would
+ * otherwise drain it when the response carries `Cache-Control: no-store`, which
+ * collectors commonly send. Cancelling is the client-abort path and measures
+ * far slower, so the body is read rather than cancelled.
+ *
+ * @see https://fetch.spec.whatwg.org/#fetch-processresponseendofbody
+ * @see https://github.com/chromium/chromium/blob/1af7c3cde84323e827f77d8066ca23da811203b8/third_party/blink/renderer/core/fetch/fetch_manager.cc#L818-L836
+ */
+async function drainResponseBody(response: Response): Promise<void> {
+  try {
+    // Empty and opaque responses have no body to read.
+    const body = response.body;
+    if (!body) {
+      return;
+    }
+
+    // Throws when the body is already locked to another reader, which happens
+    // when the same response is handed to more than one export.
+    const reader = body.getReader();
+    try {
+      // Chunks are dropped as they arrive so a large response is never buffered.
+      let chunk = await reader.read();
+      while (!chunk.done) {
+        chunk = await reader.read();
+      }
+    } finally {
+      // A held reader keeps the body locked, and a later export handed the same
+      // response could then not drain it.
+      reader.releaseLock();
+    }
+  } catch (error) {
+    // The export outcome is decided by the response status, a body that cannot
+    // be read must not change it.
+    const drainError =
+      error instanceof Error ? error : new Error(String(error));
+    diag.debug(
+      `Fetch transport failed to drain response body: ${drainError.message}`,
+    );
+  }
+}
+
 export class FetchTransport implements IExporterTransport {
   public constructor(private readonly _config: FetchRequestParameters) {}
 
@@ -103,6 +148,21 @@ export class FetchTransport implements IExporterTransport {
     }
 
     let keepalive = false;
+    let reservedBytes = 0;
+
+    const clearTimeoutIfSet = () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    };
+
+    // The quota frees only once the body drains, so the drain owns the release.
+    const releaseKeepalive = () => {
+      clearTimeoutIfSet();
+      inflightKeepaliveBytes -= reservedBytes;
+      inflightKeepaliveCount--;
+    };
+    let drainOwnsRelease = false;
 
     try {
       if (this._config.compression === 'gzip') {
@@ -126,7 +186,8 @@ export class FetchTransport implements IExporterTransport {
       keepalive = !wouldExceedBytes && !wouldExceedCount;
 
       if (keepalive) {
-        inflightKeepaliveBytes += request.byteLength;
+        reservedBytes = request.byteLength;
+        inflightKeepaliveBytes += reservedBytes;
         inflightKeepaliveCount++;
       } else {
         const reason = wouldExceedBytes
@@ -142,6 +203,18 @@ export class FetchTransport implements IExporterTransport {
         body: request,
         signal,
       });
+
+      // Not awaited: the status already decides the export outcome, and a
+      // collector that stalls mid-body must not hold up the caller.
+      const drained = drainResponseBody(response);
+      if (keepalive) {
+        // Set once the promise exists so an earlier throw still reaches the
+        // release in `finally`.
+        drainOwnsRelease = true;
+        // The abort signal stays armed, so a stalled body cannot hold the
+        // budget forever.
+        void drained.finally(releaseKeepalive);
+      }
 
       if (response.ok) {
         return { status: 'success' };
@@ -173,12 +246,12 @@ export class FetchTransport implements IExporterTransport {
         error: fetchError,
       };
     } finally {
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-      }
-      if (keepalive) {
-        inflightKeepaliveBytes -= request.byteLength;
-        inflightKeepaliveCount--;
+      if (!drainOwnsRelease) {
+        if (keepalive) {
+          releaseKeepalive();
+        } else {
+          clearTimeoutIfSet();
+        }
       }
     }
   }

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
@@ -33,7 +33,7 @@ export function _resetKeepaliveTracking(): void {
  * far slower, so the body is read rather than cancelled.
  *
  * @see https://fetch.spec.whatwg.org/#fetch-processresponseendofbody
- * @see https://github.com/chromium/chromium/blob/1af7c3cde84323e827f77d8066ca23da811203b8/third_party/blink/renderer/core/fetch/fetch_manager.cc#L818-L836
+ * @see https://issues.chromium.org/issues/546438373
  */
 async function drainResponseBody(response: Response): Promise<void> {
   try {

--- a/server/server.ts
+++ b/server/server.ts
@@ -22,6 +22,18 @@ const platformsDir = join(__dirname, '..', 'tests', 'integration', 'platforms');
 
 const PORT = 3001;
 
+// Opt-in mode for reproducing the keepalive quota leak: a no-store response
+// holds keepalive budget until the body is read. Off by default so the normal
+// response stays byte-identical to production.
+const SIMULATE_NO_STORE = process.env['EMB_NO_STORE'] === '1';
+
+// Mirrors the real ingest, which answers 200 with a literal 0 body under a
+// text/html content type. The SDK never reads it.
+const ingestResponseHeaders = (): Record<string, string> => ({
+  'Content-Type': 'text/html; charset=utf-8',
+  ...(SIMULATE_NO_STORE && { 'Cache-Control': 'no-store' }),
+});
+
 const mimeTypes: Record<string, string> = {
   '.html': 'text/html',
   '.js': 'application/javascript',
@@ -152,8 +164,8 @@ const server = createServer((req, res) => {
 
         logReceivedLogRecords(logRecords);
 
-        res.writeHead(200);
-        res.end('OK');
+        res.writeHead(200, ingestResponseHeaders());
+        res.end('0');
       })
       .catch((e: unknown) => {
         console.error('Error handling log request:', e);
@@ -212,8 +224,8 @@ const server = createServer((req, res) => {
           }
         }
 
-        res.writeHead(200);
-        res.end('OK');
+        res.writeHead(200, ingestResponseHeaders());
+        res.end('0');
       })
       .catch((e: unknown) => {
         console.error('Error parsing gzip request:', e);
@@ -255,6 +267,9 @@ const server = createServer((req, res) => {
 
 server.listen(PORT, () => {
   logInfo(`Debug collector running on http://localhost:${PORT}`);
+  if (SIMULATE_NO_STORE) {
+    logWarn('EMB_NO_STORE=1: ingest responses carry Cache-Control: no-store');
+  }
   logInfo('To send telemetry to the debug collector, add your');
   logInfo(`appID to ./demo/frontend/.env:`);
   logInfo(`  VITE_APP_ID=your-app-id`);

--- a/turbo.json
+++ b/turbo.json
@@ -41,7 +41,8 @@
     },
     "//#server": {
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "passThroughEnv": ["EMB_NO_STORE"]
     }
   }
 }


### PR DESCRIPTION
## What problem is this solving?

`FetchTransport` never reads the response body. Chromium returns a request's share of the cumulative 64KiB keepalive quota only once the body is read to its end, and Blink skips its own drain when the response carries `Cache-Control: no-store`, which any gateway or CDN in front of the endpoint can set. Where it is set, exports leak the quota until it is exhausted and every later keepalive export fails silently. The transport's counters released at response headers, so it kept setting `keepalive: true` on budget the browser no longer had.

## Short description of changes

- Drain the response body once the fetch resolves, without awaiting it: the status already decides the export outcome, so a collector that stalls mid-body cannot hold up the caller.
- Release the keepalive counters when the drain settles rather than in `finally`, so they track when the browser actually returns the quota. The abort signal stays armed through the drain, so a stalled body cannot hold the budget past the request timeout.
- Read errors log at `diag.debug` and never change the export outcome. Cancelling would take Blink's client-abort path, which never reaches the release. The reader lock is released so a response handed to a later export can still be drained.
- The local collector mirrors the real ingest response, with `EMB_NO_STORE=1` as an opt-in switch for reproducing the leak. Turbo runs in strict env mode, so the flag needs a `passThroughEnv` entry to reach the collector task under `npm run dev`.
- Same defect as https://github.com/open-telemetry/opentelemetry-js/pull/7002, whose fix does not reach us: the export delegate injects this transport, not `otlp-exporter-base`'s. The approach follows https://github.com/open-telemetry/opentelemetry-js/pull/7070.

## How has this been tested?

Seven unit tests in `FetchTransport.test.ts` cover the drain on success and on a retryable status, the export settling before the body ends, locked and erroring bodies, and the budget being held until the drain settles then released when it fails. File passes 32/32, plus `npm run check` and `npm run lint` from the repo root.

Measured in headless Chromium against the local collector run with `EMB_NO_STORE=1`, so `/v2/spans` answers with `Cache-Control: no-store`. Each request posts a gzipped body of 16,529 bytes with `keepalive: true`, sequentially.

| | outcome |
| --- | --- |
| Raw `fetch`, body left unread | 3 succeed, the 4th throws `TypeError: Failed to fetch` at 49,587 B cumulative |
| Through `FetchTransport` | 20 of 20 succeed, ~330 KB cumulative, every one sent with `keepalive: true` |

The undrained arm wedges one request short of the 64KiB budget and never recovers. The drained arm passes roughly five times the budget without a failure, and a passthrough spy on `window.fetch` confirms none of the 20 silently fell back to `keepalive: false`.

## Performance Impact

Benchmarked in headless Chromium against the local collector, 1000 responses per arm, ingest-shaped reply (200, 1-byte body). Run twice, once with the default headers and once with `EMB_NO_STORE=1`.

| measurement | default | `no-store` |
| --- | --- | --- |
| 1000 drains, timed in batches | 15.2 ms total, 15.2 us per response | 11.8 ms total, 11.8 us per response |
| 1000 sequential round trips, drain awaited | 337.9 ms | 347.0 ms |
| 1000 sequential round trips, body left unread | 297.1 ms | 306.7 ms |

A drain costs ~12-15 us of main-thread time per response, so ~15 ms spread across 1000 exports. The awaited round-trip rows put an upper bound of ~0.04 ms per request on it; the shipped code does not await the drain, so nothing on the export path pays even that. `no-store` does not make the drain measurably more expensive, which is expected: the body is one byte either way, only Blink's own buffering differs.

## Checklist

- [ ] Documentation added
- [x] Tests added

