### PR TITLE
EMBR-13856 feat: add fold measurement duration to DOM state instrumentation

### DIFF
--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.test.ts
@@ -217,7 +217,7 @@ describe('DOMStateInstrumentation', () => {
     expect(logs[0].attributes).to.have.property('dom_state.element_count');
   });
 
-  it('stamps the fold capture time as an attribute while the log itself is stamped at part end', async () => {
+  it('stamps the fold capture time both as wall clock and relative to zero time, while the log itself is stamped at part end', async () => {
     createInstrumentation();
     // Real elapsed time between capture and part end, so a stamp taken at
     // either moment is tellable from one taken at the other.
@@ -226,12 +226,23 @@ describe('DOMStateInstrumentation', () => {
     endSessionPart();
 
     const logs = getDomStateLogs();
-    const captureMillis = logs[0].attributes[
+    const timestampMillis = logs[0].attributes[
       'dom_state.images_above_fold.timestamp'
     ] as number;
-    expect(captureMillis).to.be.a('number');
-    expect(captureMillis).to.be.lessThan(beforePartEnd);
-    // The hrTime conversion truncates below the millisecond, so allow for it.
+    const captureMillis = logs[0].attributes[
+      'dom_state.images_above_fold.capture_time'
+    ] as number;
+    expect(timestampMillis).to.be.a('number');
+    expect(timestampMillis).to.be.lessThan(beforePartEnd);
+    // No bfcache restore or soft navigation happens in this test, so zero time
+    // sits at time origin: the two attributes describe the same instant, one
+    // as wall clock and one as ms since zero time, so they agree once rebased.
+    expect(captureMillis).to.equal(timestampMillis - performance.timeOrigin);
+
+    // The log itself is stamped at the part-end flush, not the earlier fold
+    // capture, since its other attributes (element count, document box) are
+    // only measured at the flush. The hrTime conversion truncates below the
+    // millisecond, so allow for it.
     expect(hrTimeToMilliseconds(logs[0].hrTime)).to.be.at.least(
       Math.floor(beforePartEnd),
     );
@@ -425,6 +436,9 @@ describe('DOMStateInstrumentation', () => {
     expect(logs[0].attributes).to.not.have.property(
       'dom_state.images_above_fold.timestamp',
     );
+    expect(logs[0].attributes).to.not.have.property(
+      'dom_state.images_above_fold.capture_time',
+    );
     expect(logs[0].attributes).to.have.property(
       'dom_state.element_count',
       expected.count,
@@ -605,6 +619,9 @@ describe('DOMStateInstrumentation', () => {
     );
     expect(logs[1].attributes).to.not.have.property(
       'dom_state.images_above_fold.timestamp',
+    );
+    expect(logs[1].attributes).to.not.have.property(
+      'dom_state.images_above_fold.capture_time',
     );
     expect(logs[1].attributes).to.have.property('dom_state.element_count');
   });

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/DOMStateInstrumentation.ts
@@ -10,6 +10,7 @@ import {
   ATTR_DOM_STATE_DOCUMENT_HEIGHT,
   ATTR_DOM_STATE_DOCUMENT_WIDTH,
   ATTR_DOM_STATE_ELEMENT_COUNT,
+  ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_CAPTURE_TIME,
   ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_COUNT,
   ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_TIMESTAMP,
   ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_VIEWPORT_HEIGHT,
@@ -26,11 +27,14 @@ import type { DOMStateInstrumentationArgs } from './types.ts';
   end itself.
 
   The fold measurement (images above the fold, the viewport they were judged
-  against, and its capture time as `images_above_fold.timestamp`) describes what
-  the user sees first: at most one per page, taken only while a session part is
-  engaged, at the load event, at the first part start after a load nobody
-  watched, or at attach to an already loaded page. It rides the first part-end
-  log sent after the capture.
+  against, and its capture time as both `images_above_fold.timestamp` — wall
+  clock — and `images_above_fold.capture_time` — ms from zero time) describes
+  what the user sees first: at most one per page, taken only while a session
+  part is engaged, at the load event, at the first part start after a load
+  nobody watched, or at attach to an already loaded page. It rides the first
+  part-end log sent after the capture; the log itself keeps the part end's own
+  timestamp, since its other attributes (element count, document box, ...)
+  are measured at the flush, not at the earlier capture.
 */
 export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
   private readonly _onLoad: () => void;
@@ -146,6 +150,7 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
         return;
       }
 
+      const captureEpochMillis = this.perf.getNowMillis();
       this._pendingFoldAttributes = {
         [ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_COUNT]:
           this._countImagesAboveFold(measurement),
@@ -153,7 +158,9 @@ export class DOMStateInstrumentation extends EmbraceInstrumentationBase {
           measurement.viewportHeight,
         [ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_VIEWPORT_WIDTH]:
           measurement.viewportWidth,
-        [ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_TIMESTAMP]: this.perf.getNowMillis(),
+        [ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_TIMESTAMP]: captureEpochMillis,
+        [ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_CAPTURE_TIME]:
+          this.perf.millisFromZeroTimeEpoch(captureEpochMillis),
       };
     } catch (e) {
       this._diag.error('failed to capture dom-state fold measurement', e);

--- a/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/constants.ts
+++ b/packages/web-sdk/src/instrumentations/dom-state/DOMStateInstrumentation/constants.ts
@@ -18,3 +18,5 @@ export const ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_VIEWPORT_WIDTH =
   'dom_state.images_above_fold.viewport_width';
 export const ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_TIMESTAMP =
   'dom_state.images_above_fold.timestamp';
+export const ATTR_DOM_STATE_IMAGES_ABOVE_FOLD_CAPTURE_TIME =
+  'dom_state.images_above_fold.capture_time';

--- a/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.test.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.test.ts
@@ -89,6 +89,46 @@ describe('OTelPerformanceManager', () => {
     expect(performanceManager.millisFromZeroTime(500)).to.equal(0); // 500 - 800 clamped to 0
   });
 
+  it('rebases millisFromZeroTimeEpoch onto timeOrigin when zero time equals timeOrigin', () => {
+    // zero time = timeOrigin (1000); getNowMillis() = 1000 + now() (500) = 1500
+    expect(performanceManager.millisFromZeroTimeEpoch(1500)).to.equal(500); // 1500 - 1000, matching now()
+  });
+
+  it('rebases millisFromZeroTimeEpoch onto activationStart on prerendered pages', () => {
+    const clockWithActivation: PerformanceClock = {
+      timeOrigin: 1000,
+      now: sinon.stub().returns(500),
+      getEntriesByType: sinon
+        .stub()
+        .returns([{ activationStart: 200 } as PerformanceNavigationTiming]),
+    };
+    const perf = new OTelPerformanceManager(clockWithActivation);
+    // zero time = timeOrigin (1000) + activationStart (200) = 1200
+    expect(perf.millisFromZeroTimeEpoch(1500)).to.equal(300); // 1500 - 1200
+  });
+
+  it('clamps millisFromZeroTimeEpoch to 0 for epoch values before activationStart', () => {
+    const clockWithActivation: PerformanceClock = {
+      timeOrigin: 1000,
+      now: sinon.stub().returns(500),
+      getEntriesByType: sinon
+        .stub()
+        .returns([{ activationStart: 200 } as PerformanceNavigationTiming]),
+    };
+    const perf = new OTelPerformanceManager(clockWithActivation);
+    expect(perf.millisFromZeroTimeEpoch(1100)).to.equal(0); // 1100 - 1200 clamped to 0
+  });
+
+  it('rebases millisFromZeroTimeEpoch onto the pageshow gap after a bfcache restore', () => {
+    updateZeroTimeMillis(1800); // gap from timeOrigin (1000) is 800ms
+    expect(performanceManager.millisFromZeroTimeEpoch(2000)).to.equal(200); // 2000 - 1800
+  });
+
+  it('clamps millisFromZeroTimeEpoch to 0 for epoch values before the bfcache restore', () => {
+    updateZeroTimeMillis(1800); // gap from timeOrigin (1000) is 800ms
+    expect(performanceManager.millisFromZeroTimeEpoch(1500)).to.equal(0); // 1500 - 1800 clamped to 0
+  });
+
   it('returns timeOrigin when clock has no getEntriesByType (activationStart = 0)', () => {
     expect(performanceManager.getZeroTime()).to.equal(1000); // timeOrigin (1000) + activationStart (0)
   });

--- a/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/OTelPerformanceManager.ts
@@ -70,4 +70,11 @@ export class OTelPerformanceManager implements PerformanceManager {
   // prerendering activity captured before activationStart).
   public millisFromZeroTime = (originOffset: number) =>
     Math.max(0, originOffset - (this.getZeroTime() - this._clock.timeOrigin));
+
+  // Same rebase as millisFromZeroTime, but for a value that has already had
+  // timeOrigin added in (e.g. getNowMillis(), epochMillisFromOrigin(...)) rather
+  // than a raw offset still relative to it — feeding an epoch value into
+  // millisFromZeroTime would double-count timeOrigin.
+  public millisFromZeroTimeEpoch = (epochMillis: number) =>
+    Math.max(0, epochMillis - this.getZeroTime());
 }

--- a/packages/web-sdk/src/utils/PerformanceManager/README.md
+++ b/packages/web-sdk/src/utils/PerformanceManager/README.md
@@ -41,11 +41,19 @@ line.
 | `getZeroTime()` | What is the epoch timestamp of the current view's start? | `max(timeOrigin + activationStart, lastResetEpoch)` |
 | `millisFromZeroTime(offset)` | How many ms after the current view started did this raw offset occur? | `max(0, offset - (getZeroTime() - timeOrigin))` |
 | `getNowMillis()` | What is the wall-clock epoch time right now? | `timeOrigin + performance.now()` |
+| `millisFromZeroTimeEpoch(epochMillis)` | How many ms after the current view started did this *epoch* value occur? | `max(0, epochMillis - getZeroTime())` |
 
 Zero time never participates in converting a raw offset to an epoch: the
 offset already contains the full distance from time origin, so
 `epochMillisFromOrigin` is a pure frame translation. Adding a raw offset to
 `getZeroTime()` instead would count the origin→zero-time gap twice.
+
+`millisFromZeroTime` and `millisFromZeroTimeEpoch` compute the same kind of
+answer but must not be swapped: the former takes a raw offset still relative
+to time origin (`entry.startTime`, `performance.now()`), the latter a value
+that already has `timeOrigin` added in (`getNowMillis()`,
+`epochMillisFromOrigin(...)`). Passing an epoch value to `millisFromZeroTime`
+counts `timeOrigin` twice — see the worked example below.
 
 **Durations need no conversion at all.** `entry.duration`, or any difference
 of two offsets in the same frame (`responseEnd - fetchStart`), is
@@ -71,12 +79,13 @@ Each method, applied to this scenario:
 | `getZeroTime()` | `1,700,000,060,000` (12:01:00.000) | the span **start** — anchoring the span to the current view's start so its duration reads "time from view start until render" |
 | `millisFromZeroTime(61_000)` | `61,000 - 60,000 = 1,000` | the `render_time` **attribute** — "rendered 1s into the current view" |
 | `getNowMillis()` | `1,700,000,061,500` (12:01:01.500) | the default **log timestamp** when there is no event-specific offset to convert |
+| `millisFromZeroTimeEpoch(getNowMillis())` | `1,700,000,061,500 - 1,700,000,060,000 = 1,500` | an attribute capturing "how far into the view is it right now" from an already-epoch reading |
 
 The resulting span: start `12:01:00`, end `12:01:01`, duration **1s**, with a
 `render_time` attribute of **1,000ms** — all four numbers telling the same
 story.
 
-The two ways to get this wrong, with the same inputs:
+The three ways to get this wrong, with the same inputs:
 
 - Recording the raw `61,000` as the attribute claims the render took **61s**,
   because it silently measures from the original hard navigation. Across a
@@ -84,6 +93,11 @@ The two ways to get this wrong, with the same inputs:
 - Computing the epoch as `getZeroTime() + 61,000` yields
   `1,700,000,121,000` (12:02:01) — one full minute in the future, because the
   60s origin→zero-time gap got counted twice.
+- Computing `millisFromZeroTime(getNowMillis())` yields
+  `1,700,000,061,500 - 60,000 = 1,700,000,001,500` — still trillion-scale,
+  because `getNowMillis()` already has `timeOrigin` added in and
+  `millisFromZeroTime` subtracts assuming it doesn't. `millisFromZeroTimeEpoch`
+  exists precisely so this input never needs `millisFromZeroTime` at all.
 
 ## Instrumentation catalog
 
@@ -140,6 +154,24 @@ One log for the first click/keydown/scroll per session part.
 | --- | --- | --- |
 | log timestamp | `event.timeStamp` | `epochMillisFromOrigin` |
 | `emb.first_interaction.time` | `event.timeStamp` | `millisFromZeroTime` |
+
+#### DOMStateInstrumentation
+
+One `dom-state` log per session part end.
+
+| Telemetry field | Source | Method |
+| --- | --- | --- |
+| `dom_state.images_above_fold.timestamp` | — (the moment the fold measurement is taken) | `getNowMillis()` |
+| `dom_state.images_above_fold.capture_time` | — (the same moment) | `millisFromZeroTimeEpoch(getNowMillis())` |
+
+Both attributes are derived from a single `getNowMillis()` read at fold-capture
+time and held until the session-part-end flush that actually sends the log —
+one as wall clock, one rebased onto zero time. The log's own timestamp is
+untouched by this: it still defaults to "now" at the flush, since the log's
+other attributes (element count, average depth, document box) are only
+measured at that later point, not at the earlier capture. Everything else is
+counts and pixels, not timing data. `getNavigationEntry()` is also read for
+`loadEventStart`, used only as a fired/not-fired predicate, never emitted.
 
 ### Time-origin instrumentations
 
@@ -226,7 +258,6 @@ non-timing data, or OTel's default "now".
 | ServerTimingInstrumentation | `emb.server_timing.duration` — a duration reported by the server, frame-independent |
 | LoafInstrumentation | aggregated long-animation-frame durations (sums, maxima) — pure durations |
 | MaxScrollDepthInstrumentation | none — pixels, percent, booleans |
-| DOMStateInstrumentation | counts and pixels, plus one `getNowMillis()` read that pins the held view snapshot's log timestamp to the capture moment rather than to the session-part-end flush that sends it. Also reads `getNavigationEntry()` for `loadEventStart`, used only as a fired/not-fired predicate, never emitted |
 | EmptyRootInstrumentation | none — span event uses OTel's default "now" |
 | NavigationInstrumentation | route spans start/end at OTel's default "now", which is genuinely when the route change occurs |
 

--- a/packages/web-sdk/src/utils/PerformanceManager/types.ts
+++ b/packages/web-sdk/src/utils/PerformanceManager/types.ts
@@ -3,6 +3,7 @@ export interface PerformanceManager {
   getNavigationEntry: () => PerformanceNavigationTiming | null;
   getNowMillis: () => number;
   millisFromZeroTime: (originOffset: number) => number;
+  millisFromZeroTimeEpoch: (epochMillis: number) => number;
   getZeroTime: () => number;
 }
 

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs-after-part.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-handle-204-with-body-logs-after-part.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "D592135524C312EE983F779AA9B4AC30"
+              "stringValue": "C6951B7D2E86531B82AC885C8D01B57D"
             }
           },
           {
@@ -110,8 +110,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460923101000000",
-              "observedTimeUnixNano": "1788460923101000000",
+              "timeUnixNano": "1788803640096000000",
+              "observedTimeUnixNano": "1788803640096000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -149,13 +149,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "58A4D4B095295C8FB196D57ADC4BA198"
+                    "stringValue": "35BA6CBA883C4D3BC48ED5023E02C950"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B917CF3F380846CA8A8AD1BF001864ED"
+                    "stringValue": "699E1C109C76F07A3E06CE4EF71ECFE6"
                   }
                 },
                 {
@@ -167,7 +167,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "F0E68CE33E0948395D885195E0F0B2D8"
+                    "stringValue": "80C6418310843370DFD836AFD1253F53"
                   }
                 },
                 {
@@ -191,7 +191,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "679C78432C815D9BCA80829723D6AF4F"
+                    "stringValue": "91C2BECAF4111C76259DEB286854F365"
                   }
                 },
                 {
@@ -212,8 +212,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460923101000000",
-              "observedTimeUnixNano": "1788460923101000000",
+              "timeUnixNano": "1788803640096000000",
+              "observedTimeUnixNano": "1788803640096000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "dom-state",
@@ -269,19 +269,25 @@
                 {
                   "key": "dom_state.images_above_fold.timestamp",
                   "value": {
-                    "doubleValue": 1788460922208.6
+                    "intValue": 1788803639179
+                  }
+                },
+                {
+                  "key": "dom_state.images_above_fold.capture_time",
+                  "value": {
+                    "doubleValue": 47.300048828125
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "02465A21D84712C1558B2BBDCA7AA510"
+                    "stringValue": "8FFE4E9C9CBD24C754BFE16A6A678A99"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "B917CF3F380846CA8A8AD1BF001864ED"
+                    "stringValue": "699E1C109C76F07A3E06CE4EF71ECFE6"
                   }
                 },
                 {
@@ -293,7 +299,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "F0E68CE33E0948395D885195E0F0B2D8"
+                    "stringValue": "80C6418310843370DFD836AFD1253F53"
                   }
                 },
                 {
@@ -317,7 +323,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "679C78432C815D9BCA80829723D6AF4F"
+                    "stringValue": "91C2BECAF4111C76259DEB286854F365"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/chromium-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/chromium-vite-7-es2015-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "2C6C2A93070AD9FDA53E09155C4D32EE"
+              "stringValue": "D8DC5E1000589E714ACFEC2A5C4C2336"
             }
           },
           {
@@ -110,11 +110,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460919197000000",
-              "observedTimeUnixNano": "1788460919201000000",
+              "timeUnixNano": "1788803634463800049",
+              "observedTimeUnixNano": "1788803634467000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0.20000001788139343,\"cacheDuration\":1.699999988079071,\"dnsDuration\":0,\"connectionDuration\":0.09999999403953552,\"requestDuration\":3.9000000059604645}"
+                "stringValue": "{\"waitingDuration\":0.10000002384185791,\"cacheDuration\":2.100000023841858,\"dnsDuration\":0,\"connectionDuration\":0.19999998807907104,\"requestDuration\":0.5}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -133,13 +133,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "doubleValue": 5.9000000059604645
+                    "doubleValue": 2.900000035762787
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "doubleValue": 5.9000000059604645
+                    "doubleValue": 2.900000035762787
                   }
                 },
                 {
@@ -151,7 +151,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1788460919195-4658582520590"
+                    "stringValue": "v6-1788803634461-2439536294721"
                   }
                 },
                 {
@@ -163,13 +163,13 @@
                 {
                   "key": "browser.web_vital.navigation_id",
                   "value": {
-                    "intValue": 9990
+                    "intValue": 3164
                   }
                 },
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "3F41A17F16C8499F8C86B3DA51F3AFCA"
+                    "stringValue": "F725607446199C8AE51EA14F9558914A"
                   }
                 },
                 {
@@ -187,7 +187,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "C6252CF8646984502FCF29FF3AA2A2C7"
+                    "stringValue": "2B437467BF076B9E0134A9AFEE25FA45"
                   }
                 },
                 {
@@ -223,25 +223,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 4
+                    "intValue": 0
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 2
+                    "intValue": 3
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "8EAD713C24B3FCF537558358BDE76218"
+                    "stringValue": "8AF8A899D9BCD65CE2ACD922AEF5C8F2"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "029AC6A568D02D7D5B4037569BF81710"
+                    "stringValue": "3E772369F8CF798D0982EFA57265C9A0"
                   }
                 },
                 {
@@ -260,11 +260,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1788460919212800049",
-              "observedTimeUnixNano": "1788460919216000000",
+              "timeUnixNano": "1788803634513699951",
+              "observedTimeUnixNano": "1788803634515000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":5.9000000059604645,\"firstByteToFCP\":66.09999999403954,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":2.900000035762787,\"firstByteToFCP\":89.09999996423721,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -283,13 +283,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 72
+                    "intValue": 92
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 72
+                    "intValue": 92
                   }
                 },
                 {
@@ -301,7 +301,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1788460919194-8357777908343"
+                    "stringValue": "v6-1788803634461-2218828954485"
                   }
                 },
                 {
@@ -313,13 +313,13 @@
                 {
                   "key": "browser.web_vital.navigation_id",
                   "value": {
-                    "intValue": 9990
+                    "intValue": 3164
                   }
                 },
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "3F41A17F16C8499F8C86B3DA51F3AFCA"
+                    "stringValue": "F725607446199C8AE51EA14F9558914A"
                   }
                 },
                 {
@@ -337,7 +337,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "C6252CF8646984502FCF29FF3AA2A2C7"
+                    "stringValue": "2B437467BF076B9E0134A9AFEE25FA45"
                   }
                 },
                 {
@@ -349,13 +349,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "07393B28C877400E263DC0705E50A95E"
+                    "stringValue": "F24F512CE79C0B5CFD710C665D5E5DA8"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "029AC6A568D02D7D5B4037569BF81710"
+                    "stringValue": "3E772369F8CF798D0982EFA57265C9A0"
                   }
                 },
                 {
@@ -382,8 +382,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460919325600098",
-              "observedTimeUnixNano": "1788460919326000000",
+              "timeUnixNano": "1788803634594599854",
+              "observedTimeUnixNano": "1788803634604000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -415,7 +415,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "doubleValue": 128.60004884004593
+                    "doubleValue": 130.7999023795128
                   }
                 },
                 {
@@ -433,13 +433,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "07D0FD4ED042A85C1453443143132C6F"
+                    "stringValue": "DFC59D5E2E743832BFB643CC1F90F663"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "029AC6A568D02D7D5B4037569BF81710"
+                    "stringValue": "3E772369F8CF798D0982EFA57265C9A0"
                   }
                 },
                 {
@@ -451,7 +451,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "3F41A17F16C8499F8C86B3DA51F3AFCA"
+                    "stringValue": "F725607446199C8AE51EA14F9558914A"
                   }
                 },
                 {
@@ -475,7 +475,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "C6252CF8646984502FCF29FF3AA2A2C7"
+                    "stringValue": "2B437467BF076B9E0134A9AFEE25FA45"
                   }
                 },
                 {
@@ -496,8 +496,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460919327000000",
-              "observedTimeUnixNano": "1788460919327000000",
+              "timeUnixNano": "1788803634605000000",
+              "observedTimeUnixNano": "1788803634605000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -535,13 +535,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "47571F071C4FA776AD50C759B8A0C0E4"
+                    "stringValue": "8ABD82682B939E742F0B55DDBC1E5066"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "029AC6A568D02D7D5B4037569BF81710"
+                    "stringValue": "3E772369F8CF798D0982EFA57265C9A0"
                   }
                 },
                 {
@@ -553,7 +553,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "3F41A17F16C8499F8C86B3DA51F3AFCA"
+                    "stringValue": "F725607446199C8AE51EA14F9558914A"
                   }
                 },
                 {
@@ -577,7 +577,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "C6252CF8646984502FCF29FF3AA2A2C7"
+                    "stringValue": "2B437467BF076B9E0134A9AFEE25FA45"
                   }
                 },
                 {
@@ -598,8 +598,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460919327000000",
-              "observedTimeUnixNano": "1788460919327000000",
+              "timeUnixNano": "1788803634605000000",
+              "observedTimeUnixNano": "1788803634605000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "dom-state",
@@ -655,19 +655,25 @@
                 {
                   "key": "dom_state.images_above_fold.timestamp",
                   "value": {
-                    "intValue": 1788460919197
+                    "doubleValue": 1788803634463.8
+                  }
+                },
+                {
+                  "key": "dom_state.images_above_fold.capture_time",
+                  "value": {
+                    "doubleValue": 42.10009765625
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "2D85C34993BCFFC956179C8B02BB5DD8"
+                    "stringValue": "5714B20A19E888B09DE3917FD7FBF707"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "029AC6A568D02D7D5B4037569BF81710"
+                    "stringValue": "3E772369F8CF798D0982EFA57265C9A0"
                   }
                 },
                 {
@@ -679,7 +685,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "3F41A17F16C8499F8C86B3DA51F3AFCA"
+                    "stringValue": "F725607446199C8AE51EA14F9558914A"
                   }
                 },
                 {
@@ -703,7 +709,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "C6252CF8646984502FCF29FF3AA2A2C7"
+                    "stringValue": "2B437467BF076B9E0134A9AFEE25FA45"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs-after-part.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-handle-204-with-body-logs-after-part.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "5FBB8CDC27BE1C401EEC696BF3A1D5BA"
+              "stringValue": "558736EA602E236C57BB9BBBC5B29D2F"
             }
           },
           {
@@ -98,8 +98,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460943399000000",
-              "observedTimeUnixNano": "1788460943399000000",
+              "timeUnixNano": "1788803643835000000",
+              "observedTimeUnixNano": "1788803643835000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -137,13 +137,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "E772042683646A59A84372FE23FE1AA4"
+                    "stringValue": "C1306FE4462C737CCC12CC0D2C99F6E2"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "0397452D80EA2EE632ED5E6417FD2B27"
+                    "stringValue": "76D29325B4B984CB73C8F156CCC9E5BC"
                   }
                 },
                 {
@@ -155,7 +155,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "A633C1CA6C1B2F0BD1E06ED3FA64F992"
+                    "stringValue": "EE6F877A5AA5D05B18CB328EF300DABC"
                   }
                 },
                 {
@@ -179,7 +179,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "3CB76AD69FE7BA886034A9128C54EA0F"
+                    "stringValue": "DA1F3882689EC5B3CF20CA69D4D2A0B4"
                   }
                 },
                 {
@@ -200,8 +200,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460943399000000",
-              "observedTimeUnixNano": "1788460943399000000",
+              "timeUnixNano": "1788803643836000000",
+              "observedTimeUnixNano": "1788803643836000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "dom-state",
@@ -257,19 +257,25 @@
                 {
                   "key": "dom_state.images_above_fold.timestamp",
                   "value": {
-                    "intValue": 1788460942441
+                    "intValue": 1788803642746
+                  }
+                },
+                {
+                  "key": "dom_state.images_above_fold.capture_time",
+                  "value": {
+                    "intValue": 43
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "356CB29757974E91F6CC910E08D92F0C"
+                    "stringValue": "9A11AFB0C2657BCBE8E23D413290589C"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "0397452D80EA2EE632ED5E6417FD2B27"
+                    "stringValue": "76D29325B4B984CB73C8F156CCC9E5BC"
                   }
                 },
                 {
@@ -281,7 +287,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "A633C1CA6C1B2F0BD1E06ED3FA64F992"
+                    "stringValue": "EE6F877A5AA5D05B18CB328EF300DABC"
                   }
                 },
                 {
@@ -305,7 +311,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "3CB76AD69FE7BA886034A9128C54EA0F"
+                    "stringValue": "DA1F3882689EC5B3CF20CA69D4D2A0B4"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/firefox-vite-7-es2015-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "C53DA079CEB14DA53D20ED7CEAC17CAA"
+              "stringValue": "CFB29E7A350AC48CCA7F1C8AE0779156"
             }
           },
           {
@@ -98,11 +98,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460937314000000",
-              "observedTimeUnixNano": "1788460937317000000",
+              "timeUnixNano": "1788803639004000000",
+              "observedTimeUnixNano": "1788803639008000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":3,\"dnsDuration\":0,\"connectionDuration\":1,\"requestDuration\":0}"
+                "stringValue": "{\"waitingDuration\":0,\"cacheDuration\":4,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":3}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -121,13 +121,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 4
+                    "intValue": 7
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 4
+                    "intValue": 7
                   }
                 },
                 {
@@ -139,7 +139,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1788460937308-7632342468739"
+                    "stringValue": "v6-1788803638995-7899075284938"
                   }
                 },
                 {
@@ -157,7 +157,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0EF7EF03EF58072CDBA6F60D80C9EB69"
+                    "stringValue": "80903815B2A0CB8D138C3906B34F277A"
                   }
                 },
                 {
@@ -175,7 +175,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "EDB16D77C41C917F49FAE54C1BA13B43"
+                    "stringValue": "6980BDC6299BC980B6FBCFA0B29E9972"
                   }
                 },
                 {
@@ -199,7 +199,7 @@
                 {
                   "key": "emb.web_vital.attribution.tcpConnection",
                   "value": {
-                    "intValue": 1
+                    "intValue": 0
                   }
                 },
                 {
@@ -211,25 +211,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 0
+                    "intValue": 3
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 3
+                    "intValue": 4
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "2C0B9EFB266EFF407281698C508313DA"
+                    "stringValue": "48E08A063E73BAE0245684351E1F0CCA"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "866BD8BEA2E836C66F52811AF50864A8"
+                    "stringValue": "7512D5CD29E9A4C1CEB8CD93ACEFC367"
                   }
                 },
                 {
@@ -248,11 +248,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1788460937314000000",
-              "observedTimeUnixNano": "1788460937318000000",
+              "timeUnixNano": "1788803639004000000",
+              "observedTimeUnixNano": "1788803639011000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":4,\"firstByteToFCP\":52,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":7,\"firstByteToFCP\":71,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -271,13 +271,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 56
+                    "intValue": 78
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 56
+                    "intValue": 78
                   }
                 },
                 {
@@ -289,7 +289,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1788460937308-3833978756462"
+                    "stringValue": "v6-1788803638995-1817463184838"
                   }
                 },
                 {
@@ -307,7 +307,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0EF7EF03EF58072CDBA6F60D80C9EB69"
+                    "stringValue": "80903815B2A0CB8D138C3906B34F277A"
                   }
                 },
                 {
@@ -325,7 +325,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "EDB16D77C41C917F49FAE54C1BA13B43"
+                    "stringValue": "6980BDC6299BC980B6FBCFA0B29E9972"
                   }
                 },
                 {
@@ -337,13 +337,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "7D386D617A76102FFBC1BC36117B1343"
+                    "stringValue": "071F77A5F5C25FF74ED07296524A5E51"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "866BD8BEA2E836C66F52811AF50864A8"
+                    "stringValue": "7512D5CD29E9A4C1CEB8CD93ACEFC367"
                   }
                 },
                 {
@@ -370,8 +370,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460937461000000",
-              "observedTimeUnixNano": "1788460937462000000",
+              "timeUnixNano": "1788803639184000000",
+              "observedTimeUnixNano": "1788803639185000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -403,7 +403,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 147
+                    "intValue": 180
                   }
                 },
                 {
@@ -421,13 +421,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "E5C86D832470E7F720528CD07EC47B25"
+                    "stringValue": "D86FEC98E068D9FDC70E2BC3C2911CE3"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "866BD8BEA2E836C66F52811AF50864A8"
+                    "stringValue": "7512D5CD29E9A4C1CEB8CD93ACEFC367"
                   }
                 },
                 {
@@ -439,7 +439,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0EF7EF03EF58072CDBA6F60D80C9EB69"
+                    "stringValue": "80903815B2A0CB8D138C3906B34F277A"
                   }
                 },
                 {
@@ -463,7 +463,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "EDB16D77C41C917F49FAE54C1BA13B43"
+                    "stringValue": "6980BDC6299BC980B6FBCFA0B29E9972"
                   }
                 },
                 {
@@ -484,8 +484,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460937463000000",
-              "observedTimeUnixNano": "1788460937463000000",
+              "timeUnixNano": "1788803639186000000",
+              "observedTimeUnixNano": "1788803639186000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -523,13 +523,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "EA2AFE3EF1BE16E01A281980B330D063"
+                    "stringValue": "8AB3D82B8BF06A75253690087B2F30DC"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "866BD8BEA2E836C66F52811AF50864A8"
+                    "stringValue": "7512D5CD29E9A4C1CEB8CD93ACEFC367"
                   }
                 },
                 {
@@ -541,7 +541,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0EF7EF03EF58072CDBA6F60D80C9EB69"
+                    "stringValue": "80903815B2A0CB8D138C3906B34F277A"
                   }
                 },
                 {
@@ -565,7 +565,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "EDB16D77C41C917F49FAE54C1BA13B43"
+                    "stringValue": "6980BDC6299BC980B6FBCFA0B29E9972"
                   }
                 },
                 {
@@ -586,8 +586,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460937463000000",
-              "observedTimeUnixNano": "1788460937463000000",
+              "timeUnixNano": "1788803639186000000",
+              "observedTimeUnixNano": "1788803639186000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "dom-state",
@@ -643,19 +643,25 @@
                 {
                   "key": "dom_state.images_above_fold.timestamp",
                   "value": {
-                    "intValue": 1788460937314
+                    "intValue": 1788803639004
+                  }
+                },
+                {
+                  "key": "dom_state.images_above_fold.capture_time",
+                  "value": {
+                    "intValue": 78
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "01AB3AAED515E99F70920A5A9C278073"
+                    "stringValue": "246F5ECCDB431EAEE1D51FB8410B6A8F"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "866BD8BEA2E836C66F52811AF50864A8"
+                    "stringValue": "7512D5CD29E9A4C1CEB8CD93ACEFC367"
                   }
                 },
                 {
@@ -667,7 +673,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "0EF7EF03EF58072CDBA6F60D80C9EB69"
+                    "stringValue": "80903815B2A0CB8D138C3906B34F277A"
                   }
                 },
                 {
@@ -691,7 +697,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "EDB16D77C41C917F49FAE54C1BA13B43"
+                    "stringValue": "6980BDC6299BC980B6FBCFA0B29E9972"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs-after-part.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-handle-204-with-body-logs-after-part.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "CFB95B667F2C82C67DB833BDB5EB437A"
+              "stringValue": "26ABAB155A163E152BE2FE391F05E131"
             }
           },
           {
@@ -98,8 +98,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460954604000000",
-              "observedTimeUnixNano": "1788460954604000000",
+              "timeUnixNano": "1788803641409000000",
+              "observedTimeUnixNano": "1788803641409000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -137,13 +137,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "56FD15FF303B1A5FFE718A9A3605219A"
+                    "stringValue": "DCD8A1C581F54408C6B6A1F23BCA3DD6"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "36BFF5A78C2194ED83267A3282A9D1F5"
+                    "stringValue": "91A73BAED492F8F71236FE2B1867D470"
                   }
                 },
                 {
@@ -155,7 +155,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AADE6DC34E8992EBA374289B074E40BE"
+                    "stringValue": "A85C2BD01A6BA6FBEA5424D0365D9B5E"
                   }
                 },
                 {
@@ -179,7 +179,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "B01DBDF44123CF3BD38BBDEC0D52423A"
+                    "stringValue": "31D17262584F0730EDADEBA7A7550F57"
                   }
                 },
                 {
@@ -200,8 +200,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460954604000000",
-              "observedTimeUnixNano": "1788460954604000000",
+              "timeUnixNano": "1788803641409000000",
+              "observedTimeUnixNano": "1788803641409000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "dom-state",
@@ -257,19 +257,25 @@
                 {
                   "key": "dom_state.images_above_fold.timestamp",
                   "value": {
-                    "intValue": 1788460953813
+                    "intValue": 1788803640535
+                  }
+                },
+                {
+                  "key": "dom_state.images_above_fold.capture_time",
+                  "value": {
+                    "intValue": 24
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "D52C867D2E3145EBA31B52DB6164825D"
+                    "stringValue": "7E05A248A0681AFB551E247000408016"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "36BFF5A78C2194ED83267A3282A9D1F5"
+                    "stringValue": "91A73BAED492F8F71236FE2B1867D470"
                   }
                 },
                 {
@@ -281,7 +287,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "AADE6DC34E8992EBA374289B074E40BE"
+                    "stringValue": "A85C2BD01A6BA6FBEA5424D0365D9B5E"
                   }
                 },
                 {
@@ -305,7 +311,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "B01DBDF44123CF3BD38BBDEC0D52423A"
+                    "stringValue": "31D17262584F0730EDADEBA7A7550F57"
                   }
                 },
                 {

--- a/tests/integration/tests/__golden__/webkit-vite-7-es2015-log.json
+++ b/tests/integration/tests/__golden__/webkit-vite-7-es2015-log.json
@@ -54,7 +54,7 @@
           {
             "key": "emb.app_instance_id",
             "value": {
-              "stringValue": "906A28116A71B37AD6AEC2481DF61776"
+              "stringValue": "89EA5A21B1C7C0BBA9DCDD70A8A6F3A6"
             }
           },
           {
@@ -98,11 +98,11 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460951076000000",
-              "observedTimeUnixNano": "1788460951079000000",
+              "timeUnixNano": "1788803636621000000",
+              "observedTimeUnixNano": "1788803636624000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"waitingDuration\":6,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":5}"
+                "stringValue": "{\"waitingDuration\":2,\"cacheDuration\":0,\"dnsDuration\":0,\"connectionDuration\":0,\"requestDuration\":0}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -121,13 +121,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 11
+                    "intValue": 2
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 11
+                    "intValue": 2
                   }
                 },
                 {
@@ -139,7 +139,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1788460951074-9620983498254"
+                    "stringValue": "v6-1788803636618-4679253680181"
                   }
                 },
                 {
@@ -157,7 +157,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "81DAA79C45A421D1CF031BEBEB487D0C"
+                    "stringValue": "8367BBD36BE18928C3E7A8F20C85EB34"
                   }
                 },
                 {
@@ -175,7 +175,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "CE382D18775B45A0F9BB5EE50DBDFD87"
+                    "stringValue": "7E1F4C4B91F136423370B01D81072CD0"
                   }
                 },
                 {
@@ -211,25 +211,25 @@
                 {
                   "key": "emb.web_vital.attribution.serverResponse",
                   "value": {
-                    "intValue": 5
+                    "intValue": 0
                   }
                 },
                 {
                   "key": "emb.web_vital.attribution.unattributed",
                   "value": {
-                    "intValue": 7
+                    "intValue": 2
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "72B4FEAD2541D4A4F3729EDB95E8027E"
+                    "stringValue": "2F7DCC0F00EEAED005B16D1FFD5247D2"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "28A6E86B63D09F91B0228FFE5F145B7E"
+                    "stringValue": "D066D0ABC20EF3D899FA145FC62B0BDE"
                   }
                 },
                 {
@@ -248,11 +248,11 @@
               "droppedAttributesCount": 0
             },
             {
-              "timeUnixNano": "1788460951085000000",
-              "observedTimeUnixNano": "1788460951088000000",
+              "timeUnixNano": "1788803636630000000",
+              "observedTimeUnixNano": "1788803636632000000",
               "severityNumber": 9,
               "body": {
-                "stringValue": "{\"timeToFirstByte\":11,\"firstByteToFCP\":52,\"loadState\":\"complete\"}"
+                "stringValue": "{\"timeToFirstByte\":2,\"firstByteToFCP\":40,\"loadState\":\"complete\"}"
               },
               "eventName": "browser.web_vital",
               "attributes": [
@@ -271,13 +271,13 @@
                 {
                   "key": "browser.web_vital.value",
                   "value": {
-                    "intValue": 63
+                    "intValue": 42
                   }
                 },
                 {
                   "key": "browser.web_vital.delta",
                   "value": {
-                    "intValue": 63
+                    "intValue": 42
                   }
                 },
                 {
@@ -289,7 +289,7 @@
                 {
                   "key": "browser.web_vital.id",
                   "value": {
-                    "stringValue": "v6-1788460951074-7103791213279"
+                    "stringValue": "v6-1788803636618-1496918746974"
                   }
                 },
                 {
@@ -307,7 +307,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "81DAA79C45A421D1CF031BEBEB487D0C"
+                    "stringValue": "8367BBD36BE18928C3E7A8F20C85EB34"
                   }
                 },
                 {
@@ -325,7 +325,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "CE382D18775B45A0F9BB5EE50DBDFD87"
+                    "stringValue": "7E1F4C4B91F136423370B01D81072CD0"
                   }
                 },
                 {
@@ -337,13 +337,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "361EB436AEB0E3EFD689E23D4C2768C7"
+                    "stringValue": "A1A59E99D32C0881319F8BCE0845EB9A"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "28A6E86B63D09F91B0228FFE5F145B7E"
+                    "stringValue": "D066D0ABC20EF3D899FA145FC62B0BDE"
                   }
                 },
                 {
@@ -370,8 +370,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460951229000000",
-              "observedTimeUnixNano": "1788460951232000000",
+              "timeUnixNano": "1788803636776000000",
+              "observedTimeUnixNano": "1788803636783000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "first-interaction",
@@ -403,7 +403,7 @@
                 {
                   "key": "first_interaction.time",
                   "value": {
-                    "intValue": 153
+                    "intValue": 155
                   }
                 },
                 {
@@ -421,13 +421,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "A55398C271F6913279AEC9CD7650C998"
+                    "stringValue": "76F3291E26E9809182726575B697546F"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "28A6E86B63D09F91B0228FFE5F145B7E"
+                    "stringValue": "D066D0ABC20EF3D899FA145FC62B0BDE"
                   }
                 },
                 {
@@ -439,7 +439,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "81DAA79C45A421D1CF031BEBEB487D0C"
+                    "stringValue": "8367BBD36BE18928C3E7A8F20C85EB34"
                   }
                 },
                 {
@@ -463,7 +463,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "CE382D18775B45A0F9BB5EE50DBDFD87"
+                    "stringValue": "7E1F4C4B91F136423370B01D81072CD0"
                   }
                 },
                 {
@@ -484,8 +484,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460951232000000",
-              "observedTimeUnixNano": "1788460951232000000",
+              "timeUnixNano": "1788803636784000000",
+              "observedTimeUnixNano": "1788803636784000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "max-scroll-depth",
@@ -523,13 +523,13 @@
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "5737C76425E74C28D27FAEC1668E40F3"
+                    "stringValue": "08A015755088FCB157839C6357263776"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "28A6E86B63D09F91B0228FFE5F145B7E"
+                    "stringValue": "D066D0ABC20EF3D899FA145FC62B0BDE"
                   }
                 },
                 {
@@ -541,7 +541,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "81DAA79C45A421D1CF031BEBEB487D0C"
+                    "stringValue": "8367BBD36BE18928C3E7A8F20C85EB34"
                   }
                 },
                 {
@@ -565,7 +565,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "CE382D18775B45A0F9BB5EE50DBDFD87"
+                    "stringValue": "7E1F4C4B91F136423370B01D81072CD0"
                   }
                 },
                 {
@@ -586,8 +586,8 @@
           },
           "logRecords": [
             {
-              "timeUnixNano": "1788460951232000000",
-              "observedTimeUnixNano": "1788460951232000000",
+              "timeUnixNano": "1788803636784000000",
+              "observedTimeUnixNano": "1788803636784000000",
               "severityNumber": 9,
               "body": {},
               "eventName": "dom-state",
@@ -643,19 +643,25 @@
                 {
                   "key": "dom_state.images_above_fold.timestamp",
                   "value": {
-                    "intValue": 1788460951076
+                    "intValue": 1788803636621
+                  }
+                },
+                {
+                  "key": "dom_state.images_above_fold.capture_time",
+                  "value": {
+                    "intValue": 33
                   }
                 },
                 {
                   "key": "log.record.uid",
                   "value": {
-                    "stringValue": "D40C72402643159499A15240DF430CF7"
+                    "stringValue": "7B04E4C172597F9E271678236F3704B4"
                   }
                 },
                 {
                   "key": "emb.user_session_id",
                   "value": {
-                    "stringValue": "28A6E86B63D09F91B0228FFE5F145B7E"
+                    "stringValue": "D066D0ABC20EF3D899FA145FC62B0BDE"
                   }
                 },
                 {
@@ -667,7 +673,7 @@
                 {
                   "key": "emb.session_part_id",
                   "value": {
-                    "stringValue": "81DAA79C45A421D1CF031BEBEB487D0C"
+                    "stringValue": "8367BBD36BE18928C3E7A8F20C85EB34"
                   }
                 },
                 {
@@ -691,7 +697,7 @@
                 {
                   "key": "app.surface.id",
                   "value": {
-                    "stringValue": "CE382D18775B45A0F9BB5EE50DBDFD87"
+                    "stringValue": "7E1F4C4B91F136423370B01D81072CD0"
                   }
                 },
                 {

--- a/tests/integration/utils/test-with-mock-api.ts
+++ b/tests/integration/utils/test-with-mock-api.ts
@@ -157,6 +157,7 @@ const IGNORED_ATTRIBUTES_LIST = [
   'first_interaction.time',
   'app.surface.id',
   'dom_state.images_above_fold.timestamp',
+  'dom_state.images_above_fold.capture_time',
 ];
 
 // Which export batch a record rides in depends on where the processor's batch


### PR DESCRIPTION
## What problem is this solving?

The DOM state fold measurement recorded its capture moment only as a raw wall-clock timestamp (`dom_state.images_above_fold.timestamp`), which grows unbounded across a long single-page-app visit and doesn't describe "how far into the current view" the fold was captured — the same gap the SDK's other zero-time instrumentations (element timing, user timing, soft navigation, first interaction) already close.

## Short description of changes

- Add `dom_state.images_above_fold.capture_time`: the fold capture moment expressed in ms since zero time, sent alongside the existing wall-clock `dom_state.images_above_fold.timestamp`.
- Add `millisFromZeroTimeEpoch(epochMillis)` to `PerformanceManager`/`OTelPerformanceManager`: rebases an already-epoch value (e.g. `getNowMillis()`) onto zero time. This is distinct from `millisFromZeroTime(offset)`, which expects a raw time-origin-relative offset — feeding an epoch value into that method double-counts `timeOrigin`.
- Catalog `DOMStateInstrumentation` under the zero-time instrumentations section of `PerformanceManager/README.md`, and document the new method in its API table and worked example.
- Regenerate the `vite-7` integration golden files (the only platform whose goldens include `dom-state` logs) to include the new attribute.

## How has this been tested?

- Unit tests in `DOMStateInstrumentation.test.ts` cover both attributes' values and confirm the log's own timestamp still lands at part end (unaffected by the fold's earlier capture). `OTelPerformanceManager.test.ts` adds baseline, activationStart-rebase, and bfcache-rebase/clamp coverage for the new method.
- `npm run check` (typecheck + eslint) passes across all packages.
- Reran the `vite-7` Playwright suite (chromium/firefox/webkit) against the regenerated goldens — all pass.

## Checklist

- [x] Documentation added
- [x] Tests added