### PR TITLE
chore: make sure system certificates are used when installing fonts/browsers through node

### DIFF
--- a/tests/integration/platforms/next-15-turbopack-app/next.config.ts
+++ b/tests/integration/platforms/next-15-turbopack-app/next.config.ts
@@ -3,6 +3,12 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   productionBrowserSourceMaps: true,
   serverExternalPackages: ['@opentelemetry/instrumentation'],
+  experimental: {
+    // Adds OS Native trust certificates.
+    // Required for next to download fonts from Google.
+    // @ts-expect-error
+    turbopackUseSystemTlsCerts: true,
+  },
 };
 
 export default nextConfig;

--- a/tests/integration/platforms/next-15-turbopack-pages/next.config.ts
+++ b/tests/integration/platforms/next-15-turbopack-pages/next.config.ts
@@ -4,6 +4,12 @@ const nextConfig: NextConfig = {
   productionBrowserSourceMaps: true,
   reactStrictMode: true,
   serverExternalPackages: ['@opentelemetry/instrumentation'],
+  experimental: {
+    // Adds OS Native trust certificates.
+    // Required for next to download fonts from Google.
+    // @ts-expect-error
+    turbopackUseSystemTlsCerts: true,
+  },
 };
 
 export default nextConfig;

--- a/tests/integration/playwright.config.ts
+++ b/tests/integration/playwright.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
 import { GRACEFUL_SHUTDOWN } from './constants/test.ts';
 
+// Adds OS Native trust certificates.
+// Required for next to download fonts from Google.
+process.env['NODE_USE_SYSTEM_CA'] = '1';
+
 export default defineConfig({
   timeout: 10 * 1000, // 10 seconds
   webServer: [

--- a/tests/integration/utils/run-platform-smoke-test.ts
+++ b/tests/integration/utils/run-platform-smoke-test.ts
@@ -57,6 +57,12 @@ const runPlatformBuildSmokeTest = async (
         try {
           const { stdout } = await execAsync(`npm run build:${target}`, {
             cwd: platformPath,
+            env: {
+              ...process.env,
+              // Adds OS Native trust certificates.
+              // Required for next to download fonts from Google.
+              NODE_USE_SYSTEM_CA: '1',
+            },
           });
 
           console.log('Build output:', stdout);


### PR DESCRIPTION
## What problem is this solving?

* Makes sure `NODE_USE_SYSTEM_CA` is propagated when running tests and building 
* Sets `turbopackUseSystemTlsCerts` for turbopack 

