### PR TITLE
fix(transport): keep the request timeout armed until a non-keepalive body drains

### DIFF
--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.test.ts
@@ -483,6 +483,28 @@ describe('FetchTransport', () => {
         clearTimeoutSpy.restore();
       }
     });
+
+    it('should hold the fallback timer until a non-keepalive body drains', async () => {
+      const body = createPendingBody();
+      reinstallFetch().resolves(new Response(body.stream, { status: 200 }));
+      const clearTimeoutSpy = sinon.spy(globalThis, 'clearTimeout');
+
+      try {
+        const transport = makeTransport();
+        // Over the budget, so this request is sent without keepalive.
+        await transport.send(largePayload, 1000);
+        await flushBodyDrain();
+
+        void expect(clearTimeoutSpy.called).to.be.false;
+
+        body.close();
+        await flushBodyDrain();
+
+        void expect(clearTimeoutSpy.calledOnce).to.be.true;
+      } finally {
+        clearTimeoutSpy.restore();
+      }
+    });
   });
 
   describe('HTTP status classification', () => {

--- a/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
+++ b/packages/web-sdk/src/transport/FetchTransport/FetchTransport.ts
@@ -162,7 +162,7 @@ export class FetchTransport implements IExporterTransport {
       inflightKeepaliveBytes -= reservedBytes;
       inflightKeepaliveCount--;
     };
-    let drainOwnsRelease = false;
+    let drainOwnsCleanup = false;
 
     try {
       if (this._config.compression === 'gzip') {
@@ -207,14 +207,12 @@ export class FetchTransport implements IExporterTransport {
       // Not awaited: the status already decides the export outcome, and a
       // collector that stalls mid-body must not hold up the caller.
       const drained = drainResponseBody(response);
-      if (keepalive) {
-        // Set once the promise exists so an earlier throw still reaches the
-        // release in `finally`.
-        drainOwnsRelease = true;
-        // The abort signal stays armed, so a stalled body cannot hold the
-        // budget forever.
-        void drained.finally(releaseKeepalive);
-      }
+      // Set once the promise exists so an earlier throw still reaches the
+      // cleanup in `finally`.
+      drainOwnsCleanup = true;
+      // Trailing the drain keeps the abort signal armed, so a stalled body can
+      // hold neither the budget nor the timer forever.
+      void drained.finally(keepalive ? releaseKeepalive : clearTimeoutIfSet);
 
       if (response.ok) {
         return { status: 'success' };
@@ -246,7 +244,9 @@ export class FetchTransport implements IExporterTransport {
         error: fetchError,
       };
     } finally {
-      if (!drainOwnsRelease) {
+      // Only the paths that threw before a response reach this: once the drain
+      // exists it owns the cleanup.
+      if (!drainOwnsCleanup) {
         if (keepalive) {
           releaseKeepalive();
         } else {


### PR DESCRIPTION
## What

Follow-up to #1508. The response body drain releases the keepalive quota, so the release was moved onto the drain's continuation rather than run when `send()` resolves. That hand-off only covered the keepalive path: for a request sent without keepalive, `finally` still ran `clearTimeoutIfSet()` as soon as `send()` returned, while the drain was in flight.

On browsers with `AbortSignal.timeout` this is harmless, since there is no fallback timer to clear and the signal fires on its own. On the `AbortController` fallback, clearing the timer early leaves the drain unbounded: a collector that stalls mid-body leaves a locked reader and a read that never settles for the life of the document. No keepalive quota is at stake on that path, so the impact is a leaked stream on older browsers rather than failing exports.

## Change

The drain now owns the cleanup on both paths:

```ts
const drained = drainResponseBody(response);
drainOwnsCleanup = true;
void drained.finally(keepalive ? releaseKeepalive : clearTimeoutIfSet);
```

`drainOwnsRelease` is renamed to `drainOwnsCleanup` to match what it now guards. The `finally` block is unchanged in behavior; it is reachable only from the paths that threw before a response existed (fetch rejection, gzip failure).

## Tests

One test added under `AbortSignal.timeout fallback`: an over-budget (so non-keepalive) send against a body held open, asserting `clearTimeout` is not called while the body is open and is called once it closes.

Verified the test catches the regression by stashing the source change and re-running: it fails at the mid-drain assertion, and passes with the change restored. `npm run check` is clean and the full suite passes (1169).